### PR TITLE
Catalog index column name and flags. 

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2424,12 +2424,12 @@ class Observation():
             outModel.zeroframe = np.zeros((numint, ys, xs))
 
         # EXPTYPE OPTIONS
-        # exptypes = ['NRC_IMAGE', 'NRC_GRISM', 'NRC_TACQ', 'NRC_CORON',
+        # exptypes = ['NRC_IMAGE', 'NRC_WFSS', 'NRC_TACQ', 'NRC_CORON',
         #            'NRC_DARK', 'NRC_TSIMAGE', 'NRC_TSGRISM']
         # nrc_tacq and nrc_coron are not currently implemented.
 
         exptype = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
-                              "wfss": "NRC_GRISM", "ts_wfss": "NRC_TSGRISM"},
+                              "wfss": "NRC_WFSS", "ts_wfss": "NRC_TSGRISM"},
                    "niriss": {"imaging": "NIS_IMAGE"},
                    "fgs": {"imaging": "FGS_IMAGE"}}
 
@@ -2702,7 +2702,7 @@ class Observation():
             groupextnum = 3
 
         exptype = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
-                              "wfss": "NRC_GRISM", "ts_wfss": "NRC_TSGRISM"},
+                              "wfss": "NRC_WFSS", "ts_wfss": "NRC_TSGRISM"},
                    "niriss": {"imaging": "NIS_IMAGE"},
                    "fgs": {"imaging": "FGS_IMAGE"}}
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -801,22 +801,7 @@ class Catalog_seed():
 
         # If the input catalog has an index column
         # use that, otherwise add one
-        #if 'index' in mtlist.colnames:
-        #    indexes = mtlist['index']
-        #else:
-        #    indexes = np.arange(1, len(mtlist['x_or_RA']) + 1)
-        ## Make sure there is no 0th object
-        #if np.min(indexes) == 0:
-        #    indexes += 1
-        ## Make sure the index numbers don't overlap with any
-        ## sources already present. Increment the maxindex
-        ## value.
-        #if np.min(indexes) <= self.maxindex:
-        #    indexes += self.maxindex
-        #self.maxindex = np.max(indexes)
-
         indexes = self.get_index_numbers(mtlist)
-
 
         if MT_tracking is True:
             # Here, we are tracking a non-sidereal target.
@@ -1517,22 +1502,6 @@ class Catalog_seed():
 
         # If the input catalog has an index column
         # use that, otherwise add one
-        #if 'index' in lines.colnames:
-        #    print('Using point source catalog index numbers')
-        #    indexes = lines['index']
-        #else:
-        #    print('No point source catalog index numbers. Adding to output: {}.'.format(psfile))
-        #    indexes = np.arange(1, len(lines['x_or_RA']) + 1)
-        # Make sure there is no 0th object
-        #if np.min(indexes) == 0:
-        #    indexes += 1
-        # Make sure the index numbers don't overlap with any
-        # sources already present. Increment the maxindex
-        # value.
-        #if np.min(indexes) <= self.maxindex:
-        #    indexes += self.maxindex
-        #self.maxindex = np.max(indexes)
-
         indexes = self.get_index_numbers(lines)
 
         dtor = math.radians(1.)
@@ -1541,10 +1510,10 @@ class Catalog_seed():
         xc = (self.subarray_bounds[2] + self.subarray_bounds[0]) / 2.
         yc = (self.subarray_bounds[3] + self.subarray_bounds[1]) / 2.
 
-        #Define the min and max source locations (in pixels) that fall onto the subarray
-        #Include the effects of a requested grism_direct image, and also keep sources that
-        #will only partially fall on the subarray
-        #pixel coords here can still be negative and kept if the grism image is being made
+        # Define the min and max source locations (in pixels) that fall onto the subarray
+        # Include the effects of a requested grism_direct image, and also keep sources that
+        # will only partially fall on the subarray
+        # pixel coords here can still be negative and kept if the grism image is being made
 
         # First, coord limits for just the subarray
         miny = 0
@@ -2180,20 +2149,6 @@ class Catalog_seed():
 
         # If an index column is present use that, otherwise
         # create one
-        #if 'index' in galaxylist.colnames:
-        #    indexes = galaxylist['index']
-        #else:
-        #    indexes = np.arange(1, len(galaxylist['radius']) + 1)
-        # Make sure there is no 0th object
-        #if np.min(indexes) == 0:
-        #    indexes += 1
-        # Increment the index numbers so that these
-        # sources don't overlap with any others already
-        # in place
-        #if np.min(indexes) <= self.maxindex:
-        #    indexes += self.maxindex
-        #self.maxindex = np.max(indexes)
-
         indexes = self.get_index_numbers(galaxylist)
 
         # Check the source list and remove any sources that are well outside the
@@ -2515,22 +2470,6 @@ class Catalog_seed():
                       "DEC_degrees     pixel_x   pixel_y    magnitude   counts/sec    counts/frame\n"))
 
         # Add an index column if not present
-        #if 'index' in lines.colnames:
-        #    indexes = lines['index']
-        #else:
-        #    print('No extended object catalog index numbers. Adding to output: {}.'.format(eoutcat))
-        #    indexes = np.arange(1, len(lines['filename']) + 1)
-        #    lines['index'] = indexes
-
-        # Make sure there is no 0th source
-        #if np.min(indexes) == 0:
-        #    indexes += 1
-        # Make sure the index numbers don't overlap with
-        # sources that are already added
-        #if np.min(indexes) <= self.maxindex:
-        #    indexes += self.maxindex
-        #self.maxindex = np.max(indexes)
-
         indexes = self.get_index_numbers(lines)
 
         # Check the source list and remove any sources that are well outside the


### PR DESCRIPTION
This is a very small update to `catalog_seed_image.py`. Testing WFSS simulations have revealed that I had a typo in the column name for the index in the galaxies catalog (it was `indexes` rather than `index`). I fixed that, and moved the index checking/generating into a separate function so it's easier to maintain across all catalogs. I also made some PEP-8 changes in the same area. 

I also found that the flag used to denote source positions in pixels rather than RA/Dec was inconsistent between several of the catalogs. It was 'position_pixels' or 'position_pixel'. I've updated the code so that all catalogs use the former.