### PR TITLE
WIP: Add several intermediate outputs as attributes to imaging_simulator.py

### DIFF
--- a/mirage/imaging_simulator.py
+++ b/mirage/imaging_simulator.py
@@ -36,8 +36,6 @@ from .utils import read_fits
 
 class ImgSim():
     def __init__(self):
-        # Set the MIRAGE_DATA environment variable if it is not
-        # set already. This is for users at STScI.
         self.env_var = 'MIRAGE_DATA'
         datadir = os.environ.get(self.env_var)
         if datadir is None:
@@ -76,6 +74,12 @@ class ImgSim():
         obs.seedheader = cat.seedinfo
         obs.paramfile = self.paramfile
         obs.create()
+
+        # Make useful information class attributes
+        self.seedimage = cat.seedimage
+        self.seed_segmap = cat.seed_segmap
+        self.seedinfo = cat.seedinfo
+        self.linDark = obs.linDark
 
     def read_dark_product(self, file):
         # Read in dark product that was produced


### PR DESCRIPTION
This PR adds some intermediate outputs from `imaging_simulator.py` as class attributes, so that the user has access to them after the code has been run. 

Currently this includes the seed image, the seed segmentation map, a dictionary of information about the seed image, and the linearized dark.

We should make similar additions to wfss_simulator.py