### PR TITLE
Catalogs with mulitple filters

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1906,7 +1906,7 @@ class Catalog_seed():
             The name of the catalog column to use for source magnitudes
         """
         # Determine the filter name to look for
-        if self.params['Inst']['instrument'].lower() in [nircam, niriss]:
+        if self.params['Inst']['instrument'].lower() in ['nircam', 'niriss']:
             if self.params['Readout']['pupil'][0].upper() == 'F':
                 usefilt = 'pupil'
             else:


### PR DESCRIPTION
These changes allow source catalogs to contain magnitude columns for multiple instruments/filters. The motivation behind this is to allow for fewer catalog files that users need to keep track of and place into the observation list file.

Mirage will read in the catalog and search for the appropriate column to use for a given simulation. It will first look for a column with the name <instrument>_<filter>_magnitude (e.g. "niriss_f090w_magnitude"). If that column is present, it will be used. If it is not present, Mirage will search for a generic 'magnitude' column (i.e. what is expected currently in Mirage catalogs). If neither column name is present, an error is raised.

Note that for FGS, the first column name that is searched for is 'fgs_magnitude' since FGS has no filters.