### PR TITLE
Add config dir to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup, find_packages, Extension, Command
 from setuptools.command.test import test as TestCommand
 
 
-
 # allows you to build sphinx docs from the package
 # main directory with "python setup.py build_sphinx"
 
@@ -45,6 +44,7 @@ except ImportError:
             print('!\n! Sphinx is not installed!\n!', file=sys.stderr)
             exit(1)
 
+
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -77,12 +77,12 @@ setup(
     version='2.0.1',
     description='Create simulated JWST data',
     long_description=('A tool to create simulated NIRCam, NIRISS,'
-                        'and FGS exposures'
-                        'using an input dark current exposure and a'
-                        'noiseless seed image, which can be produced'
-                        'from source catalogs. Data can optionally be'
-                        'dispersed as well, to simulate wide field'
-                        'slitless data files.'),
+                      'and FGS exposures'
+                      'using an input dark current exposure and a'
+                      'noiseless seed image, which can be produced'
+                      'from source catalogs. Data can optionally be'
+                      'dispersed as well, to simulate wide field'
+                      'slitless data files.'),
     author='STScI (Hilbert, Volk, Chambers, Sahlmann et al.)',
     author_email='hilbert@stsci.edu',
     url='https://github.com/spacetelescope/mirage',
@@ -99,7 +99,8 @@ setup(
     package_data={'mirage': ['tests/test_data/*/*.yaml',
                              'tests/test_data/*/*.list',
                              'tests/test_data/*/*.xml',
-                             'tests/test_data/*/*.pointing']
+                             'tests/test_data/*/*.pointing',
+                             'config/*.*']
                   },
     install_requires=[
         'astropy>=1.2',


### PR DESCRIPTION
This PR introduces a small change in setup.py. Previously, when installing mirage using `python setup.py install` the majority of the files in the config directory were not being installed. (Note that this problem did not seem to exist when installing using `pip install .` from within the mirage directory.) I have added the files in the config directory to the list of `package_data` in setup.py. This seems to have solved the problem, and all files are now installed when using `python setup.py install`. I also checked `pip` and that installation is unchanged after this fix.