### PR TITLE
Changes to add the NRM mode of NIRISS as an option.

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -25,7 +25,7 @@ from ..utils import set_telescope_pointing_separated as stp
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {"nircam": ["imaging", "ts_imaging", "wfss", "ts_wfss"],
-         "niriss": ["imaging"],
+         "niriss": ["imaging","ami"],
          "fgs": ["imaging"]}
 
 
@@ -844,7 +844,7 @@ class Observation():
 
         exptype = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
                               "wfss": "NRC_GRISM", "ts_wfss": "NRC_TSGRISM"},
-                   "niriss": {"imaging": "NIS_IMAGE"},
+                   "niriss": {"imaging": "NIS_IMAGE","ami": "NIS_IMAGE"},
                    "fgs": {"imaging": "FGS_IMAGE"}}
 
         try:

--- a/tests/test_data/NIRISS/niriss_imaging_test.yaml
+++ b/tests/test_data/NIRISS/niriss_imaging_test.yaml
@@ -1,0 +1,123 @@
+Inst:
+  instrument: NIRISS         #Instrument name
+  mode: imaging   #Observation mode (e.g. imaging, WFSS, moving_target)
+  use_JWST_pipeline: True   #Use pipeline in data transformations
+
+Readout:
+  readpatt: NISRAPID      #Readout pattern (RAPID, BRIGHT2, etc)
+  ngroup: 5             #Number of groups in integration
+  nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
+  array_name: NIS_CEN    #Name of array (FULL, SUB160, SUB64P, etc)
+  filter: F480M       #Filter of simulated data (F090W, F322W2, etc)
+  pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
+
+Reffiles:                                 #Set to None or leave blank if you wish to skip that step
+  dark: /ifs/jwst/wit/nircam/nircam_simulator_data/niriss_darks/NISNIRISSDARK-172500017_15_496_SE_2017-09-07T05h28m22_dms_uncal.fits   #Dark current integration used as the base
+  linearized_darkfile: None # Linearized dark ramp to use as input. Supercedes dark above
+  badpixmask: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_mask_0008.fits # If linearized dark is used, populate output DQ extensions using this file
+  superbias: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_superbias_0080.fits #Superbias file. Set to None or leave blank if not using
+  linearity: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_linearity_0010.fits #linearity correction coefficients
+  saturation: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_saturation_0010.fits #well depth reference files
+  gain: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_gain_0005.fits
+  pixelflat: None
+  illumflat: None                               #Illumination flat field file
+  astrometric: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_distortion_0008.asdf #Astrometric distortion file (asdf)
+  distortion_coeffs: /ifs/jwst/wit/nircam/nircam_simulator_data/NIRISS_SIAF_09-28-2017.csv        #CSV file containing distortion coefficients
+  ipc: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/Kernel_to_add_IPC_effects_from_jwst_niriss_ipc_0007.fits  #File containing IPC kernel to apply
+  invertIPC: False      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
+  occult: None                                    #Occulting spots correction image
+  pixelAreaMap: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_area_0011.fits  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
+  subarray_defs:   config   #File that contains a list of all possible subarray names and coordinates
+  readpattdefs:    config   #File that contains a list of all possible readout pattern names and associated NFRAME/NSKIP values
+  crosstalk:       config   #File containing crosstalk coefficients
+  filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
+  flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
+  filter_throughput: config #File containing filter throughput curve
+
+nonlin:
+  limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
+  accuracy: 0.000001                        #Non-linearity accuracy threshold
+  maxiter: 10                              #Maximum number of iterations to use when applying non-linearity
+  robberto:  False                         #Use Massimo Robberto type non-linearity coefficients
+
+cosmicRay:
+  path: /ifs/jwst/wit/nircam/nircam_simulator_data/cosmic_ray_library/         #Path to CR library
+  library: SUNMIN    #Type of cosmic rayenvironment (SUNMAX, SUNMIN, FLARE)
+  scale: 1.5     #Cosmic ray scaling factor
+  suffix: IPC_NIRCam_B5    #Suffix of library file names
+  seed: 2956411739      #Seed for random number generator
+
+simSignals:
+  pointsource: niriss_point_sources.list #File containing a list of point sources to add (x,y locations and magnitudes)
+  psfpath: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/webbpsf_files/  #Path to PSF library
+  psfbasename: niriss                        #Basename of the files in the psf library
+  psfpixfrac: 0.1                           #Fraction of a pixel between entries in PSF library (e.g. 0.1 = files for PSF centered at 0.1 pixel intervals within pixel)
+  psfwfe: predicted   #PSF WFE value. Can be predicted or requirements
+  psfwfegroup: 0      #WFE realization group (0 to 4)
+  galaxyListFile: None
+  extended: None          #Extended emission count rate image file name
+  extendedscale: 1.0         #Scaling factor for extended emission image
+  extendedCenter: 1024,1024  #x,y pixel location at which to place the extended image if it is smaller than the output array size
+  PSFConvolveExtended: True #Convolve the extended image with the PSF before adding to the output image (True or False)
+  movingTargetList: None   #Name of file containing a list of point source moving targets (e.g. KBOs, asteroids) to add.
+  movingTargetSersic: None  #ascii file containing a list of 2D sersic profiles to have moving through the field
+  movingTargetExtended: None      #ascii file containing a list of stamp images to add as moving targets (planets, moons, etc)
+  movingTargetConvolveExtended: True       #convolve the extended moving targets with PSF before adding.
+  movingTargetToTrack: None #File containing a single moving target which JWST will track during observation (e.g. a planet, moon, KBO, asteroid)	This file will only be used if mode is set to "moving_target"
+  zodiacal:  None                          #Zodiacal light count rate image file
+  zodiscale:  1.0                            #Zodi scaling factor
+  scattered:  None                          #Scattered light count rate image file
+  scatteredscale: 1.0                        #Scattered light scaling factor
+  bkgdrate: medium                         #Constant background count rate. Number (ADU/sec/pixel) or 'high','medium','low' similar to what is used in the ETC
+  poissonseed: 2012872553                  #Random number generator seed for Poisson simulation)
+  photonyield: True                         #Apply photon yield in simulation
+  pymethod: True                            #Use double Poisson simulation for photon yield
+
+Telescope:
+  ra: 53.1                     #RA of simulated pointing
+  dec: -27.8                   #Dec of simulated pointing
+  rotation: 0.0                #y axis rotation (degrees E of N)
+  tracking: sidereal   #Telescope tracking. Can be sidereal or non-sidereal
+
+newRamp:
+  dq_configfile: config
+  sat_configfile: config
+  superbias_configfile: config
+  refpix_configfile: config
+  linear_configfile: config
+
+Output:
+  file: V88888024002P000000000112o_NIS_F480M_uncal.fits   #Output filename
+  directory: ./   # Directory in which to place output files
+  datatype: linear,raw # Type of data to save. 'linear' for linearized ramp. 'raw' for raw ramp. 'linear,raw' for both
+  format: DMS          #Output file format Options: DMS, SSR(not yet implemented)
+  save_intermediates: False   #Save intermediate products separately (point source image, etc)
+  grism_source_image: False   # Create an image to be dispersed?
+  unsigned: True   #Output unsigned integers? (0-65535 if true. -32768 to 32768 if false)
+  dmsOrient: True    #Output in DMS orientation (vs. fitswriter orientation).
+  program_number: 42424    #Program Number
+  title: Black Holes at the Restaurant at the End of the Universe   #Program title
+  PI_Name: D. Adams  #Proposal PI Name
+  Proposal_category: GO  #Proposal category
+  Science_category: Cosmology  #Science category
+  observation_number: '002'    #Observation Number
+  observation_label: Obs1    #User-generated observation Label
+  visit_number: '024'    #Visit Number
+  visit_group: '01'    #Visit Group
+  visit_id: '88888024002'    #Visit ID
+  sequence_id: '2'    #Sequence ID
+  activity_id: '2o'    #Activity ID. Increment with each exposure.
+  exposure_number: '00001'    #Exposure Number
+  obs_id: 'V88888024002P000000000112o'   #Observation ID number
+  date_obs: '2019-10-15'  #Date of observation
+  time_obs: '06:29:11.852'  #Time of observation
+  obs_template: 'NIRISS Imaging'  #Observation template
+  primary_dither_type: NONE  #Primary dither pattern name
+  total_primary_dither_positions: 1  #Total number of primary dither positions
+  primary_dither_position: 1  #Primary dither position number
+  subpix_dither_type: 2-POINT-MEDIUM-WITH-NIRISS  #Subpixel dither pattern name
+  total_subpix_dither_positions: 2  #Total number of subpixel dither positions
+  subpix_dither_position: 2  #Subpixel dither position number
+  xoffset: 344.284  #Dither pointing offset in x (arcsec)
+  yoffset: 466.768  #Dither pointing offset in y (arcsec)

