### PR TITLE
WIP: Frametime calculation update

### DIFF
--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -29,6 +29,7 @@ from . import read_siaf_table
 from . import set_telescope_pointing_separated as set_telescope_pointing
 from . import moving_targets
 from . import segmentation_map as segmap
+from .utils import calc_frame_time
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {'nircam': ["imaging", "ts_imaging", "wfss", "ts_wfss"],
@@ -122,8 +123,11 @@ class Catalog_seed():
                                                           self.coord_adjust['x']])).astype(np.int)
 
         # calculate the exposure time of a single frame, based on the size of the subarray
-        self.calcFrameTime()
-
+        #self.calcFrameTime()
+        self.frametime = calc_frame_time(self.params['Inst']['instrument'], self.params['Readout']['array_name'],
+                                         self.nominal_dims[0], self.nominal_dims[1], self.params['Readout']['namp'])
+        print("Frametime is {}".format(self.frametime))
+        
         # Read in the pixel area map, which will be needed for certain
         # sources in the seed image
         self.prepare_PAM()
@@ -520,40 +524,6 @@ class Catalog_seed():
                 for i in range(1, len(mov_targs_ramps)):
                     mov_targs_integration += mov_targs_ramps[0]
         return mov_targs_integration, mov_targs_segmap
-
-    def calcFrameTime(self):
-        # calculate the exposure time of a single frame of the proposed output ramp
-        # based on the size of the cropped dark current integration
-        # numint, numgrp, yd, xd = self.dark.data.shape
-        yd, xd = self.nominal_dims
-        # self.frametime = (xd/self.params['Readout']['namp'] + 12.) * (yd + 1) * 10.00 * 1.e-6
-        # UPDATED VERSION, 16 Sept 2017
-        if 'nircam' in self.params['Inst']['instrument'].lower():
-            colpad = 12
-            rowpad = 2
-            if ((xd <= 8) & (yd <= 8)):
-                rowpad = 3
-            self.frametime = ((1.0 * xd / self.params['Readout']['namp'] + colpad) * (yd + rowpad)) * 1.e-5
-        elif self.params['Inst']['instrument'].lower() in ['niriss', 'fgs']:
-            # the following applies to NIRISS and Guider full frame imaging and
-            # NIRISS sub-arrays.
-            #
-            # According JDox the NIRCam full frame time is 10.73677 seconds the
-            # same as for NIRISS, but right now the change does not apply to NIRCam.
-            #
-            #
-            # note that the Guider frame time may be different for small sub-arrays
-            # less than 64 pixels square, but that needs to be confirmed.
-            colpad = 12
-            if self.params['Readout']['namp'] == 4:
-                pad1 = 1
-                pad2 = 1
-            else:
-                pad1 = 2
-                pad2 = 0
-            self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) 
-                              * (xd + pad1)) * 0.00001
-        print("Frametime is {}".format(self.frametime))
 
     def calcCoordAdjust(self):
         # Calculate the factors by which to expand the output array size, as well as the coordinate

--- a/mirage/scripts/catalog_seed_image.py
+++ b/mirage/scripts/catalog_seed_image.py
@@ -553,6 +553,7 @@ class Catalog_seed():
                 pad2 = 0
             self.frametime = (pad2 + (yd / self.params['Readout']['namp'] + colpad) 
                               * (xd + pad1)) * 0.00001
+        print("Frametime is {}".format(self.frametime))
 
     def calcCoordAdjust(self):
         # Calculate the factors by which to expand the output array size, as well as the coordinate

--- a/mirage/scripts/utils.py
+++ b/mirage/scripts/utils.py
@@ -24,6 +24,83 @@ import re
 from astropy.io import ascii as asc
 
 
+def calc_frame_time(instrument, aperture, xdim, ydim, amps):
+    """Calculate the readout time for a single frame
+    of a given size and number of amplifiers. Note that for
+    NIRISS and FGS, the fast readout direction is opposite to 
+    that in NIRCam, so we switch xdim and ydim so that we can
+    keep a single equation.
+
+    Parameters:
+    -----------
+    instrument : str
+        Name of the instrument being simulated
+
+    aperture : str
+        Name of aperture being simulated (e.g "NRCA1_FULL")
+        Currently this is only used to check for the FGS
+        ACQ1 aperture, which uses a unique value of colpad
+        below.
+
+    xdim : int
+        Number of columns in the frame
+
+    ydim : int
+        Number of rows in the frame
+    
+    amps : int
+        Number of amplifiers used to read out the frame
+
+    Returns:
+    --------
+    frametime : float
+        Readout time in seconds for the frame
+    """
+    instrument = instrument.lower()
+    if instrument == "nircam":
+        xs = xdim
+        ys = ydim
+        colpad = 12
+
+        # Fullframe
+        if amps == 4:
+            rowpad = 1
+            fullpad = 1
+        else:
+            # All subarrays
+            rowpad = 2
+            fullpad = 0
+            if ((xdim <= 8) & (ydim <= 8)):
+                # The smallest subarray
+                rowpad = 3
+
+    elif instrument == "niriss":
+        xs = ydim
+        ys = xdim
+        colpad = 12
+
+        # Fullframe
+        if amps == 4:
+            rowpad = 1
+            fullpad = 1
+        else:
+            rowpad = 2
+            fullpad = 0
+
+    elif instrument == 'fgs':
+        xs = ydim
+        ys = xdim
+        colpad = 6
+        if 'acq1' in aperture.lower():
+            colpad = 12
+        rowpad = 1
+        if amps == 4:
+            fullpad = 1
+        else:
+            fullpad = 0
+
+    return ((1.0 * xs / amps + colpad) * (ys + rowpad) + fullpad) * 1.e-5
+            
 def get_siaf():
     '''Return a dictionary that holds the contents of the SIAF config
     file.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except ImportError:
 
 setup(
     name='mirage',
-    version = '1.1',
+    version = '1.1.2',
     description = 'Create simulated JWST data',
     long_description = ('A tool to create simulated NIRCam, NIRISS,'
                         'and FGS exposures'


### PR DESCRIPTION
These updates have cleaned up the frame time calculation function. NIRCam had an error in the calculated full frame time. That error was fixed. The function was also cleaned up such that only one equation is used for all instruments/apertures and it was moved into `utils.py` since it is called within both `catalog_seed_image.py` and `obs_generator.py`. My tests have shown correct exposure times calculated for NIRCam and NIRISS full frame and subarrays. FGS exposure times match those given on the relevant JDox page: https://jwst-docs.stsci.edu/display/JTI/Fine+Guidance+Sensor%2C+FGS