### PR TITLE
Use relic for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ mirage.egg-info
 docs/_build
 docs/_static
 docs/_templates
+
+# Versioning via Relic #
+########################
+RELIC-INFO
+mirage/version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,11 @@ include mirage/config/refpix.cfg
 include mirage/config/saturation.cfg
 include mirage/config/superbias.cfg
 include mirage/config/xtalk20150303g0.errorcut.txt
+include RELIC-INFO
+exclude mirage/version.py
+
+# Not recommended: Uncomment below to bundle RELIC during `sdist`
+#
+#recursive-include relic *
+#prune relic/.git
+#prune relic/tests

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python
 import os
+import pkgutil
 import subprocess
 import sys
 from setuptools import setup, find_packages, Extension, Command
 from setuptools.command.test import test as TestCommand
+
+
+if not pkgutil.find_loader('relic'):
+    relic_local = os.path.exists('relic')
+    relic_submodule = (relic_local and
+                       os.path.exists('.gitmodules') and
+                       not os.listdir('relic'))
+    try:
+        if relic_submodule:
+            subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+        elif not relic_local:
+            subprocess.check_call(['git', 'clone', 'https://github.com/spacetelescope/relic.git'])
+
+        sys.path.insert(1, 'relic')
+    except subprocess.CalledProcessError as e:
+        print(e)
+        exit(1)
+
+import relic.release
+
+version = relic.release.get_info()
+relic.release.write_template(version, 'mirage')
 
 
 # allows you to build sphinx docs from the package
@@ -74,7 +97,7 @@ except ImportError:
 
 setup(
     name='mirage',
-    version='2.1.1',
+    version=version.pep386,
     description='Create simulated JWST data',
     long_description=('A tool to create simulated NIRCam, NIRISS,'
                       'and FGS exposures'


### PR DESCRIPTION
This PR introduces changes to enable the use of the `spacetelescope` `relic` package to handle version control. 

All changes so far are boilerplate from the `relic` README:
https://github.com/spacetelescope/relic

After making these changes, I ran `python setup.py develop` and it looks like the `relic`'s versioning is working, although it has reset back to version 0.0.0. This seems ok to me, since we have been fairly lax about keeping the version number up to date manually thus far.
`Finished processing dependencies for mirage==0.0.0.dev325+g3345b35e`