--- a/tests/test_data/NIRISS/niriss_nrm_test.yaml
+++ b/tests/test_data/NIRISS/niriss_nrm_test.yaml
@@ -1,0 +1,123 @@
+Inst:
+  instrument: NIRISS         #Instrument name
+  mode: ami   #Observation mode (e.g. imaging, WFSS, moving_target)
+  use_JWST_pipeline: True   #Use pipeline in data transformations
+
+Readout:
+  readpatt: NISRAPID      #Readout pattern (RAPID, BRIGHT2, etc)
+  ngroup: 5             #Number of groups in integration
+  nint: 1          #Number of integrations per exposure
+  resets_bet_ints: 1 #Number of detector resets between integrations
+  array_name: NIS_CEN    #Name of array (FULL, SUB160, SUB64P, etc)
+  filter: F480M       #Filter of simulated data (F090W, F322W2, etc)
+  pupil: CLEAR        #Pupil element for simulated data (CLEAR, GRISMC, etc)
+
+Reffiles:                                 #Set to None or leave blank if you wish to skip that step
+  dark: /ifs/jwst/wit/nircam/nircam_simulator_data/niriss_darks/NISNIRISSDARK-172500017_15_496_SE_2017-09-07T05h28m22_dms_uncal.fits   #Dark current integration used as the base
+  linearized_darkfile: None # Linearized dark ramp to use as input. Supercedes dark above
+  badpixmask: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_mask_0008.fits # If linearized dark is used, populate output DQ extensions using this file
+  superbias: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_superbias_0080.fits #Superbias file. Set to None or leave blank if not using
+  linearity: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_linearity_0010.fits #linearity correction coefficients
+  saturation: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_saturation_0010.fits #well depth reference files
+  gain: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_gain_0005.fits
+  pixelflat: None
+  illumflat: None                               #Illumination flat field file
+  astrometric: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_distortion_0008.asdf #Astrometric distortion file (asdf)
+  distortion_coeffs: /ifs/jwst/wit/nircam/nircam_simulator_data/NIRISS_SIAF_09-28-2017.csv        #CSV file containing distortion coefficients
+  ipc: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/Kernel_to_add_IPC_effects_from_jwst_niriss_ipc_0007.fits  #File containing IPC kernel to apply
+  invertIPC: False      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
+  occult: None                                    #Occulting spots correction image
+  pixelAreaMap: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/reference_files/jwst_niriss_area_0011.fits  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
+  subarray_defs:   config   #File that contains a list of all possible subarray names and coordinates
+  readpattdefs:    config   #File that contains a list of all possible readout pattern names and associated NFRAME/NSKIP values
+  crosstalk:       config   #File containing crosstalk coefficients
+  filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
+  flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
+  filter_throughput: config #File containing filter throughput curve
+
+nonlin:
+  limit: 60000.0                           #Upper singal limit to which nonlinearity is applied (ADU)
+  accuracy: 0.000001                        #Non-linearity accuracy threshold
+  maxiter: 10                              #Maximum number of iterations to use when applying non-linearity
+  robberto:  False                         #Use Massimo Robberto type non-linearity coefficients
+
+cosmicRay:
+  path: /ifs/jwst/wit/nircam/nircam_simulator_data/cosmic_ray_library/         #Path to CR library
+  library: SUNMIN    #Type of cosmic rayenvironment (SUNMAX, SUNMIN, FLARE)
+  scale: 1.5     #Cosmic ray scaling factor
+  suffix: IPC_NIRCam_B5    #Suffix of library file names
+  seed: 2956411739      #Seed for random number generator
+
+simSignals:
+  pointsource: niriss_point_sources.list #File containing a list of point sources to add (x,y locations and magnitudes)
+  psfpath: /ifs/jwst/wit/niriss/nircam_ramp_simulation_files/webbpsf_files/  #Path to PSF library
+  psfbasename: niriss                        #Basename of the files in the psf library
+  psfpixfrac: 0.1                           #Fraction of a pixel between entries in PSF library (e.g. 0.1 = files for PSF centered at 0.1 pixel intervals within pixel)
+  psfwfe: predicted   #PSF WFE value. Can be predicted or requirements
+  psfwfegroup: 0      #WFE realization group (0 to 4)
+  galaxyListFile: None
+  extended: None          #Extended emission count rate image file name
+  extendedscale: 1.0         #Scaling factor for extended emission image
+  extendedCenter: 1024,1024  #x,y pixel location at which to place the extended image if it is smaller than the output array size
+  PSFConvolveExtended: True #Convolve the extended image with the PSF before adding to the output image (True or False)
+  movingTargetList: None   #Name of file containing a list of point source moving targets (e.g. KBOs, asteroids) to add.
+  movingTargetSersic: None  #ascii file containing a list of 2D sersic profiles to have moving through the field
+  movingTargetExtended: None      #ascii file containing a list of stamp images to add as moving targets (planets, moons, etc)
+  movingTargetConvolveExtended: True       #convolve the extended moving targets with PSF before adding.
+  movingTargetToTrack: None #File containing a single moving target which JWST will track during observation (e.g. a planet, moon, KBO, asteroid)	This file will only be used if mode is set to "moving_target"
+  zodiacal:  None                          #Zodiacal light count rate image file
+  zodiscale:  1.0                            #Zodi scaling factor
+  scattered:  None                          #Scattered light count rate image file
+  scatteredscale: 1.0                        #Scattered light scaling factor
+  bkgdrate: medium                         #Constant background count rate. Number (ADU/sec/pixel) or 'high','medium','low' similar to what is used in the ETC
+  poissonseed: 2012872553                  #Random number generator seed for Poisson simulation)
+  photonyield: True                         #Apply photon yield in simulation
+  pymethod: True                            #Use double Poisson simulation for photon yield
+
+Telescope:
+  ra: 53.1                     #RA of simulated pointing
+  dec: -27.8                   #Dec of simulated pointing
+  rotation: 0.0                #y axis rotation (degrees E of N)
+  tracking: sidereal   #Telescope tracking. Can be sidereal or non-sidereal
+
+newRamp:
+  dq_configfile: config
+  sat_configfile: config
+  superbias_configfile: config
+  refpix_configfile: config
+  linear_configfile: config
+
+Output:
+  file: V88888024002P000000000112o_NIS_NRM_F480M_uncal.fits   #Output filename
+  directory: ./   # Directory in which to place output files
+  datatype: linear,raw # Type of data to save. 'linear' for linearized ramp. 'raw' for raw ramp. 'linear,raw' for both
+  format: DMS          #Output file format Options: DMS, SSR(not yet implemented)
+  save_intermediates: False   #Save intermediate products separately (point source image, etc)
+  grism_source_image: False   # Create an image to be dispersed?
+  unsigned: True   #Output unsigned integers? (0-65535 if true. -32768 to 32768 if false)
+  dmsOrient: True    #Output in DMS orientation (vs. fitswriter orientation).
+  program_number: 42424    #Program Number
+  title: Black Holes at the Restaurant at the End of the Universe   #Program title
+  PI_Name: D. Adams  #Proposal PI Name
+  Proposal_category: GO  #Proposal category
+  Science_category: Cosmology  #Science category
+  observation_number: '002'    #Observation Number
+  observation_label: Obs1    #User-generated observation Label
+  visit_number: '024'    #Visit Number
+  visit_group: '01'    #Visit Group
+  visit_id: '88888024002'    #Visit ID
+  sequence_id: '2'    #Sequence ID
+  activity_id: '2o'    #Activity ID. Increment with each exposure.
+  exposure_number: '00001'    #Exposure Number
+  obs_id: 'V88888024002P000000000112o'   #Observation ID number
+  date_obs: '2019-10-15'  #Date of observation
+  time_obs: '06:29:11.852'  #Time of observation
+  obs_template: 'NIRISS Imaging'  #Observation template
+  primary_dither_type: NONE  #Primary dither pattern name
+  total_primary_dither_positions: 1  #Total number of primary dither positions
+  primary_dither_position: 1  #Primary dither position number
+  subpix_dither_type: 2-POINT-MEDIUM-WITH-NIRISS  #Subpixel dither pattern name
+  total_subpix_dither_positions: 2  #Total number of subpixel dither positions
+  subpix_dither_position: 2  #Subpixel dither position number
+  xoffset: 344.284  #Dither pointing offset in x (arcsec)
+  yoffset: 466.768  #Dither pointing offset in y (arcsec)

