### PR TITLE
Updating gitignore for egg file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build/*
 dist/*
 mirages.egg-info/*
+*egg-info
 
 # Lists and images #
 ######################
@@ -32,6 +33,7 @@ examples/.ipynb_checkpoints/*
 *.aptbackup
 *.aptx
 *.docx
+mirage/scripts/#get_catalog.py#
 
 # Files #
 #########


### PR DESCRIPTION
Somewhere along the way, I rebased my local master from upstream, and a couple of strange files were created (some kind of image files called `jwst` and `jwst_backgrounds`, among others). I deleted the image files, but had to add the others to my `.gitignore` before git would allow me to rebase my master branch the next time.