### PR TITLE
Set OPD map and realization during PSF library generation

### DIFF
--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -63,6 +63,17 @@ class CreatePSFLibrary:
         number must be a square number. Default is 16.
         E.g. num_psfs = 16 will have the class create a 4x4 grid of fiducial PSFs.
 
+    opd_type: str
+        The type of OPD map you would like to use to create the PSFs. Options are
+        "predicted" or "requirements" where the predicted map is of the expected
+        WFE and the requirements map is slightly more conservative (has slightly
+        larger WFE). Default is "requirements"
+
+    opd_number: int
+        The realization of the OPD map pulled from the OPD file. Options are an
+        integer from 0 to 9, one for each of the 10 Monte Carlo realizations of
+        the telescope included in the OPD map file. Default is 0.
+
     save: bool
         True/False boolean if you want to save your file
 
@@ -174,7 +185,7 @@ class CreatePSFLibrary:
         return ij_list, location_list
 
     def __init__(self, instrument, filters="all", detectors="all", fov_pixels=101, oversample=5, num_psfs=16,
-                 save=True, fileloc=None, filename=None, overwrite=True):
+                 opd_type="requirements", opd_number=0, save=True, fileloc=None, filename=None, overwrite=True):
 
         # Pull correct capitalization of instrument name
         webbpsf_name_dict = {"NIRCAM": "NIRCam", "NIRSPEC": "NIRSpec", "NIRISS": "NIRISS",
@@ -210,6 +221,8 @@ class CreatePSFLibrary:
         # Set PSF attributes
         self.fov_pixels = fov_pixels
         self.oversample = oversample
+        self.opd_type = opd_type
+        self.opd_number = opd_number
         self.save = save
         self.overwrite = overwrite
         self.fileloc = fileloc
@@ -267,13 +280,23 @@ class CreatePSFLibrary:
         # Create kernel to smooth pixel based on oversample
         kernel = astropy.convolution.Box2DKernel(width=self.oversample)
 
+        # Set output mode
+        self.webb.options['output_mode'] = 'Oversampled Image'
+
+        # Set OPD Map (pull most recent version with self.webb.opd_list call) - always predicted then requirements
+        if self.opd_type.lower() == "requirements":
+            opd = self.webb.opd_list[1]
+        elif self.opd_type.lower() == "predicted":
+            opd = self.webb.opd_list[0]
+        self.webb.pupilopd = (opd, self.opd_number)
+        print(self.webb.pupilopd)
+
         # For every filter
         final_list = []
         for filt in filter_list:
             print("\nStarting filter: {}".format(filt))
 
-            # Edit instance (created above) of instrument in WebbPSF
-            self.webb.options['output_mode'] = 'Oversampled Image'
+            # Set filter
             self.webb.filter = filt
 
             # Create an array to fill ([SCA, j, i, y, x])
@@ -294,7 +317,7 @@ class CreatePSFLibrary:
                     psf = self.webb.calc_psf(fov_pixels=self.fov_pixels, oversample=self.oversample)
 
                     # Convolve PSF with a square kernel
-                    psf_conv = astropy.convolution.convolve(psf[0].data, kernel)
+                    psf_conv = astropy.convolution.convolve(psf["OVERDIST"].data, kernel)
 
                     # Add PSF to 5D array
                     psf_arr[k, j, i, :, :] = psf_conv
@@ -304,6 +327,8 @@ class CreatePSFLibrary:
 
             header["INSTRUME"] = (self.instr, "Instrument")
             header["FILTER"] = (filt, "Filter name")
+            header["PUPILOPD"] = (self.webb.pupilopd[0], "Pupil OPD source name")
+            header["OPD_REAL"] = (self.webb.pupilopd[1], "Pupil OPD source realization from file")
 
             for i, det in enumerate(detector_list):
                 header["DETNAME{}".format(i)] = (det, "The #{} detector included in this file".format(i))


### PR DESCRIPTION
You can now set a specific realization of the OPD map when generating your library. There are now 2 new keyword args: opd_type (str "requirements" or "predicted"; default of "requirements") and opd_number (int 0-9; default of 0). 

There are also 2 new header keywords in the output: PUPILOPD is the OPD map's filename (which will contain the word "predicted" or "requirements") and OPD_REAL is the realization number. (And I am re-running the current files in the PSF library to contain these new keywords)