### PR TITLE
Update to output filename, obs_id, primary/subpix dither counters

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -678,7 +678,7 @@ class AptInput:
                             expar.append(np.int(elements[19]))
                             dkpar.append(np.int(elements[20]))
                             ddist.append(np.float(elements[21]))
-                            observation_id.append("jw{}_{}{}{}_{}".format(vid, vgrp, seq, act, exnum))
+                            observation_id.append("V{}P{}{}{}{}".format(vid, '00000000', vgrp, seq, act))
                             act_counter += 1
 
                     except:

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -678,6 +678,9 @@ class AptInput:
                             expar.append(np.int(elements[19]))
                             dkpar.append(np.int(elements[20]))
                             ddist.append(np.float(elements[21]))
+                            # For the moment we assume that the instrument being simulated is not being
+                            # run in parallel, so the parallel proposal number will be all zeros,
+                            # as seen in the line below.
                             observation_id.append("V{}P{}{}{}{}".format(vid, '00000000', vgrp, seq, act))
                             act_counter += 1
 


### PR DESCRIPTION
This PR fixes a few small bugs in `yaml_generator.py` and `apt_inputs.py`. Other work last week pointed out that the values going into the OBS_ID header keywords were incorrect (they SHOULD follow the 'V<prop_id><observation><visit>P<visit_grp>.... convention that was previously used for output filenames. 

I made sure the output filenames follow the JWST naming convention 'jw<prop_id>...', and updated OBS_ID to follow the V...P... convention.

I also fixed the way that the primary and subpixel dither counters (PATT_NUM, SUBPXNUM) were being calculated. Previously there were subpixel dither numbers that were negative. I created an APT file with a different number of primary and subpixel dithers in each observation and tested the code changes, and the counters were correct for all exposures. I'm not certain that this error would have had an effect on much of anything. I don't believe the level 3 pipeline pays attention to dither numbers, but I wanted to correct the error just in case the pipeline does look at it somewhere. It will also be more clear for any user-generated analysis software.