### PR TITLE
WIP: Filter out sources far from nominal pointing

### DIFF
--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -2724,7 +2724,7 @@ class Catalog_seed():
         # Check the source list and remove any sources that are well outside the
         # field of view of the detector. These sources cause the coordinate
         # conversion to hang.
-        indexes, lines  = self.remove_outside_fov_sources(indexes, lines, pixelflag)
+        indexes, lines  = self.remove_outside_fov_sources(indexes, lines, pixelflag, 4096)
 
         print("After extended sources, max index is {}".format(self.maxindex))
 

--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -2721,23 +2721,12 @@ class Catalog_seed():
             indexes += self.maxindex
         self.maxindex = np.max(indexes)
 
-
-
-        
-
         # Check the source list and remove any sources that are well outside the
         # field of view of the detector. These sources cause the coordinate
         # conversion to hang.
         indexes, lines  = self.remove_outside_fov_sources(indexes, lines, pixelflag)
 
-
-
-
-
-
-
-        
-        print("after extended sources, max index is {}".format(self.maxindex))
+        print("After extended sources, max index is {}".format(self.maxindex))
 
         #Loop over input lines in the source list
         all_stamps = []

--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -734,7 +734,7 @@ class Catalog_seed():
 
         return mtlist, pixelflag, pixelvelflag, msys.lower()
 
-    def basicGetImage(self, filename):
+    def basic_get_image(self, filename):
         """
         Read in image from a fits file
         
@@ -919,7 +919,7 @@ class Catalog_seed():
                 stamp = self.centerpsf
 
             elif input_type == 'extended':
-                stamp, header = self.basicGetImage(entry['filename'])
+                stamp, header = self.basic_get_image(entry['filename'])
                 if entry['pos_angle'] != 0.:
                     stamp = self.basicRotateImage(stamp, entry['pos_angle'])
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except ImportError:
 
 setup(
     name='mirage',
-    version = '1.1',
+    version = '1.1.1',
     description = 'Create simulated JWST data',
     long_description = ('A tool to create simulated NIRCam, NIRISS,'
                         'and FGS exposures'


### PR DESCRIPTION
Added functionality to make a quick check of input source positions, and remove any that are very far from the nominal detector pointing. Previously, sources which were too far away off the detector were causing `Mirage` to hang. 