### PR TITLE
I have changed the code to add/subtract the subarray bound values as …

### DIFF
--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -1113,6 +1113,8 @@ class Catalog_seed():
             else:
                 # No distortion at all - "manual mode"
                 pixelx, pixely = self.RADecToXY_manual(ra, dec)
+            pixelx = pixelx- self.subarray_bounds[0]
+            pixely = pixely- self.subarray_bounds[1]
 
         else:
             # Case where the point source list entry locations are given in units of pixels
@@ -1122,7 +1124,7 @@ class Catalog_seed():
             pixelx = entry0
             pixely = entry1
 
-            ra, dec, ra_str, dec_str = self.XYToRADec(pixelx, pixely, matrix, transform)
+            ra, dec, ra_str, dec_str = self.XYToRADec(pixelx+self.subarray_bounds[0], pixely+self.subarray_bounds[1], matrix, transform)
         return pixelx, pixely, ra, dec, ra_str, dec_str
 
     def nonsidereal_CRImage(self, file):
@@ -1619,6 +1621,8 @@ class Catalog_seed():
                     #else:
                     #    # No distortion at all - "manual mode"
                     #    pixelx, pixely = self.RADecToXY_manual(ra, dec)
+                    pixelx = pixelx-self.subarray_bounds[0]
+                    pixely = pixely-self.subarray_bounds[1]
 
                 else:
                     # Case where the point source list entry locations are given in units of pixels
@@ -1634,7 +1638,7 @@ class Catalog_seed():
                     pixelx = entry0
                     pixely = entry1
 
-                    ra, dec, ra_str, dec_str = self.XYToRADec(pixelx, pixely, attitude_matrix,
+                    ra, dec, ra_str, dec_str = self.XYToRADec(pixelx+self.subarray_bounds[0], pixely+self.subarray_bounds[1], attitude_matrix,
                                                               coord_transform)
 
                 # Get the input magnitude of the point source
@@ -2249,6 +2253,8 @@ class Catalog_seed():
                 # Call is the same regardless of whether distortion reference file
                 # is given or not
                 pixelx, pixely = self.RADecToXY_astrometric(ra, dec, attitude_matrix, coord_transform)
+                pixelx = pixelx - self.subarray_bounds[0]
+                pixely = pixely - self.subarray_bounds[1]
 
                 #else:
                 #    # No distortion. Fall back to "manual" calculations
@@ -2268,7 +2274,7 @@ class Catalog_seed():
                 pixelx = entry0
                 pixely = entry1
 
-                ra, dec, ra_str, dec_str = self.XYToRADec(pixelx, pixely, attitude_matrix, coord_transform)
+                ra, dec, ra_str, dec_str = self.XYToRADec(pixelx+self.subarray_bounds[0], pixely+self.subarray_bounds[1], attitude_matrix, coord_transform)
 
             # only keep the source if the peak will fall within the subarray
             if pixely > outminy and pixely < outmaxy and pixelx > outminx and pixelx < outmaxx:
@@ -2635,6 +2641,8 @@ class Catalog_seed():
                     #if self.runStep['astrometric']:
                     # Same function call regardless of whether distortion file is provided or not
                     pixelx, pixely = self.RADecToXY_astrometric(ra, dec, attitude_matrix, coord_transform)
+                    pixelx = pixelx - self.subarray_bounds[0]
+                    pixely = pixely - self.subarray_bounds[1]
                     #else:
                     #    # No distortion at all - "manual mode"
                     #    pixelx, pixely = self.RADecToXY_manual(ra, dec)
@@ -2653,7 +2661,7 @@ class Catalog_seed():
                     pixelx = entry0
                     pixely = entry1
 
-                    ra, dec, ra_str, dec_str = self.XYToRADec(pixelx, pixely, attitude_matrix,
+                    ra, dec, ra_str, dec_str = self.XYToRADec(pixelx+self.subarray_bounds[0], pixely+self.subarray_bounds[1], attitude_matrix,
                                                               coord_transform)
 
                 # Get the input magnitude


### PR DESCRIPTION
…needed to get sources into the right place when doing a subarray simulation.  The XYToRADec and RADecToXY routines are for pixel positions given with respect to the full frame whereas the code is assuming that pixelx, pixely are with respect to the subarray, hence whenever pixel positions are input for sources one has to use pixelx + self.subrray_bounds[0] and pixely + self.subarray_bounds[1] to get the correct RA/Dec strings, and when RA/Dec input positions are converted to pixelx, pixely positions using RADecToXY_astrometric (or RADecToXY_manual as the case may be) one has to subtract self.subarray_bounds[0] and and self.subarray_bounds[1] from pixelx and pixely respectively.  The changes have been made wherever I see the XYToRADec or RADecToXY routines being called.