### PR TITLE
Move parse_ra_dec to utils, Rework source filtering

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -47,7 +47,7 @@ from ..utils import set_telescope_pointing_separated as stp
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {"nircam": ["imaging", "ts_imaging", "wfss", "ts_wfss"],
-         "niriss": ["imaging","ami"],
+         "niriss": ["imaging", "ami"],
          "fgs": ["imaging"]}
 
 
@@ -734,8 +734,8 @@ class Observation():
             self.ra = float(self.params['Telescope']['ra'])
             self.dec = float(self.params['Telescope']['dec'])
         except:
-            self.ra, self.dec = self.parseRADec(self.params['Telescope']['ra'],
-                                                self.params['Telescope']['dec'])
+            self.ra, self.dec = utils.parse_RA_Dec(self.params['Telescope']['ra'],
+                                                   self.params['Telescope']['dec'])
 
         if abs(self.dec) > 90. or self.ra < 0. or self.ra > 360. or self.ra is None or self.dec is None:
             raise ValueError("WARNING: bad requested RA and Dec {} {}".format(self.ra, self.dec))

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -817,10 +817,6 @@ class Catalog_seed():
             pixelx, pixely, ra, dec, ra_str, dec_str = self.get_positions(
                 entry['x_or_RA'], entry['y_or_Dec'], pixelFlag, 4096)
 
-            # If the source is far from the FOV, skip it and move on to the next
-            if pixelx is None:
-                continue
-
             # Now generate a list of x,y position in each frame
             if pixvelflag is False:
                 # Calculate the RA,Dec in each frame

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1502,19 +1502,21 @@ class Catalog_seed():
 
         start_time = time.time()
         times = []
+        time_reported = False
         # Loop over input lines in the source list
         for index, values in zip(indexes, lines):
             try:
                 # Warn user of how long this calcuation might take...
-                if index < 100:
+                if len(times) < 100:
                     elapsed_time = time.time() - start_time
                     times.append(elapsed_time)
                     start_time = time.time()
-                elif index == 100:
+                elif len(times) == 100 and time_reported is False:
                     avg_time = np.mean(times)
                     total_time = len(indexes) * avg_time
                     print(("Expected time to process {} sources: {:.2f} seconds "
                            "({:.2f} minutes)".format(len(indexes), total_time, total_time/60)))
+                    time_reported = True
 
                 pixelx, pixely, ra, dec, ra_str, dec_str = self.get_positions(values['x_or_RA'],
                                                                               values['y_or_Dec'],

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1036,18 +1036,12 @@ class Catalog_seed():
                 ra_string, dec_string = self.makePos(entry0, entry1)
                 ra_number = entry0
                 dec_number = entry1
-            # near_fov = self.ignore_outside_fov_source(entry0, entry1, pixel_flag, max_source_distance)
         except:
             # if inputs can't be converted to floats, then
             # assume we have RA/Dec strings. Convert to floats.
             ra_string = input_x
             dec_string = input_y
             ra_number, dec_number = utils.parse_RA_Dec(ra_string, dec_string)
-            # near_fov = self.ignore_outside_fov_source(ra_number, dec_number, pixel_flag, max_source_distance)
-
-        # If the source is far from the fov, return Nones
-        # if not near_fov:
-        #    return None, None, None, None, 'none', 'none'
 
         # Case where point source list entries are given with RA and Dec
         if not pixel_flag:
@@ -2519,46 +2513,6 @@ class Catalog_seed():
             print("The extended source image option is being turned off")
 
         return extSourceList, all_stamps
-
-    def ignore_outside_fov_source(self, catalog_x, catalog_y, pixel_flag, max_pixel_distance):
-        """Check to see if a source is far outside the field of view of the detector
-
-        Parameters
-        ----------
-
-
-        Returns
-        -------
-
-        inside : bool
-            True if the source is within (or close) to the field of view
-            False if the source is farther than max_pixel_distnace from the fov
-        """
-        if pixel_flag:
-            # If coordinates are in pixels, filtered sources must be within max_pixel_distance of
-            # the center of the detector
-            center_x = int(self.output_dims[1] // 2)
-            center_y = int(self.output_dims[0] // 2)
-            minx = center_x - max_pixel_distance
-            maxx = center_x + max_pixel_distance
-            miny = center_y - max_pixel_distance
-            maxy = center_y + max_pixel_distance
-            if ((catalog_x > minx) & (catalog_x < maxx) & (catalog_y > miny) & (catalog_y < maxy)):
-                inside = True
-            else:
-                inside = False
-        else:
-            # If coordinates are RA, Dec, filtered sources must be within delta_degress of the
-            # reference location. Note that this is usually the center of the detector, but not always.
-            delta_degrees = (max_pixel_distance * self.siaf.XSciScale) / 3600.
-            reference_location = SkyCoord(ra=self.ra * u.deg, dec=self.dec * u.deg)
-            catalog = SkyCoord(ra=catalog_x * u.deg, dec=catalog_y * u.deg)
-            good = np.where(reference_location.separation(catalog) < delta_degrees * u.deg)[0]
-            if reference_location.separation(catalog) < (delta_degrees * u.deg):
-                inside = True
-            else:
-                inside = False
-        return inside
 
     def makeExtendedSourceImage(self, extSources, extStamps):
         dims = np.array(self.nominal_dims)

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -186,7 +186,7 @@ def get_subarray_info(params, subarray_table):
                        "a 1-amp".format(subarray_table['AperName'].data[mtch][0])))
                 print("or a 4-amp readout. The difference is a factor of 4 in")
                 print(("readout time. You have requested {} amps."
-                        .format(params['Readout']['namp'])))
+                       .format(params['Readout']['namp'])))
             else:
                 raise ValueError(("WARNING: {} requires the number of amps to be 1 or 4. Please set "
                                   "'Readout':'namp' in the input yaml file to one of these values."
@@ -197,6 +197,57 @@ def get_subarray_info(params, subarray_table):
                           .format(params['Readout']['array_name'],
                                   params['Reffiles']['subarray_defs'])))
     return params
