### PR TITLE
WIP: Add nbsphinx to the pip dependencies in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc yaml'
+        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc'
+        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc yaml'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc'
+        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc IPython'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc IPython'
+        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc IPython yaml'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
@@ -63,6 +63,7 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - git clone https://github.com/npirzkal/NIRCAM_Gsim.git
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,29 +36,29 @@ env:
         - SETUP_CMD='install'
         - SETUP_CMD='test'
 
-#matrix:
-#
-#    # Don't wait for allowed failures
-#    fast_finish: true
-#
-#    include:
-#        # build sphinx documentation with warnings
-#        - os: linux
-#          env: SETUP_CMD='build_sphinx'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-#               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
-#
-#        # PEP8 check with flake8 (only once, i.e. "os: linux")
-#        - os: linux
-#          env: MAIN_CMD='flake8 --count'
-#               SETUP_CMD='mirage'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-#
-#    allow_failures:
-#        # PEP8 will fail for numerous reasons. Ignore it.
-#        - env: MAIN_CMD='flake8 --count'
-#               SETUP_CMD='mirage'
-#               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+matrix:
+
+    # Don't wait for allowed failures
+    fast_finish: true
+
+    include:
+        # build sphinx documentation with warnings
+        - os: linux
+          env: SETUP_CMD='build_sphinx'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi nbsphinx'
+
+        # PEP8 check with flake8 (only once, i.e. "os: linux")
+        - os: linux
+          env: MAIN_CMD='flake8 --count'
+               SETUP_CMD='mirage'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+
+    allow_failures:
+        # PEP8 will fail for numerous reasons. Ignore it.
+        - env: MAIN_CMD='flake8 --count'
+               SETUP_CMD='mirage'
+               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ env:
         - SETUP_CMD='test'
 
 matrix:
-
     # Don't wait for allowed failures
     fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx'
+        - CONDA_DEPENDENCIES='pytest=3.6 sphinx pandoc'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.imgmath',
     'nbsphinx',
+    'IPython.sphinxext.ipython_console_highlighting'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -66,7 +67,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,18 @@ except ImportError:
         print(e)
         exit(1)
 
+# make sure NIRCAM_Gsim is available
+try:
+    import NIRCAM_Gsim
+except ImportError:
+    try:
+        subprocess.check_call(['git', 'clone',
+                               'https://github.com/npirzkal/NIRCAM_Gsim.git'])
+        sys.path.insert(1, 'NIRCAM_Gsim')
+        # import jwst
+    except subprocess.CalledProcessError as e:
+        print(e)
+        exit(1)
 
 setup(
     name='mirage',
@@ -133,7 +145,8 @@ setup(
         'asdf>=1.2.0',
         'scipy>=0.17',
         'photutils>=0.4.0',
-        'pysiaf>=0.1.11'
+        'pysiaf>=0.1.11',
+        'yaml'
     ],
     include_package_data=True,
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,7 @@ setup(
         'scipy>=0.17',
         'photutils>=0.4.0',
         'pysiaf>=0.1.11',
-        'yaml'
+        'pyyaml'
     ],
     include_package_data=True,
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ import relic.release
 version = relic.release.get_info()
 relic.release.write_template(version, 'mirage')
 
-
 # allows you to build sphinx docs from the package
 # main directory with "python setup.py build_sphinx"
 


### PR DESCRIPTION
While working in a different repo last week, I came across some strange behavior in Travis. A test that it listed as passing was in fact failing because the `nbsphinx` package was not found. I copied the travis file for that repo from Mirage, and a check here has revealed that mirage is having the same issue.

I have added `nbspinx` to the list of pip dependencies in the .travis.yml file. For the other repo, this revealed that `pandoc` was also missing. Once Travis runs on this PR, I'll check and see if that is also the case here.