### PR TITLE
Bugfix so multiple integrations with raw dark input is functional

### DIFF
--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -536,7 +536,7 @@ class Catalog_seed():
           else:
             pad1=2
             pad2=0
-          self.frametime=(pad2+(yd/self.params['Readout']['namp']+colpad)*(xd+pad1)*0.00001
+          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) * (xd + pad1)) * 0.00001
 
     def calcCoordAdjust(self):
         # Calculate the factors by which to expand the output array size, as well as the coordinate

--- a/nircam_simulator/scripts/catalog_seed_image.py
+++ b/nircam_simulator/scripts/catalog_seed_image.py
@@ -531,12 +531,13 @@ class Catalog_seed():
         # less than 64 pixels square, but that needs to be confirmed.
           colpad=12
           if self.params['Readout']['namp'] == 4:
-            pad1=1
-            pad2=1
+              pad1 = 1
+              pad2 = 1
           else:
-            pad1=2
-            pad2=0
-          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) * (xd + pad1)) * 0.00001
+              pad1 = 2
+              pad2 = 0
+          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) 
+                            * (xd + pad1)) * 0.00001
 
     def calcCoordAdjust(self):
         # Calculate the factors by which to expand the output array size, as well as the coordinate

--- a/nircam_simulator/scripts/dark_prep.py
+++ b/nircam_simulator/scripts/dark_prep.py
@@ -720,10 +720,22 @@ class DarkPrep():
         return dark, sbzero
 
     def darkints(self):
-        # Check the number of integrations in the dark
-        # current file and compare with the requested
-        # number of integrations. Add/remove integrations
-        # if necessary
+        """Check the number of integrations in the dark
+        current file and compare with the requested
+        number of integrations. Add/remove integrations
+        if necessary
+
+        Parameters
+        ----------
+
+        None
+
+
+        Returns
+        -------
+
+        None
+        """
         ndarkints, ngroups, ny, nx = self.dark.data.shape
         reqints = self.params['Readout']['nint']
 
@@ -744,9 +756,25 @@ class DarkPrep():
             self.integration_copy(reqints, ndarkints)
 
     def integration_copy(self, req, darkint):
-        #use copies of integrations in the dark current input to
-        #make up integrations in the case where the output has
-        #more integrations than the input
+        """Use copies of integrations in the dark current input to
+        make up integrations in the case where the output has
+        more integrations than the input
+
+        Parameters
+        ----------
+
+        req : int
+            Requested number of dark current integrations for the output
+
+        darkint : int
+            Number of integrations in the input dark current exposure
+
+        Returns
+        -------
+
+        None
+        """
+
         ncopies = np.int((req - darkint) / darkint)
         extras = (req - darkint) % darkint
 
@@ -756,7 +784,7 @@ class DarkPrep():
             if self.dark.sbAndRefpix is not None:
                 copysb = self.dark.sbAndRefpix
             if self.dark.zeroframe is not None:
-                copyzero = self.dark.zero
+                copyzero = self.dark.zeroframe
             for i in range(ncopies):
                 self.dark.data = np.vstack((self.dark.data, copydata))
                 if self.dark.sbAndRefpix is not None:
@@ -775,18 +803,36 @@ class DarkPrep():
         self.dark.header['NINTS'] = req
 
     def dataVolumeCheck(self, obj):
-        # Make sure that the input integration has
-        # enough frames/groups to create the requested
-        # number of frames/groups of the output
+        """Make sure that the input integration has
+        enough frames/groups to create the requested
+        number of frames/groups of the output
+
+        Parameters
+        ----------
+
+        obj : read_fits object
+            Instance of read_fits class containing dark current data and info
+
+        Returns
+        -------
+
+        None
+        """
         ngroup = int(self.params['Readout']['ngroup'])
         nframe = int(self.params['Readout']['nframe'])
         nskip = int(self.params['Readout']['nskip'])
 
         inputframes = obj.data.shape[1]
         if ngroup * (nskip + nframe) > inputframes:
-            print("WARNING: Not enough frames in the input integration to create the requested number of output groups. Input has {} frames. Requested output is {} groups each created from {} frames plus skipping {} frames between groups.".format(inputframes, ngroup, nframe, nskip))
-            print("for a total of {} frames.".format(ngroup * (nframe + nskip)))
-            print("Making copies of {} dark current frames and adding them to the end of the dark current integration.".format(ngroup * (nskip + nframe) - inputframes))
+            print(("WARNING: Not enough frames in the input integration to "
+                   "create the requested number of output groups. Input has "
+                   "{} frames. Requested output is {} groups each created from "
+                   "{} frames plus skipping {} frames between groups for a total "
+                   "of {} frames."
+                   .format(inputframes, ngroup, nframe, nskip, ngroup * (nframe + nskip))))
+            print(("Making copies of {} dark current frames and adding them to "
+                   "the end of the dark current integration."
+                   .format(ngroup * (nskip + nframe) - inputframes)))
 
             # Figure out how many more frames we need,
             # in terms of how many copies of the original dark

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -1425,12 +1425,13 @@ class Observation():
         # less than 64 pixels square, but that needs to be confirmed.
           colpad = 12
           if self.params['Readout']['namp'] == 4:
-            pad1 = 1
-            pad2 = 1
+              pad1 = 1
+              pad2 = 1
           else:
-            pad1 = 2
-            pad2 = 0
-          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) *(xd + pad1)) * 0.00001
+              pad1 = 2
+              pad2 = 0
+          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) 
+                            * (xd + pad1)) * 0.00001
         print('Exposure time of a single frame: ', self.frametime)
 
 

--- a/nircam_simulator/scripts/obs_generator.py
+++ b/nircam_simulator/scripts/obs_generator.py
@@ -1423,14 +1423,14 @@ class Observation():
         #
         # note that the Guider frame time may be different for small sub-arrays
         # less than 64 pixels square, but that needs to be confirmed.
-          colpad=12
+          colpad = 12
           if self.params['Readout']['namp'] == 4:
-            pad1=1
-            pad2=1
+            pad1 = 1
+            pad2 = 1
           else:
-            pad1=2
-            pad2=0
-          self.frametime=(pad2+(yd/self.params['Readout']['namp']+colpad)*(xd+pad1)*0.00001
+            pad1 = 2
+            pad2 = 0
+          self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) *(xd + pad1)) * 0.00001
         print('Exposure time of a single frame: ', self.frametime)
 
 


### PR DESCRIPTION
Fixed a small bug in dark_prep.py that was causing the simulator to crash when requesting an output with (N > 1) integrations and using as input a raw dark exposure with fewer than N integrations. Updated documentation for the affected functions.

Also fixed two missing parentheses in frame time calculations that were causing code to crash. These must have been leftover from the fixes merged in #93? 