### PR TITLE
Temporary change to use SIAF pre-delivery data for NIRCam

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -192,36 +192,6 @@ class Catalog_seed():
         base_table.add_column(det_column, index = 0)
         return base_table
 
-    #def get_siaf_information(self, instrument, aperture):
-    #    """Use pysiaf to get aperture information
-
-    #    Parameters:
-    #    -----------
-    #    instrument : str
-    #        Instrument name.
-
-    #    aperture : str
-    #        Aperture name (e.g. "NRCA1_FULL")
-
-    #    Returns:
-    #    --------
-    #    None
-    #    """
-    #    self.siaf = pysiaf.Siaf(instrument)[aperture]
-    #    self.local_roll = set_telescope_pointing.compute_local_roll(self.params['Telescope']['rotation'],
-    #                                                                self.ra, self.dec, self.siaf.V2Ref,
-    #                                                                self.siaf.V3Ref)
-    #    # Create attitude_matrix
-    #    self.attitude_matrix = rotations.attitude(self.siaf.V2Ref, self.siaf.V3Ref, self.ra, self.dec,
-    #                                              self.local_roll)
-
-    #    # Get full frame size
-    #    self.ffsize = self.siaf.XDetSize
-
-    #    # Subarray boundaries in full frame coordinates
-    #    xcorner, ycorner = siaf_interface.sci_subarray_corners(instrument, aperture)
-    #    self.subarray_bounds = [xcorner[0], ycorner[0], xcorner[1], ycorner[1]]
-
     def prepare_PAM(self):
         """
         Read in and prepare the pixel area map (PAM), to be used

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -417,10 +417,10 @@ class Catalog_seed():
     def mag_to_countrate(self, magsys, mag, photfnu=None, photflam=None):
         # Convert object magnitude to counts/sec
         #
-        # For NIRISS AMI mode, the count rate values calculated need to be 
-        # scaled by a factor 0.15/0.84 = 0.17857.  The 0.15 value is the 
-        # throughput of the NRM, while the 0.84 value is the throughput of the 
-        # imaging CLEARP element that is in place in the pupil wheel for the 
+        # For NIRISS AMI mode, the count rate values calculated need to be
+        # scaled by a factor 0.15/0.84 = 0.17857.  The 0.15 value is the
+        # throughput of the NRM, while the 0.84 value is the throughput of the
+        # imaging CLEARP element that is in place in the pupil wheel for the
         # normal imaging observations.
         if self.params['Inst']['mode'] in ['ami']:
             count_scale = 0.15 / 0.84
@@ -2956,13 +2956,13 @@ class Catalog_seed():
 
                 self.params['simSignals']['psfpath'] = os.path.join(self.params['simSignals']['psfpath'], pathaddition)
                 self.psfname = os.path.join(self.params['simSignals']['psfpath'], psfname)
-                # In the NIRISS AMI mode case, replace NIS by NIS_NRM as the PSF 
+                # In the NIRISS AMI mode case, replace NIS by NIS_NRM as the PSF
                 # files are in a separate directory and have the altered file names
-                # compared to imaging.  Hence one can point to the same base 
+                # compared to imaging.  Hence one can point to the same base
                 # directory to run both imaging and NRM models.
-                # 
-                # This set-up requires that the NRM PSF library files be placed in a directory named NIS_NRM under the 
-                # PSF path given in the .yaml file, just as the NIRISS imaging PSF library files need to be placed in a 
+                #
+                # This set-up requires that the NRM PSF library files be placed in a directory named NIS_NRM under the
+                # PSF path given in the .yaml file, just as the NIRISS imaging PSF library files need to be placed in a
                 # directory named NIS under the specified PSF path.
                 if self.params['Inst']['mode'] in ['ami']:
                     self.psfname = self.psfname.replace('NIS','NIS_NRM')

--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -22,6 +22,7 @@ import numpy as np
 
 import pysiaf
 from pysiaf import iando
+from pysiaf.constants import JWST_DELIVERY_DATA_ROOT
 from ..utils import rotations
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 
@@ -37,7 +38,16 @@ def get_siaf_information(instrument, aperture, ra, dec, telescope_roll):
     aperture : str
         Aperture name (e.g. "NRCA1_FULL")
     """
-    siaf = pysiaf.Siaf(instrument)[aperture]
+    # Temporary fix to access good NIRCam distortion coefficients which
+    # which are not yet in the PRD
+    if instrument.lower() == 'nircam':
+        import os
+        print("NOTE: Using pre-delivery SIAF data")
+        pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, instrument)
+        siaf = pysiaf.Siaf(instrument, basepath=pre_delivery_dir)[aperture]
+    else:
+        siaf = pysiaf.Siaf(instrument)[aperture]
+
     local_roll = set_telescope_pointing.compute_local_roll(telescope_roll,
                                                            ra, dec, siaf.V2Ref,
                                                            siaf.V3Ref)


### PR DESCRIPTION
This PR introduces a small, temporary change to use SIAF pre-delivery data for NIRCam only. This is because the correct SIAF distortion coefficients are not yet in the PRD, but with the merge of the pysiaf changes recently (), the manual work-around that had been in `mirage` was removed. So we need access to the correct distortion coefficients in order to have `mirage` continue to place sources in the correct locations on the detector when source positions are given in RA, Dec.

For NIRISS and FGS, `mirage` will continue to use the PRD version of the SIAF data.