### PR TITLE
Add relic to environment files

### DIFF
--- a/mirage_environment_linux.yml
+++ b/mirage_environment_linux.yml
@@ -207,5 +207,6 @@ dependencies:
     - openpyxl==2.5.8
     - poppy==0.7.0
     - pysiaf==0.2.2
+    - relic==1.1.2
     - webbpsf==0.7.0
 

--- a/mirage_environment_osx.yml
+++ b/mirage_environment_osx.yml
@@ -5,18 +5,18 @@ channels:
   - http://ssb.stsci.edu/astroconda
   - defaults
 dependencies:
-  - alabaster=0.7.11=py_3
+  - alabaster=0.7.12=py_0
   - astroquery=0.3.8=py36_0
   - babel=2.6.0=py_1
   - bleach=2.1.4=py_1
   - ca-certificates=2018.8.24=ha4d7672_0
   - certifi=2018.8.24=py36_1001
-  - docutils=0.14=py36_1
-  - entrypoints=0.2.3=py36_2
+  - docutils=0.14=py36_1001
+  - entrypoints=0.2.3=py36_1002
   - healpy=1.11.0=py36_1
   - html5lib=1.0.1=py_0
   - imagesize=1.1.0=py_0
-  - ipykernel=5.0.0=py_0
+  - ipykernel=5.0.0=pyh24bf2e0_1
   - ipywidgets=7.4.2=py_0
   - jupyter=1.0.0=py_1
   - jupyter_client=5.2.3=py_1
@@ -30,7 +30,7 @@ dependencies:
   - nbsphinx=0.3.5=py_0
   - notebook=5.7.0=py36_0
   - openssl=1.0.2p=h470a237_0
-  - pandoc=2.3=0
+  - pandoc=2.3.1=0
   - pandocfilters=1.4.2=py_1
   - prometheus_client=0.3.1=py_1
   - pyqt=5.6.0=py36h8210e8a_7
@@ -60,7 +60,7 @@ dependencies:
   - cffi=1.11.5=py36h6174b99_1
   - chardet=3.0.4=py36_1
   - click=6.7=py36hec950be_0
-  - cloudpickle=0.5.5=py36_0
+  - cloudpickle=0.5.6=py36_0
   - cryptography=2.3.1=py36hdbc3d79_0
   - cycler=0.10.0=py36hfc81398_0
   - cython=0.28.5=py36h0a44026_0
@@ -118,17 +118,17 @@ dependencies:
   - partd=0.3.8=py36hf5c4cb8_0
   - pexpect=4.6.0=py36_0
   - pickleshare=0.7.4=py36hf512f8e_0
-  - pillow=5.2.0=py36hb68e598_0
+  - pillow=5.3.0=py36hb68e598_0
   - pip=10.0.1=py36_0
   - pluggy=0.7.1=py36h28b3542_0
   - prompt_toolkit=1.0.15=py36haeda067_0
   - psutil=5.4.7=py36h1de35cc_0
   - ptyprocess=0.6.0=py36_0
   - py=1.6.0=py36_0
-  - pycparser=2.18=py36_1
+  - pycparser=2.19=py36_0
   - pygments=2.2.0=py36h240cd3f_0
   - pyopenssl=18.0.0=py36_0
-  - pyparsing=2.2.0=py36_1
+  - pyparsing=2.2.1=py36_0
   - pysocks=1.6.8=py36_0
   - pytest=3.8.1=py36_0
   - pytest-arraydiff=0.2=py36h39e3cac_0
@@ -155,7 +155,7 @@ dependencies:
   - tblib=1.3.2=py36hda67792_0
   - tk=8.6.8=ha441bb4_0
   - toolz=0.9.0=py36_0
-  - tornado=5.1=py36h1de35cc_0
+  - tornado=5.1.1=py36h1de35cc_0
   - traitlets=4.3.2=py36h65bd3ce_0
   - urllib3=1.23=py36_0
   - wcwidth=0.1.7=py36h8c6ec74_0
@@ -167,22 +167,22 @@ dependencies:
   - pysynphot=0.9.12=py36_0
   - webbpsf-data=0.7.0=0
   - asdf=2.1.0.dev1+ga161518=py36_2
-  - astropy=4.0.0.dev10786+gd099cfe=py36_0
+  - astropy=4.0.0.dev10818+gedd8090=py36_0
   - cfitsio=3.440=5
-  - crds=7.2.6.dev105+ga1c1767=py36_4
+  - crds=7.2.6.dev143+g1c80b2c=py36_4
   - drizzle=1.10.dev2+gbec16a2=py36_2
   - fitsverify=4.18=6
   - freetds=1.00.9=0
-  - gwcs=0.10a.dev21+g75e92da=py36_2
-  - jplephem=2.8.dev0+g9926bb5=py36_2
-  - jwst=0.12.0a.dev115+g9d5eb8c=py36_4
+  - gwcs=0.10a.dev25+g75a2435=py36_2
+  - jplephem=2.8.dev1+gc1b4c18=py36_2
+  - jwst=0.12.0a.dev134+g9fd3662=py36_4
   - namedlist=1.7=py36_1
   - parsley=1.3=py36_1
-  - photutils=0.5.dev35+g639bd20=py36_0
+  - photutils=0.5.dev43+g1a55172=py36_0
   - pymssql=2.1.3=py36_1
   - spherical-geometry=1.2.1.dev11+g5b65401=py36_1
   - stsci.image=2.3.0.dev0+g720cb3a=py36_2
-  - stsci.imagestats=1.5.1.dev1+g8f96637=py36_0
+  - stsci.imagestats=1.5.3.dev0+g9f0dbc0=py36_0
   - stsci.stimage=0.2.2.dev0+g7049ddc=py36_0
   - stsci.tools=3.4.13.dev0+g5f25467=py36_0
   - unixodbc=2.3.4=0
@@ -196,5 +196,5 @@ dependencies:
     - openpyxl==2.5.8
     - poppy==0.7.0
     - pysiaf==0.2.2
+    - relic==1.1.2
     - webbpsf==0.7.0
-


### PR DESCRIPTION
This PR adds the `relic` package to the `mirage` environment files. I created a new environment from scratch for the OSX version. With only minor version updates for a handful of packages, I decided to leave the linux version as-is, and just add `relic` rather than starting from scratch.