### PR TITLE
WIP: Use FittableImageModel (later EPSFModel) for psfs

### DIFF
--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -753,7 +753,13 @@ class Catalog_seed():
         eval_xshape = np.int(np.ceil(model.shape[1] / model.oversampling))
         eval_yshape = np.int(np.ceil(model.shape[0] / model.oversampling))
         y, x = np.mgrid[0:eval_yshape, 0:eval_xshape]
-        eval_psf = model.evaluate(x=x, y=y, flux=1., x_0=eval_xshape//2, y_0=eval_yshape//2)
+        eval_psf = model.evaluate(x=x, y=y, flux=1., x_0=eval_xshape/2, y_0=eval_yshape/2)
+        print(eval_xshape, eval_yshape, eval_xshape/2, eval_yshape/2)
+
+        h0=fits.PrimaryHDU(eval_psf)
+        hlist = fits.HDUList([h0])
+        hlist.writeto("temp_minimal_eval_psf.fits", overwrite=True)
+        
         return eval_psf
 
     def movingTargetInputs(self, file, input_type, MT_tracking=False,
@@ -2620,6 +2626,7 @@ class Catalog_seed():
             # values are within the aperture being used, so they could be within a subarray.
             # That is ok for this step where we are only looking at subpixel location.
             psf_file = self.find_subpix_psf_filename(entry['pixelx'], entry['pixely'])
+            print("For galaxy, PSF file is: {}".format(psf_file))
             psf_exists = self.file_exists(psf_file)
             if psf_exists:
                 psf_model = self.populate_epsfmodel(psf_file, oversample=1)

--- a/mirage/scripts/psf_generator.py
+++ b/mirage/scripts/psf_generator.py
@@ -1,0 +1,159 @@
+#! /suyr/bin/env python
+
+"""
+Class to generate PSFs to be used with Mirage
+"""
+import os
+import numpy as np
+from astropy.io import fits
+from photutils.psf import FittableImageModel
+
+class PSF():
+    def __init__(self, x_position, y_position, psf_base, interval=0.25, oversampling=1):
+        """
+        Populate FittableImageModel instance with data from the appropriate PSF file
+
+        Parameters:
+        -----------
+        x_position : float
+            Column number on the detector where the PSF will be located
+
+        y_position : float
+            Row number on the detector where the PSF will be located
+
+        psf_base : str
+            Base of the PSF filename (e.g. "NIRCam_XXXXXXXXX"
+
+        interval : float
+            Sub-pixel centering resolution of the PSF library (e.g. 0.25)
+
+        oversampling : int
+            Oversampling factor of the data in the PSF file
+
+        Returns:
+        --------
+        None
+        """
+        self.interval = interval
+        self.oversampling = oversampling
+
+        # Determine the filename of the appropriate PSF file
+        psf_filename = self.find_subpix_psf_filename(x_position, y_position, psf_base)
+
+        # Check for the existence of the file
+        if os.path.isfile(psf_filename):
+            try:
+                # Place PSF in FittableImageModel
+                self.model = self.populate_epsfmodel(psf_filename, oversample=oversampling)
+            except:
+                raise RuntimeError("ERROR: Could not load PSF file {} from library"
+                                   .format(psf_filename))
+        else:
+            raise FileNotFoundError("PSF file {} not found.".format(psf_filename))
+        
+        
+
+    def find_subpix_psf_filename(self, xloc, yloc, basename):
+        """Given an x, y location on the
+        detector, determine the filename for the most appropriate 
+        PSF file to use. This function only looks for the sub-pixel
+        position, and doesn't know about PSF variation across the 
+        detector. Therefore only the fractional part of (xloc, yloc)
+        is really important.
+
+        Parameters:
+        -----------
+        xloc : int
+            Column number on full detector of source location
+
+        yloc : int
+            Row number on full detector of source location
+
+        Returns:
+        --------
+        psf_filename : str
+            Name of fits file containing PSF to use
+        """
+        # Find sub-pixel offsets in position from the center of the pixel
+        xfract, xoff = np.modf(xloc)
+        yfract, yoff = np.modf(yloc)
+
+        # Resolution of PSF sub pixel positions
+        #interval = self.params['simSignals']['psfpixfrac']
+        numperpix = int(1./self.interval)
+        
+        # Now we need to determine the proper PSF
+        # file to read in from the library
+        # This depends on the sub-pixel offsets above
+        a_in = self.interval * int(numperpix*xfract + 0.5) - 0.5
+        b_in = self.interval * int(numperpix*yfract + 0.5) - 0.5
+        astr = "{0:.{1}f}".format(a_in, 2)
+        bstr = "{0:.{1}f}".format(b_in, 2)
+   
+        # Generate the psf file name based on the center of the point source
+        # in units of fraction of a pixel
+        frag = astr + '_' + bstr
+        frag = frag.replace('-', 'm')
+        frag = frag.replace('.', 'p')
+
+        # Generate fits filename
+        psf_filename = basename + '_' + frag + '.fits'
+        return psf_filename
+        
+    def minimal_psf_evaluation(self):
+        """
+        Create a PSF by evaluating a FittableImageModel instance. Return 
+        an array only just big enough to contain the PSF data.
+
+        Parameters:
+        -----------
+        model : obj
+            FittableImageModel instance containing the PSF model
+
+        Returns:
+        --------
+        eval_psf : ndarray
+            2D numpy array containing the evaluated PSF, with normalized signal
+        """
+        eval_xshape = np.int(np.ceil(self.model.shape[1] / self.model.oversampling))
+        eval_yshape = np.int(np.ceil(self.model.shape[0] / self.model.oversampling))
+        y, x = np.mgrid[0:eval_yshape, 0:eval_xshape]
+        eval_psf = self.model.evaluate(x=x, y=y, flux=1.,
+                                           x_0=eval_xshape/2,
+                                           y_0=eval_yshape/2)
+
+        # For testing
+        #h0=fits.PrimaryHDU(eval_psf)
+        #hlist = fits.HDUList([h0])
+        #hlist.writeto("temp_minimal_eval_psf.fits", overwrite=True)
+        
+        return eval_psf
+
+    def populate_epsfmodel(self, infile, oversample=1):
+        """Create an instance of EPSFModel and populate the data
+        from the given fits file. Also populate information
+        about the oversampling rate.
+
+        Parameters:
+        -----------
+        infile : str
+            Name of fits file containing PSF data
+
+        oversample : int
+            Factor by which the PSF data are oversampled
+
+        Returns:
+        --------
+        psf : obj
+            FittableImageModel instance
+        """
+        psf_data = fits.getdata(infile)
+
+        # Normalize
+        psf_data /= np.sum(psf_data)
+
+        # Create instance. Assume the PSF is centered
+        # in the array
+        psf = FittableImageModel(psf_data, oversampling=oversample)
+        #psf = EPSFModel(psf_data, oversampling=oversample)
+        return psf


### PR DESCRIPTION
This work is meant as preparation for a switch from using a full webbpsf-generated library containing a grid of sub-pixel centered PSF files to a situation where a single oversampled PSF will be stored in a photutils.psf.EPSFModel instance, which will do the sub-pixel interpolation. Additionally, PSF variations across the detector will be accounted for by interpolating over a grid of PSFs.

For this work, I have replaced the old method of reading in PSF files and working with them as numpy arrays with the use of FittableImageModel instances (this is because EPSFModel is not yet in photutils). I have also changed the code to prepare for detector position dependence by having a new PSF selected for each source. Previously, all galaxies and extended objects were convolved with self.centerpsf. Hopefully this will make it easier to swap in the detector position-dependent PSF later.

At the moment, the seed image produced by catalog_seed_image.py looks good except for a small (~<1 pixel) shift in galaxy and extended object locations from where they were previously. I tracked the shift to strange behavior from the output of the FittableImageModel `evaluate` method. I have asked Larry Bradley about it and am waiting on a response. Once that issue is resolved, we should be able to merge this branch and push forward with the other aspects of this PSF work.