--- a/tests/test_data/NIRISS/niriss_point_sources.list
+++ b/tests/test_data/NIRISS/niriss_point_sources.list
@@ -1,0 +1,8 @@
+#
+#
+# 
+# abmag 
+# catalog for ramp_simulator.py. created from candels catalog
+# Magnitudes are converted from input flux densities. See
+x_or_RA y_or_Dec magnitude
+53.1       -27.8       17.0

--- a/tests/test_niriss_imaging_modes.py
+++ b/tests/test_niriss_imaging_modes.py
@@ -1,0 +1,47 @@
+"""System test of mirage/NIRISS for regular and NRM imaging.
+
+Authors
+-------
+    - Kevin Volk
+
+Use
+---
+    >>> pytest -s test_niriss_imaging_modes.py
+
+Description of the test:
+------------------------
+
+The test runs mirage for the same NIRISs imaging scene in regular imaging and 
+in the NRM imaging mode.  There is only one star in the scene of the same 
+magnitude in both instances.  The code reads the two pointsource output list 
+files to get the count rates for the two cases and verifies that the proper 
+scaling has been used.  The count rate ratio should be exactly 0.15/0.84 
+between the NRM case and the regular imaging case.  Due to limitations on the 
+precision of the output format, the values differ by a fraction amount of 
+about 1.e-08 in my test.  Here the threhsold for agreement is a deviaiton of 
+less than 1.e-06.
+
+"""
+
+import os
+import pytest
+import numpy
+
+from mirage import imaging_simulator 
+
+# os.environ['MIRAGE_DATA'] = ''
+os.environ['TEST_DATA'] = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS')
+
+@pytest.mark.xfail
+def test_niriss_imaging():
+    nis = imaging_simulator.ImgSim()
+    nis.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS/niriss_imaging_test.yaml')
+    nis.create()
+    nis.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS/niriss_nrm_test.yaml')
+    nis.create()
+    value1 = numpy.loadtxt('V88888024002P000000000112o_NIS_F480M_uncal_pointsources.list',usecols=[8,])
+    value2 = numpy.loadtxt('V88888024002P000000000112o_NIS_NRM_F480M_uncal_pointsources.list',usecols=[8,])
+    fluxratio = value2 / value1
+    targetratio = 0.15 / 0.84
+    deviation = abs(fluxratio/targetratio - 1.)
+    assert deviation < 1.e-06


### PR DESCRIPTION
I have made some (fairly small) code changes to add the NIRISS AMI mode to mirage.  To use this mode one needs separate PFS files.  I have chosen to change the names of these PSF files from the regular imaging file names by replacing "NIS" by "NIS_NRM".  Only four filters can be used with the NRM for science: F277W, F380M, F430M, and F480M.  I do not have a check of this in the code because the PSF library will only cover the four allowed filters.  The other change is to scale the count rates for a given magnitude by a fixed factor due to the throughput of the NRM compared to the throughput of the CLEARP element that is in the pupil wheel of NIRISS for regular imaging in these filters.  The changes were tested for a simple case of a single star in the field.  More detailed tests need to wait until the PSF library is fully generated.

I also added a test to the tests directory, but I have not tried that out because I have never used pytest.  The steps in the test file were tried out manually and they work, so I think that the test should work OK.  I need to learn how to run the test explicitly....