+
+
+def parse_RA_Dec(ra_string, dec_string):
+    """Convert input RA and Dec strings to floats
+
+    Parameters
+    ----------
+
+    ra_string : str
+        String containing RA information. Can be in the form 10:12:13.2
+        or 10h12m13.2s
+
+    dec_string : str
+        String containing Declination information. Can be in the form
+        10:12:2.4 or 10d12m2.4s
+
+    Returns
+    -------
+
+    ra_degrees : float
+        Right Ascention value in degrees
+
+    dec_degrees : float
+        Declination value in degrees
+    """
+    try:
+        ra_string = ra_string.lower()
+        ra_string = ra_string.replace("h", ":")
+        ra_string = ra_string.replace("m", ":")
+        ra_string = ra_string.replace("s", "")
+        ra_string = re.sub(r"\s+", "", ra_string)
+        dec_string = dec_string.lower()
+        dec_string = dec_string.replace("d", ":")
+        dec_string = dec_string.replace("m", ":")
+        dec_string = dec_string.replace("s", "")
+        dec_string = re.sub(r"\s+", "", dec_string)
+
+        values = ra_string.split(":")
+        ra_degrees = 15.*(int(values[0]) + int(values[1])/60. + float(values[2])/3600.)
+
+        values = dec_string.split(":")
+        if "-" in values[0]:
+            sign = -1
+            values[0] = values[0].replace("-", "")
+        else:
+            sign = +1
+
+        dec_degrees = sign*(int(values[0]) + int(values[1])/60. + float(values[2])/3600.)
+        return ra_degrees, dec_degrees
+    except:
+        raise ValueError("Error parsing RA, Dec strings: {} {}".format(ra_string, dec_string))
 
 
 def read_subarray_definition_file(filename):


### PR DESCRIPTION
This PR updates the code to place the `parse_ra_dec` function (previously `parseRADec`) into utils.py to make it easier to call from other places. Currently catalog_seed_image.py and obs_generator.py call it. 

As part of this, I had to rework a little the way that mirage filters out sources far from the detector's field of view. Previously the table from a source catalog was passed to a function which worked on the entire table at once. However, this only worked if input locations were in units of pixels or RA, Dec in decimal degrees. If the inputs were RA and Dec strings (e.g. 10:34:23.2), it wasn't working. These strings need to be converted to decimal degrees before the sources can be filtered. That conversion is done by `parse_ra_dec`. 

So I have updated the filtering and placed it after `parse_ra_dec` is called. The downside to this is that it now works on only one source at a time, because the conversion from string to decimal degrees happens one source at a time. 

Rough speed test results, using a catalog of 10,000 sources with RA, Dec in decimal degrees. The amount of time it took to work through the catalog:

Updated code: 58 seconds
Old code: <10 seconds

I'm going to rework some more, so that the processing time only increases for catalogs where RA and Dec are given as strings.