### PR TITLE
Update file naming scheme to match JWST naming conventions

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -312,7 +312,7 @@ class AptInput:
                         obsnum, visitnum = v.split(':')
                         obsnum = str(obsnum).zfill(3)
                         visitnum = str(visitnum).zfill(3)
-                        if skip == True:
+                        if skip is True:
                             print('Skipping observation {} ({})'.format(obsnum, obslabel))
 
                     try:

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -334,7 +334,8 @@ class AptInput:
                             observation_label.append(obslabel)
                             observation_number.append(obsnum)
                             visit_number.append(visitnum)
-                            vid = "{}{}{}".format(str(propid).zfill(5), obsnum, visitnum)
+                            prop_5digit = "{0:05d}".format(int(propid))
+                            vid = "{}{}{}".format(prop_5digit, obsnum, visitnum)
                             visit_id.append(vid)
                             # Visit group hard coded to 1. It's not clear how APT divides visits up into visit
                             # groups. For now just keep everything in a single visit group.

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -334,7 +334,7 @@ class AptInput:
                             observation_label.append(obslabel)
                             observation_number.append(obsnum)
                             visit_number.append(visitnum)
-                            vid = str(propid) + obsnum + visitnum
+                            vid = "{}{}{}".format(str(propid).zfill(5), obsnum, visitnum)
                             visit_id.append(vid)
                             # Visit group hard coded to 1. It's not clear how APT divides visits up into visit
                             # groups. For now just keep everything in a single visit group.

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -334,7 +334,7 @@ class AptInput:
                             observation_label.append(obslabel)
                             observation_number.append(obsnum)
                             visit_number.append(visitnum)
-                            vid = str(propid) + visitnum + obsnum
+                            vid = str(propid) + obsnum + visitnum
                             visit_id.append(vid)
                             vgrp = '01'
                             visit_grp.append(vgrp)
@@ -370,8 +370,8 @@ class AptInput:
                             expar.append(np.int(elements[19]))
                             dkpar.append(np.int(elements[20]))
                             ddist.append(np.float(elements[21]))
-                            observation_id.append('V' + vid + 'P00000000' + vgrp + seq + act)
-                            act_counter  += 1
+                            observation_id.append("jw{}_{}{}{}_{}".format(vid, vgrp, seq, act, exnum))
+                            act_counter += 1
 
                     except:
                         pass

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -336,8 +336,13 @@ class AptInput:
                             visit_number.append(visitnum)
                             vid = str(propid) + obsnum + visitnum
                             visit_id.append(vid)
+                            # Visit group hard coded to 1. It's not clear how APT divides visits up into visit
+                            # groups. For now just keep everything in a single visit group.
                             vgrp = '01'
                             visit_grp.append(vgrp)
+                            # Parallel sequence id hard coded to 1 (Simulated instrument as prime rather than
+                            # parallel) at the moment. Future improvements may allow the proper sequence
+                            # number to be constructed.
                             seq = '1'
                             seq_id.append(seq)
                             tar.append(np.int(elements[0]))

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -880,7 +880,7 @@ class SimInput:
         input -- dictionary containing all needed exposure
                  information for one exposure
         """
-
+        instrument = input['Instrument']
         # select the right filter
         if input['detector'] == 'NIS':
             filtkey = 'FilterWheel'
@@ -901,12 +901,15 @@ class SimInput:
             outfile = input['outputfits']
             yamlout = input['yamlfile']
         else:
+            if instrument.upper() == 'NIRCAM':
+                fulldetector = 'nrc{}'.format(input['detector'].lower())
+            else:
+                fulldetector = input['detector'].lower()
             outtf = True
-            outfile = input['observation_id'] + '_' + input['detector'] + '_' + input[filtkey] + '_uncal.fits'
-            yamlout = input['observation_id'] + '_' + input['detector'] + '_' + input[filtkey] + '.yaml'
+            outfile = input['observation_id'] + '_' + fulldetector + '_uncal.fits'
+            yamlout = input['observation_id'] + '_' + fulldetector + '.yaml'
 
         yamlout = os.path.join(self.output_dir, yamlout)
-        instrument = input['Instrument']
         with open(yamlout, 'w') as f:
             f.write('Inst:\n')
             f.write('  instrument: {}          # Instrument name\n'.format(instrument))


### PR DESCRIPTION
This is a small update to `yaml_generator.py` and `apt_inputs.py` that updates the file naming convention of the outputs (both yaml file names, as well as the requested `mirage` output fits filename) to match that of JWST.

See https://jwst-docs.stsci.edu/display/JDAT/File+Naming+Conventions+and+Data+Products for details.

Filenames produced by `mirage` should now match those produced by the JWST pipeline.

Note that at the moment this has only been tested on NIRCam, as the yaml_generator only currently supports NIRCam and one engineering-only NIRISS mode.