### PR TITLE
WIP: Add background as user input in yaml_generator. Default to 'low'

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2959,14 +2959,6 @@ class Catalog_seed():
             else:
                 raise ValueError("WARNING: grism_source_image needs to be True or False")
 
-        # Location of extended image on output array, pixel x, y values.
-        try:
-            self.params['simSignals']['extendedCenter'] = np.fromstring(self.params['simSignals']['extendedCenter'], dtype=int, sep=", ")
-        except:
-            raise RuntimeError(("WARNING: not able to parse the extendedCenter list {}. "
-                                "It should be a comma-separated list of x and y pixel positions."
-                                .format(self.params['simSignals']['extendedCenter'])))
-
         # check the output metadata, including visit and observation numbers, obs_id, etc
         #
         # kwchecks = ['program_number', 'visit_number', 'visit_group',

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -120,9 +120,10 @@ class SimInput:
         self.filter_throughput = 'config'
         self.observation_table = None
         self.use_JWST_pipeline = True
-        self.use_linearized_darks = False
+        self.use_linearized_darks = True
         self.simdata_output_dir = './'
         self.psfwfe = 'predicted'
+        self.background_rate = 'low'
         self.psfwfegroup = 0
         self.resets_bet_ints = 1  # NIRCam should be 1
         self.tracking = 'sidereal'
@@ -323,7 +324,7 @@ class SimInput:
         self.info['use_JWST_pipeline'] = [self.use_JWST_pipeline] * len(darks)
 
         # add background rate to the table
-        # self.info['bkgdrate'] = np.array([self.bkgdrate]*len(self.info['Mode']))
+        self.info['bkgdrate'] = np.array([self.background_rate]*len(self.info['Mode']))
 
         # grism entries
         grism_source_image = ['False'] * len(self.info['Mode'])
@@ -1134,19 +1135,18 @@ class SimInput:
                 MovingTargetExtended = input['{}_movext'.format(catkey)]
                 MovingTargetConvolveExtended = input['{}_movconv'.format(catkey)]
                 MovingTargetToTrack = input['{}_solarsys'.format(catkey)]
-                BackgroundRate = input['{}_bkgd'.format(catkey)]
+                #BackgroundRate = input['{}_bkgd'.format(catkey)]
             elif instrument.lower() == 'niriss':
                 PointSourceCatalog = input['PointSourceCatalog']
                 GalaxyCatalog = input['GalaxyCatalog']
                 ExtendedCatalog = input['ExtendedCatalog']
                 ExtendedScale = input['ExtendedScale']
-                ExtendedCenter = input['ExtendedCenter']
                 MovingTargetList = input['MovingTargetList']
                 MovingTargetSersic = input['MovingTargetSersic']
                 MovingTargetExtended = input['MovingTargetExtended']
                 MovingTargetConvolveExtended = input['MovingTargetConvolveExtended']
                 MovingTargetToTrack = input['MovingTargetToTrack']
-                BackgroundRate = input['BackgroundRate']
+                #BackgroundRate = input['BackgroundRate']
 
             f.write(('  pointsource: {}   #File containing a list of point sources to add (x, y locations and magnitudes)\n'
                      .format(PointSourceCatalog)))
@@ -1160,8 +1160,6 @@ class SimInput:
                      'to simulate\n'.format(GalaxyCatalog)))
             f.write('  extended: {}          #Extended emission count rate image file name\n'.format(ExtendedCatalog))
             f.write('  extendedscale: {}                          #Scaling factor for extended emission image\n'.format(ExtendedScale))
-            f.write(('  extendedCenter: {}                   #x, y pixel location at which to place the extended image '
-                     'if it is smaller than the output array size\n'.format(ExtendedCenter)))
             f.write(('  PSFConvolveExtended: True #Convolve the extended image with the PSF before adding to the output '
                      'image (True or False)\n'))
             f.write(('  movingTargetList: {}          #Name of file containing a list of point source moving targets (e.g. '
@@ -1180,7 +1178,7 @@ class SimInput:
             f.write('  scattered:  None                          #Scattered light count rate image file\n')
             f.write('  scatteredscale: 1.0                        #Scattered light scaling factor\n')
             f.write(('  bkgdrate: {}                         #Constant background count rate (ADU/sec/pixel) or '
-                     '"high","medium","low" similar to what is used in the ETC\n'.format(BackgroundRate)))
+                     '"high","medium","low" similar to what is used in the ETC\n'.format(input['bkgdrate'])))
             f.write(('  poissonseed: {}                  #Random number generator seed for Poisson simulation)\n'
                      .format(np.random.randint(1, 2**32-2))))
             f.write('  photonyield: True                         #Apply photon yield in simulation\n')


### PR DESCRIPTION
This PR makes some small changes to `yaml_generator.py`. The background rate is added as a user input, and defaults to 'low' if the input is not provided. Previously this information was gathered from the observation list file. 

Now that I think about it though, what about the case of an observation with multiple epochs where the background may be different between the epochs? That situation would be better addressed using the observation list file. Perhaps we should go back to getting this info from the observation list file, and default to 'low' if it is not in there? 

I have also removed references to the `ExtendedCenter` parameter. This parameter is not used in the seed image generation. The location on the detector to place extended targets is collected from the extended target catalog.