### PR TITLE
Fixing PSF locations in header, default PSF center, and PEP8 cleanup

### DIFF
--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -6,6 +6,7 @@ from astropy.io import fits
 import numpy as np
 import webbpsf
 
+
 class CreatePSFLibrary:
 
     # Class variables for NIRCam short vs long wave information:
@@ -25,9 +26,10 @@ class CreatePSFLibrary:
         Description
         -----------
         Class to create a PSF library in the following format:
-            For a given instrument, 1 file per filter in the form [SCA, j, i, y, x] where
-            (j,i) is the PSF position on the detector grid (integer positions) and (y,x)
-            is the 2D PSF. This class must be run separately for each instrument.
+            For a given instrument, the output file (1 per filter) will contain a 5D array
+            with axes [SCA, j, i, y, x] where SCA is the detector, (j,i) is the PSF position
+            on the detector grid (integer positions) and (y,x) is the 2D PSF. This class must
+            be run separately for each instrument.
 
         Parameters
         ----------
@@ -128,10 +130,11 @@ class CreatePSFLibrary:
         """
 
         # Pull correct capitalization of instrument name
-        webbpsf_name_dict = {"NIRCAM": "NIRCam", "NIRSPEC": "NIRSpec", "NIRISS": "NIRISS", "MIRI": "MIRI", "FGS": "FGS"}
+        webbpsf_name_dict = {"NIRCAM": "NIRCam", "NIRSPEC": "NIRSpec",
+                             "NIRISS": "NIRISS", "MIRI": "MIRI", "FGS": "FGS"}
         self.instr = webbpsf_name_dict[instrument.upper()]
 
-        # Create instance of instrument in WebbPSF (same as webbpsf.instr)
+        # Create instance of instrument in WebbPSF
         self.webb = getattr(webbpsf, self.instr)()
 
         # Set the filters and detectors based on the inputs
@@ -145,7 +148,7 @@ class CreatePSFLibrary:
         # Set the locations on the detector of the fiducial PSFs
         self.ij_list, self.loc_list, self.location_list = self._set_psf_locations(num_psfs, psf_location)
 
-        # For NIRCam: Check if filters/detectors match in terms of if they are longwave/shortwave
+        # For NIRCam: Check if filters/detectors match in terms of if they are long/shortwave
         if self.instr == "NIRCam":
             for filt, det_list in zip(self.filter_list, self.detector_list):
                 for det in det_list:
@@ -201,7 +204,7 @@ class CreatePSFLibrary:
         else:
             raise TypeError("Method of setting detectors is not valid - see docstring for options")
 
-        # If the user hand chose a detector list, check it's a valid list for the chosen instrument
+        # If the user hand chose a detector list, check it's valid for the chosen instrument
         if self.detector_input not in ["all", "shortwave", "longwave"]:
             det = set(detector_list).difference(set(self.webb.detector_list))
             if det != set():
@@ -226,7 +229,7 @@ class CreatePSFLibrary:
         else:
             raise TypeError("Method of setting filters is not valid - see docstring for options")
 
-        # If the user hand chose a filter list, check it's a valid list for the chosen instrument
+        # If the user hand chose a filter list, check it's valid for the chosen instrument
         if self.filter_input not in ["all", "shortwave", "longwave"]:
             filt = set(filter_list).difference(set(self.webb.filter_list))
             if filt != set():
@@ -262,15 +265,16 @@ class CreatePSFLibrary:
         """
         This method is called in the create_files() method
 
-        For a given instrument, 1 file per filter in the form [SCA, j, i, y, x] where
-        (j,i) is the PSF position on the detector grid (integer positions) and (y,x)
-        is the 2D PSF.
+        For a given instrument, the output file (1 per filter) will contain a 5D array
+        with axes [SCA, j, i, y, x] where SCA is the detector, (j,i) is the PSF position
+        on the detector grid (integer positions) and (y,x) is the 2D PSF.
 
         Returns
         -------
         This saves out the library files if requested and then returns a list of all the
-        hdulist objects created (each in the form of [SCA, j, i, y, x], 1 per filter
+        hdulist objects created (each with a 5D array of [SCA, j, i, y, x], 1 per filter
         requested).
+
         """
 
         # Set extension to read based on distortion choice

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -250,12 +250,12 @@ class CreatePSFLibrary:
         # Set the center values
         if num_psfs == 1:
             ij_list = [(0, 0)]
-            loc_list = [psf_location[::-1]]  # list of x,y location
-            location_list = [(psf_location[::-1])]  # tuple of (x,y)
+            loc_list = list(psf_location[::-1])  # list of x,y location
+            location_list = [psf_location[::-1]]  # tuple of (x,y)
         else:
             ij_list = list(itertools.product(range(self.length), range(self.length)))
             loc_list = [int(round(num * 2047)) for num in np.linspace(0, 1, self.length, endpoint=True)]
-            location_list = list(itertools.product(loc_list, loc_list))  # list of tuples (x,y) (for webbpsf)
+            location_list = list(itertools.product(loc_list, loc_list))  # list of tuples (x,y) (for WebbPSF)
 
         return ij_list, loc_list, location_list
 

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -199,7 +199,7 @@ class CreatePSFLibrary:
         elif type(self.detector_input) is list:
             detector_list = self.detector_input
         else:
-            raise TypeError("Method of setting detectors is not valid - see docstring for options")
+            raise TypeError("Method of setting detectors is not valid.")
 
         # If the user hand chose a detector list, check it's valid for the chosen instrument
         if self.detector_input not in ["all", "shortwave", "longwave"]:
@@ -225,7 +225,7 @@ class CreatePSFLibrary:
         elif type(self.filter_input) is list:
             filter_list = self.filter_input
         else:
-            raise TypeError("Method of setting filters is not valid - see docstring for options")
+            raise TypeError("Method of setting filters is not valid.")
 
         # If the user hand chose a filter list, check it's valid for the chosen instrument
         if self.filter_input not in ["all", "shortwave", "longwave"]:
@@ -384,11 +384,13 @@ class CreatePSFLibrary:
             header["DATAVERS"] = (psf[ext].header["DATAVERS"], "WebbPSF reference data files version ")
 
             # Add descriptor for how the file was made
-            header["COMMENT"] = "For a given instrument, 1 file per filter in the form [SCA, j, i, y, x]"
-            header["COMMENT"] = "where (j,i) is the PSF position on the detector grid (integer "
-            header["COMMENT"] = "positions) and (y,x) is the 2D PSF. The order of the detectors can be "
-            header["COMMENT"] = "found under the  header DETNAME* keywords and the order of the fiducial "
-            header["COMMENT"] = "PSFs ((j,i) and (y,x)) under the header DET_JI*/DET_YX* keywords"
+            # the output file (1 per filter) will contain a 5D array with axes[SCA, j, i, y, x]
+            header["COMMENT"] = "For a given instrument, the output file (1 per filter) will contain "
+            header["COMMENT"] = "a 5D array with axes[SCA, j, i, y, x] where (j,i) is the PSF position "
+            header["COMMENT"] = "on the detector grid (integer positions) and (y,x) is the 2D PSF. The "
+            header["COMMENT"] = "order of the detectors can be found under the  header DETNAME* "
+            header["COMMENT"] = "keywords and the order of the fiducial PSFs ((j,i) and (y,x)) under "
+            header["COMMENT"] = "the header DET_JI*/DET_YX* keywords"
 
             # Add header labels
             header.insert("INSTRUME", ('', ''))

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -93,7 +93,7 @@ class CreatePSFLibrary:
 
         filename : str
             The name to save your current file under if "save" keyword is set to True.
-            Default of None will save it in the form: "{intr}_{filt}_fovp{}_samp{}_npsf{}.fits"
+            Default of None will save it in the form: "{instr}_{filt}_fovp{}_samp{}_npsf{}.fits"
 
         overwrite : bool
             True/False boolean to overwrite the output file if it already exists. Default

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -339,8 +339,15 @@ class CreatePSFLibrary:
             header["NWAVES"] = (psf[ext].header["NWAVES"], "Number of wavelengths used in calculation")
 
             for k, ij in enumerate(self.ij_list):  # these were originally written out in (i,j) and (x,y)
+
+                # Even arrays are shifted by 0.5 so they are centered correctly during calc_psf computation
+                # But this needs to be expressed correctly in the header
+                loc = np.asarray(self.location_list[k], dtype=float)
+                if self.fov_pixels % 2 == 0:
+                    loc += 0.5
+
                 header["DET_JI{}".format(k)] = (str(ij[::-1]), "The #{} PSF's (j,i) detector position".format(k))
-                header["DET_YX{}".format(k)] = (str((self.location_list[k][1], self.location_list[k][0])),
+                header["DET_YX{}".format(k)] = (str(tuple(loc[::-1])),
                                                 "The #{} PSF's (y,x) detector pixel position".format(k))
 
             header["NUM_PSFS"] = (self.num_psfs, "The total number of fiducial PSFs")

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -416,12 +416,13 @@ class CreatePSFLibrary:
                     name = "{}_{}_fovp{}_samp{}_npsf{}.fits".format(self.instr.lower(), filt.lower(),
                                                                     self.fov_pixels, self.oversample,
                                                                     self.num_psfs)
+                    filepath = os.path.join(self.fileloc, name)
                 else:
-                    self.filepath = os.path.join(self.fileloc, self.filename)
+                    filepath = os.path.join(self.fileloc, self.filename)
 
-                print("  Saving file: {}".format(self.filepath))
+                print("  Saving file: {}".format(filepath))
 
-                hdu.writeto(self.filepath, overwrite=self.overwrite)
+                hdu.writeto(filepath, overwrite=self.overwrite)
 
             # Create something to return
             final_list.append(hdu)

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -9,10 +9,10 @@ import webbpsf
 class CreatePSFLibrary:
 
     # Class variables for NIRCam short vs long wave information:
-    nrca_short_filters = ['F070W', 'F090W', 'F115W', 'F140M', 'F150W2', 'F150W', 'F162M', 'F164N', 'F182M', 'F187N',
-                          'F200W', 'F210M', 'F212N']
-    nrca_long_filters = ['F250M', 'F277W', 'F300M', 'F322W2', 'F323N', 'F335M', 'F356W', 'F360M', 'F405N', 'F410M',
-                         'F430M', 'F444W', 'F460M', 'F466N', 'F470N', 'F480M']
+    nrca_short_filters = ['F070W', 'F090W', 'F115W', 'F140M', 'F150W2', 'F150W', 'F162M',
+                          'F164N', 'F182M', 'F187N', 'F200W', 'F210M', 'F212N']
+    nrca_long_filters = ['F250M', 'F277W', 'F300M', 'F322W2', 'F323N', 'F335M', 'F356W', 'F360M',
+                         'F405N', 'F410M', 'F430M', 'F444W', 'F460M', 'F466N', 'F470N', 'F480M']
 
     nrca_short_detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']
     nrca_long_detectors = ['NRCA5', 'NRCB5']

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -18,7 +18,7 @@ class CreatePSFLibrary:
     nrca_short_detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4']
     nrca_long_detectors = ['NRCA5', 'NRCB5']
 
-    def __init__(self, instrument, filters="all", detectors="all", num_psfs=16, psf_location=(1024, 1024),
+    def __init__(self, instrument, filters="all", detectors="all", num_psfs=16, psf_location=(1023, 1023),
                  add_distortion=True, fov_pixels=101, oversample=5, opd_type="requirements", opd_number=0,
                  save=True, fileloc=None, filename=None, overwrite=True,
                  **kwargs):
@@ -59,7 +59,7 @@ class CreatePSFLibrary:
 
         psf_location : tuple
             If num_psfs = 1, then this is used to set the (y,x) location of that PSF.
-            Default is (1024,1024).
+            Default is (1023,1023).
 
         add_distortion : bool
             If True, the PSF will have distortions applied: the geometric distortion from
@@ -247,7 +247,7 @@ class CreatePSFLibrary:
 
         # Set the center values
         if num_psfs == 1:
-            # (1023.5, 1023.5) is the center, but we want an integer location- so default is (1024,1024)
+            # (1023.5, 1023.5) is the center, but we want an integer location- so default is (1023,1023)
             ij_list = [(0, 0)]
             loc_list = list(psf_location[::-1])  # list of x,y location
             location_list = [psf_location[::-1]]  # tuple of (x,y)

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -252,8 +252,8 @@ class CreatePSFLibrary:
         if num_psfs == 1:
             # Want this case to be at the specified location
             ij_list = [(0, 0)]
-            loc_list = [psf_location[1], psf_location[0]]  # list of x,y location
-            location_list = [(psf_location[1], psf_location[0])]  # tuple of (x,y)
+            loc_list = [psf_location[::-1]]  # list of x,y location
+            location_list = [(psf_location[::-1])]  # tuple of (x,y)
         else:
             ij_list = list(itertools.product(range(self.length), range(self.length)))
             loc_list = [int(round(num * 2047)) for num in np.linspace(0, 1, self.length, endpoint=True)]
@@ -345,7 +345,7 @@ class CreatePSFLibrary:
             header["NWAVES"] = (psf[ext].header["NWAVES"], "Number of wavelengths used in calculation")
 
             for k, ij in enumerate(self.ij_list):  # these were originally written out in (i,j) and (x,y)
-                header["DET_JI{}".format(k)] = (str((ij[1], ij[0])), "The #{} PSF's (j,i) detector position".format(k))
+                header["DET_JI{}".format(k)] = (str(ij[::-1]), "The #{} PSF's (j,i) detector position".format(k))
                 header["DET_YX{}".format(k)] = (str((self.location_list[k][1], self.location_list[k][0])),
                                                 "The #{} PSF's (y,x) detector pixel position".format(k))
 

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -180,9 +180,8 @@ class CreatePSFLibrary:
                                    "falls within the detector band.")
 
     def _set_detectors(self, filter):
-        """Get the list of detectors to include in the PSF library files"""
+        """Set the list of detectors to include in the PSF library files"""
 
-        # Set detector list
         if self.detector_input == "all":
             if self.instr != "NIRCam":
                 detector_list = self.webb.detector_list
@@ -211,9 +210,8 @@ class CreatePSFLibrary:
         return detector_list
 
     def _set_filters(self):
-        """Get the list of filters to create PSF library files for"""
+        """Set the list of filters to create PSF library files for"""
 
-        # Set filter list
         if self.filter_input == "all":
             filter_list = self.webb.filter_list
         elif self.filter_input == "shortwave":
@@ -249,6 +247,7 @@ class CreatePSFLibrary:
 
         # Set the center values
         if num_psfs == 1:
+            # (1023.5, 1023.5) is the center, but we want an integer location- so default is (1024,1024)
             ij_list = [(0, 0)]
             loc_list = list(psf_location[::-1])  # list of x,y location
             location_list = [psf_location[::-1]]  # tuple of (x,y)
@@ -267,8 +266,8 @@ class CreatePSFLibrary:
 
         Returns
         -------
-        This saves out the library files (if requested) and then returns a list of all the
-        hdulist objects created (a 5D array of [SCA, j, i, y, x], 1 per filter requested).
+        Returns a list of all the hdulist objects created (a 5D array of [SCA, j, i, y, x],
+        1 per filter) and saves out the library files if requested.
 
         """
 
@@ -402,10 +401,8 @@ class CreatePSFLibrary:
             # Add header labels
             header.insert("INSTRUME", ('', ''))
             header.insert("INSTRUME", ('COMMENT', '/ PSF Library Information'))
-
             header.insert("NORMALIZ", ('', ''))
             header.insert("NORMALIZ", ('COMMENT', '/ WebbPSF Creation Information'))
-
             header.insert("DATAVERS", ('COMMENT', '/ File Description'), after=True)
             header.insert("DATAVERS", ('', ''), after=True)
 
@@ -415,13 +412,10 @@ class CreatePSFLibrary:
             # Write file out
             if self.save:
 
-                # Set file information
                 if self.fileloc is None:
                     self.fileloc = os.path.expandvars('$MIRAGE_DATA/{}/'
                                                       'test_webbpsf_library'.format(self.instr.lower()))
-
                 if self.filename is None:
-                    # E.g. filename: nircam_f090w_fovp1000_samp5_npsf16.fits
                     name = "{}_{}_fovp{}_samp{}_npsf{}.fits".format(self.instr.lower(), filt.lower(),
                                                                     self.fov_pixels, self.oversample,
                                                                     self.num_psfs)
@@ -433,7 +427,6 @@ class CreatePSFLibrary:
 
                 hdu.writeto(filepath, overwrite=self.overwrite)
 
-            # Create something to return
             final_list.append(hdu)
 
         return final_list

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -170,11 +170,14 @@ class CreatePSFLibrary:
         """Raise an error based on mis-matched short/long wave detectors/filters"""
 
         if "short filter" in msg_type.lower():
-            message = "You are trying to apply a shortwave filter ({}) to a longwave detector ({}). ".format(filt, det)
+            message = "You are trying to apply a shortwave filter ({}) to a " \
+                      "longwave detector ({}). ".format(filt, det)
         if "long filter" in msg_type.lower():
-            message = "You are trying to apply a longwave filter ({}) to a shortwave detector ({}). ".format(filt, det)
+            message = "You are trying to apply a longwave filter ({}) to a " \
+                      "shortwave detector ({}). ".format(filt, det)
 
-        raise ValueError(message + "Please change these entries so the filter falls within the detector band.")
+        raise ValueError(message + "Please change these entries so the filter "
+                                   "falls within the detector band.")
 
     def _set_detectors(self, filter):
         """Get the list of detectors to include in the PSF library files"""
@@ -202,7 +205,8 @@ class CreatePSFLibrary:
         if self.detector_input not in ["all", "shortwave", "longwave"]:
             det = set(detector_list).difference(set(self.webb.detector_list))
             if det != set():
-                raise ValueError("Instrument {} doesn't have the detector(s) {}.".format(self.instr, det))
+                raise ValueError("Instrument {} doesn't have the detector(s) "
+                                 "{}.".format(self.instr, det))
 
         return detector_list
 
@@ -227,7 +231,8 @@ class CreatePSFLibrary:
         if self.filter_input not in ["all", "shortwave", "longwave"]:
             filt = set(filter_list).difference(set(self.webb.filter_list))
             if filt != set():
-                raise ValueError("Instrument {} doesn't have the filter(s) {}.".format(self.instr, filt))
+                raise ValueError("Instrument {} doesn't have the filter(s) "
+                                 "{}.".format(self.instr, filt))
 
         return filter_list
 
@@ -307,7 +312,9 @@ class CreatePSFLibrary:
 
                     # Create PSF
                     psf = self.webb.calc_psf(add_distortion=self.add_distortion,
-                                             fov_pixels=self.fov_pixels, oversample=self.oversample, **self._kwargs)
+                                             fov_pixels=self.fov_pixels,
+                                             oversample=self.oversample,
+                                             **self._kwargs)
 
                     # Convolve PSF with a square kernel
                     psf_conv = astropy.convolution.convolve(psf[ext].data, kernel)
@@ -401,13 +408,14 @@ class CreatePSFLibrary:
 
                 # Set file information
                 if self.fileloc is None:
-                    self.fileloc = os.path.expandvars('$MIRAGE_DATA/{}/test_webbpsf_library'.format(self.instr.lower()))
+                    self.fileloc = os.path.expandvars('$MIRAGE_DATA/{}/'
+                                                      'test_webbpsf_library'.format(self.instr.lower()))
 
                 if self.filename is None:
                     # E.g. filename: nircam_f090w_fovp1000_samp5_npsf16.fits
-                    name = "{}_{}_fovp{}_samp{}_npsf{}.fits".format(self.instr.lower(), filt.lower(), self.fov_pixels,
-                                                                    self.oversample, self.num_psfs)
-                    self.filepath = os.path.join(self.fileloc, name)
+                    name = "{}_{}_fovp{}_samp{}_npsf{}.fits".format(self.instr.lower(), filt.lower(),
+                                                                    self.fov_pixels, self.oversample,
+                                                                    self.num_psfs)
                 else:
                     self.filepath = os.path.join(self.fileloc, self.filename)
 

--- a/mirage/psf/psf_library.py
+++ b/mirage/psf/psf_library.py
@@ -27,9 +27,80 @@ class CreatePSFLibrary:
         Class to create a PSF library in the following format:
             For a given instrument, 1 file per filter in the form [SCA, j, i, y, x] where
             (j,i) is the PSF position on the detector grid (integer positions) and (y,x)
-            is the 2D PSF.
+            is the 2D PSF. This class must be run separately for each instrument.
 
-        This class must be run separately for each instrument.
+        Parameters
+        ----------
+        instrument : str
+            The name of the instrument you want to run. Can be any capitalization. Can
+            only run 1 instrument at a time. Right now this class is only set up for NIRCam,
+            NIRISS, and FGS (they are 2048x2048)
+
+        filters : str or list
+            Which filter(s) you want to create a library for.
+
+            Can be a string of 1 filter name, a list of filter names (as strings), or
+            the default "all" will run through all the filters in the filter_list
+            attribute of webbpsf.INSTR(). Spelling/capitalization must match what
+            webbpsf expects. See also special case for NIRCam. Default is "all"
+
+        detectors : str or list
+            Which detector(s) you want to create a library for.
+
+            Can be a string of 1 detector name, a list of detector names (as strings), or
+            the default "all" will run through all the detectors in the detector_list
+            attribute of webbpsf.INSTR(). Spelling/capitalization must match what
+            webbpsf expects. See also special case for NIRCam. Default is "all"
+
+        num_psfs : int
+            The total number of fiducial PSFs to be created and saved in the files. This
+            number must be a square number. Default is 16.
+            E.g. num_psfs = 16 will have the class create a 4x4 grid of fiducial PSFs.
+
+        psf_location : tuple
+            If num_psfs = 1, then this is used to set the (y,x) location of that PSF.
+            Default is (1024,1024).
+
+        add_distortion : bool
+            If True, the PSF will have distortions applied: the geometric distortion from
+            the detectors (using data from SIAF) and the rotation of the detectors with
+            respect to the focal plane. Default is True.
+
+        fov_pixels : int
+            The field of view in undersampled detector pixels used by WebbPSF when
+            creating the PSFs. Default is 101 pixels.
+
+        oversample : int
+            The oversampling factor used by WebbPSF when creating the PSFs. Default is 5.
+
+        opd_type : str
+            The type of OPD map you would like to use to create the PSFs. Options are
+            "predicted" or "requirements" where the predicted map is of the expected
+            WFE and the requirements map is slightly more conservative (has slightly
+            larger WFE). Default is "requirements"
+
+        opd_number : int
+            The realization of the OPD map pulled from the OPD file. Options are an
+            integer from 0 to 9, one for each of the 10 Monte Carlo realizations of
+            the telescope included in the OPD map file. Default is 0.
+
+        save : bool
+            True/False boolean if you want to save your file
+
+        fileloc : str
+            Where to save your file if "save" keyword is set to True. Default of None
+            will save in the current directory
+
+        filename : str
+            The name to save your current file under if "save" keyword is set to True.
+            Default of None will save it in the form: "INSTR_FILT_fovp####_samp#_npsf##.fits"
+
+        overwrite : bool
+            True/False boolean to overwrite the output file if it already exists.
+
+        **kwargs
+            This can be used to add any extra arguments to the webbpsf calc_psf() method
+            call.
 
         Special Case for NIRCam:
         For NIRCam, you can set detectors and filters with multiple options.
@@ -44,79 +115,6 @@ class CreatePSFLibrary:
         If you choose individual filters and detectors, they must match in
         shortwave or longwave. Mismatched lists of short and long wave filters and
         detectors will result in an error.
-
-        Parameters
-        ----------
-        instrument: str
-            The name of the instrument you want to run. Can be any capitalization. Can
-            only run 1 instrument at a time. Right now this class is only set up for NIRCam,
-            NIRISS, and FGS (they are 2048x2048)
-
-        filters: str or list
-            Which filter(s) you want to create a library for.
-
-            Can be a string of 1 filter name, a list of filter names (as strings), or
-            the default "all" will run through all the filters in the filter_list
-            attribute of webbpsf.INSTR(). Spelling/capitalization must match what
-            webbpsf expects. See also special case for NIRCam. Default is "all"
-
-        detectors: str or list
-            Which detector(s) you want to create a library for.
-
-            Can be a string of 1 detector name, a list of detector names (as strings), or
-            the default "all" will run through all the detectors in the detector_list
-            attribute of webbpsf.INSTR(). Spelling/capitalization must match what
-            webbpsf expects. See also special case for NIRCam. Default is "all"
-
-        num_psfs: int
-            The total number of fiducial PSFs to be created and saved in the files. This
-            number must be a square number. Default is 16.
-            E.g. num_psfs = 16 will have the class create a 4x4 grid of fiducial PSFs.
-
-        psf_location: tuple
-            If num_psfs = 1, then this is used to set the (y,x) location of that PSF.
-            Default is (1024,1024).
-
-        add_distortion: bool
-            If True, the PSF will have distortions applied: the geometric distortion from
-            the detectors (using data from SIAF) and the rotation of the detectors with
-            respect to the focal plane. Default is True.
-
-        fov_pixels: int
-            The field of view in undersampled detector pixels used by WebbPSF when
-            creating the PSFs. Default is 101 pixels.
-
-        oversample: int
-            The oversampling factor used by WebbPSF when creating the PSFs. Default is 5.
-
-        opd_type: str
-            The type of OPD map you would like to use to create the PSFs. Options are
-            "predicted" or "requirements" where the predicted map is of the expected
-            WFE and the requirements map is slightly more conservative (has slightly
-            larger WFE). Default is "requirements"
-
-        opd_number: int
-            The realization of the OPD map pulled from the OPD file. Options are an
-            integer from 0 to 9, one for each of the 10 Monte Carlo realizations of
-            the telescope included in the OPD map file. Default is 0.
-
-        save: bool
-            True/False boolean if you want to save your file
-
-        fileloc: str
-            Where to save your file if "save" keyword is set to True. Default of None
-            will save in the current directory
-
-        filename: str
-            The name to save your current file under if "save" keyword is set to True.
-            Default of None will save it in the form: "INSTR_FILT_fovp####_samp#_npsf##.fits"
-
-        overwrite: bool
-            True/False boolean to overwrite the output file if it already exists.
-
-        **kwargs
-            This can be used to add any extra arguments to the webbpsf calc_psf() method
-            call.
 
         Use
         ---
@@ -182,7 +180,7 @@ class CreatePSFLibrary:
         raise ValueError(message + "Please change these entries so the filter falls within the detector band.")
 
     def _set_detectors(self, filter):
-        """ Get the list of detectors to include in the PSF library files """
+        """Get the list of detectors to include in the PSF library files"""
 
         # Set detector list to loop over
         if self.detector_input == "all":
@@ -212,7 +210,7 @@ class CreatePSFLibrary:
         return detector_list
 
     def _set_filters(self):
-        """ Get the list of filters to create PSF library files for """
+        """Get the list of filters to create PSF library files for"""
 
         # Set filter list to loop over
         if self.filter_input == "all":
@@ -237,7 +235,7 @@ class CreatePSFLibrary:
         return filter_list
 
     def _set_psf_locations(self, num_psfs, psf_location):
-        """ Set the locations on the detector of the fiducial PSFs. Assumes a 2048x2048 detector"""
+        """Set the locations on the detector of the fiducial PSFs. Assumes a 2048x2048 detector"""
 
         # The locations these PSFs should be centered on for a 2048x2048 detector
         self.num_psfs = num_psfs
@@ -268,12 +266,11 @@ class CreatePSFLibrary:
         (j,i) is the PSF position on the detector grid (integer positions) and (y,x)
         is the 2D PSF.
 
-        Returns:
+        Returns
         -------
         This saves out the library files if requested and then returns a list of all the
         hdulist objects created (each in the form of [SCA, j, i, y, x], 1 per filter
         requested).
-
         """
 
         # Set extension to read based on distortion choice

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -141,7 +141,7 @@ def test_one_psf():
                              fov_pixels=fov_pixels, psf_location=(0, 10), save=False)
     grid2 = inst2.create_files()
 
-    assert grid1[0][0].header["DET_YX0"] == "(1024.0, 1024.0)"  # the default is the integer center of the NIS aperture
+    assert grid1[0][0].header["DET_YX0"] == "(1023.0, 1023.0)"  # the default is the integer center of the NIS aperture
     assert grid2[0][0].header["DET_YX0"] == "(0.0, 10.0)"  # (y,x)
 
     # Compare to the WebbPSF calc_psf output to make sure it's placing the PSF in the right location

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -199,10 +199,10 @@ def test_setting_inputs():
                              num_psfs=1, fov_pixels=1, oversample=2, save=False)
     grid4 = inst4.create_files()
 
-    # # Pass the name "shortwave" to both filter and detector - This case takes 6min alone to run - excluding for time
-    # inst5 = CreatePSFLibrary(instrument="NIRCam", filters="shortwave", detectors="shortwave",
-    #                          num_psfs=1, fov_pixels=1, oversample=2, save=False)
-    # grid5 = inst5.create_files()
+    # Pass the name "shortwave" to both filter and detector
+    inst5 = CreatePSFLibrary(instrument="NIRCam", filters="shortwave", detectors="shortwave",
+                             num_psfs=1, fov_pixels=1, oversample=2, save=False)
+    grid5 = inst5.create_files()
 
     # Length is the number of filters, Shape of those objects follows (det, j, i, y, x)
     assert len(grid1) == 1
@@ -213,8 +213,8 @@ def test_setting_inputs():
     assert grid3[0][0].data.shape == (1, 1, 1, 2, 2)
     assert len(grid4) == 16
     assert grid4[0][0].data.shape == (2, 1, 1, 2, 2)
-    # assert len(grid5) == 13
-    # assert grid5[0][0].data.shape == (8, 1, 1, 2, 2)
+    assert len(grid5) == 13
+    assert grid5[0][0].data.shape == (8, 1, 1, 2, 2)
 
     # Check that passing strings and lists produces the same result
     assert np.array_equal(grid1[0][0].data, grid3[0][0].data)

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -47,7 +47,14 @@ def test_all_filters_and_detectors():
 
 
 def test_compare_to_calc_psf():
-    """Check that the output grid has the expected PSFs in the right grid locations by comparing to calc_psf"""
+    """
+    Check that the output grid has the expected PSFs in the right grid locations by comparing
+    to calc_psf
+
+    This case also uses an even length array, so we'll need to subtract 0.5 from the detector
+    position because grid header has been shifted during calc_psf to account for it being an
+    even length array and this shift shouldn't happen 2x (ie again in calc_psf call below)
+    """
 
     oversample = 2
     fov_pixels = 10
@@ -61,8 +68,8 @@ def test_compare_to_calc_psf():
     psfnum = 1
     loc = grid[0][0].header["DET_YX{}".format(psfnum)]  # (y,x) location
     pos = grid[0][0].header["DET_JI{}".format(psfnum)]  # (j,i) position
-    locy = int(loc.split()[0][1:-1])
-    locx = int(loc.split()[1][:-1])
+    locy = int(float(loc.split()[0][1:-1]) - 0.5)
+    locx = int(float(loc.split()[1][:-1]) - 0.5)
     posj = int(pos.split()[0][1:-1])
     posi = int(pos.split()[1][:-1])
     gridpsf = grid[0][0].data[0, posj, posi, :, :]
@@ -134,8 +141,8 @@ def test_one_psf():
                              fov_pixels=fov_pixels, psf_location=(0, 10), save=False)
     grid2 = inst2.create_files()
 
-    assert grid1[0][0].header["DET_YX0"] == "(1024, 1024)"  # the default is the center of the NIS aperture
-    assert grid2[0][0].header["DET_YX0"] == "(0, 10)"  # (y,x)
+    assert grid1[0][0].header["DET_YX0"] == "(1024.0, 1024.0)"  # the default is the integer center of the NIS aperture
+    assert grid2[0][0].header["DET_YX0"] == "(0.0, 10.0)"  # (y,x)
 
     # Compare to the WebbPSF calc_psf output to make sure it's placing the PSF in the right location
     nis = webbpsf.NIRISS()

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -28,14 +28,14 @@ def test_all_filters_and_detectors():
                              num_psfs=1, add_distortion=False, fov_pixels=1, oversample=2, save=False)
     grid1, grid2 = inst1.create_files()
 
-    # Check that only and all the SW detectors are in this file
+    # Check that only and all the SW detectors are in the first file
     det_list = []
     for i in range(len(grid1[0].data)):
         det_list.append(grid1[0].header["DETNAME{}".format(i)])
     assert len(grid1[0].data) == len(CreatePSFLibrary.nrca_short_detectors)
     assert set(det_list) == set(CreatePSFLibrary.nrca_short_detectors)
 
-    # Check that only and all the LW detectors are in this file
+    # Check that only and all the LW detectors are in the second file
     det_list = []
     for i in range(len(grid2[0].data)):
         det_list.append(grid2[0].header["DETNAME{}".format(i)])
@@ -44,7 +44,7 @@ def test_all_filters_and_detectors():
 
 
 def test_compare_to_calc_psf():
-    """Check that the output PSF matches calc_psf"""
+    """Check that the output grid has the expected PSFs in the right grid locations by comparing to calc_psf"""
 
     oversample = 2
     fov_pixels = 10
@@ -64,7 +64,7 @@ def test_compare_to_calc_psf():
     posi = int(pos.split()[1][:-1])
     gridpsf = grid[0][0].data[0, posj, posi, :, :]
 
-    # Using header data, create the expected same PSF via calc_psf + convolution
+    # Using grid header data, create the expected same PSF via calc_psf + convolution
     fgs = webbpsf.FGS()
     fgs.detector = "FGS1"
     fgs.filter = "FGS"
@@ -79,7 +79,7 @@ def test_compare_to_calc_psf():
 
 
 def test_nircam_errors():
-    """Check that there are checks for incorrect value setting - particularly with NIRCam"""
+    """Check that there are errors for incorrect value setting - particularly with NIRCam"""
 
     longfilt = "F250M"
     shortfilt = "F140M"
@@ -94,7 +94,7 @@ def test_nircam_errors():
                              num_psfs=1, fov_pixels=1, save=False)  # no error
     inst2.create_files()
 
-    # Should error - Bad filter/detector combination (SW filt to LW det)
+    # Should error - Bad filter/detector combination (LW filt to SW det)
     with pytest.raises(ValueError) as excinfo:
         inst3 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=shortdet, add_distortion=False,
                                  num_psfs=1, fov_pixels=1, save=False)  # error

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -9,7 +9,6 @@ import webbpsf
 from mirage.psf.psf_library import CreatePSFLibrary
 
 
-# @pytest.mark.skip()
 def test_all_filters_and_detectors():
     """Check that setting filters and detectors to all works"""
 
@@ -44,9 +43,9 @@ def test_all_filters_and_detectors():
     assert set(det_list) == set(CreatePSFLibrary.nrca_long_detectors)
 
 
-# @pytest.mark.skip()
 def test_compare_to_calc_psf():
     """Check that the output PSF matches calc_psf"""
+
     oversample = 2
     fov_pixels = 10
 
@@ -79,9 +78,9 @@ def test_compare_to_calc_psf():
     assert np.array_equal(gridpsf, convpsf)
 
 
-# @pytest.mark.skip()
 def test_nircam_errors():
     """Check that there are checks for incorrect value setting - particularly with NIRCam"""
+
     longfilt = "F250M"
     shortfilt = "F140M"
     longdet = "NRCB5"
@@ -117,9 +116,9 @@ def test_nircam_errors():
     assert "ValueError" in str(excinfo)
 
 
-# @pytest.mark.skip()
-def test_onepsf():
+def test_one_psf():
     """Check that setting num_psfs = 1 produces the PSF in the expected location"""
+
     oversample = 2
     fov_pixels = 101
 
@@ -145,7 +144,6 @@ def test_onepsf():
     assert np.array_equal(convpsf, grid2[0][0].data[0, 0, 0, :, :])
 
 
-# @pytest.mark.skip()
 def test_saving(tmpdir):
     """Test saving files works properly"""
 
@@ -164,7 +162,6 @@ def test_saving(tmpdir):
         assert np.array_equal(infile[0].data, grid[0][0].data)
 
 
-# @pytest.mark.skip()
 def test_setting_inputs():
     """Test that no errors are raised when filters and detectors can be set different ways"""
 
@@ -188,10 +185,10 @@ def test_setting_inputs():
                              num_psfs=1, fov_pixels=1, oversample=2, save=False)
     grid4 = inst4.create_files()
 
-    # Pass the name "shortwave" to both filter and detector
+    # # Pass the name "shortwave" to both filter and detector - This case takes 6min alone to run - excluding for time
     # inst5 = CreatePSFLibrary(instrument="NIRCam", filters="shortwave", detectors="shortwave",
     #                          num_psfs=1, fov_pixels=1, oversample=2, save=False)
-    # grid5 = inst5.create_files()  # This case takes 6min alone to run - excluding for time
+    # grid5 = inst5.create_files()
 
     # Length is the number of filters, Shape of those objects follows (det, j, i, y, x)
     assert len(grid1) == 1

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -13,20 +13,23 @@ def test_all_filters_and_detectors():
     """Check that setting filters and detectors to all works"""
 
     # Case 1: Setting filters="all" and "detectors="all"
-    inst1 = CreatePSFLibrary(instrument="FGS", filters="all", detectors="all", num_psfs=1, save=False)
+    inst1 = CreatePSFLibrary(instrument="FGS", filters="all", detectors="all",
+                             num_psfs=1, save=False)
     grid1 = inst1.create_files()
-    inst2 = CreatePSFLibrary(instrument="FGS", filters="FGS", detectors=["FGS1", "FGS2"], num_psfs=1, save=False)
+    inst2 = CreatePSFLibrary(instrument="FGS", filters="FGS", detectors=["FGS1", "FGS2"],
+                             num_psfs=1, save=False)
     grid2 = inst2.create_files()
 
-    # Check they are the same
+    # Check outputs are the same
     assert np.array_equal(grid1[0][0].data, grid2[0][0].data)
 
     # Case 2: NIRCam should be able to pull all the appropriate detectors based on the filter type (SW vs LW)
     longfilt = "F250M"
     shortfilt = "F140M"
-    inst1 = CreatePSFLibrary(instrument="NIRCam", filters=[shortfilt, longfilt], detectors="all",
-                             num_psfs=1, add_distortion=False, fov_pixels=1, oversample=2, save=False)
-    grid1, grid2 = inst1.create_files()
+    inst3 = CreatePSFLibrary(instrument="NIRCam", filters=[shortfilt, longfilt],
+                             detectors="all", num_psfs=1, add_distortion=False,
+                             fov_pixels=1, oversample=2, save=False)
+    grid1, grid2 = inst3.create_files()
 
     # Check that only and all the SW detectors are in the first file
     det_list = []
@@ -87,31 +90,31 @@ def test_nircam_errors():
     shortdet = "NRCA3"
 
     # Shouldn't error - applying SW to SW and LW to LW
-    inst1 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=longdet, add_distortion=False,
-                             num_psfs=1, fov_pixels=1, save=False)  # no error
+    inst1 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=longdet,
+                             add_distortion=False, num_psfs=1, fov_pixels=1, save=False)  # no error
     inst1.create_files()
-    inst2 = CreatePSFLibrary(instrument="NIRCam", filters=shortfilt, detectors=shortdet, add_distortion=False,
-                             num_psfs=1, fov_pixels=1, save=False)  # no error
+    inst2 = CreatePSFLibrary(instrument="NIRCam", filters=shortfilt, detectors=shortdet,
+                             add_distortion=False, num_psfs=1, fov_pixels=1, save=False)  # no error
     inst2.create_files()
 
     # Should error - Bad filter/detector combination (LW filt to SW det)
     with pytest.raises(ValueError) as excinfo:
-        inst3 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=shortdet, add_distortion=False,
-                                 num_psfs=1, fov_pixels=1, save=False)  # error
+        inst3 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=shortdet,
+                                 add_distortion=False, num_psfs=1, fov_pixels=1, save=False)  # error
         inst3.create_files()
     assert "ValueError" in str(excinfo)
 
     # Should error - Bad filter/detector combination (SW filt to LW det)
     with pytest.raises(ValueError) as excinfo:
-        inst4 = CreatePSFLibrary(instrument="NIRCam", filters=shortfilt, detectors=longdet, add_distortion=False,
-                                 num_psfs=1, fov_pixels=1, save=False)  # error
+        inst4 = CreatePSFLibrary(instrument="NIRCam", filters=shortfilt, detectors=longdet,
+                                 add_distortion=False, num_psfs=1, fov_pixels=1, save=False)  # error
         inst4.create_files()
     assert "ValueError" in str(excinfo)
 
     # Should error - Bad num_psfs entry (must be a square number)
     with pytest.raises(ValueError) as excinfo:
-        inst5 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=longdet, add_distortion=False,
-                                 num_psfs=3, fov_pixels=1, save=False)  # error
+        inst5 = CreatePSFLibrary(instrument="NIRCam", filters=longfilt, detectors=longdet,
+                                 add_distortion=False, num_psfs=3, fov_pixels=1, save=False)  # error
         inst5.create_files()
     assert "ValueError" in str(excinfo)
 
@@ -123,11 +126,13 @@ def test_one_psf():
     fov_pixels = 101
 
     # Create 2 cases with different locations: the default center and a set location
-    inst1 = CreatePSFLibrary(instrument="NIRISS", filters="F090W", detectors="NIS", num_psfs=1, add_distortion=True,
-                             oversample=oversample, fov_pixels=fov_pixels, save=False)
+    inst1 = CreatePSFLibrary(instrument="NIRISS", filters="F090W", detectors="NIS",
+                             num_psfs=1, add_distortion=True, oversample=oversample,
+                             fov_pixels=fov_pixels, save=False)
     grid1 = inst1.create_files()
-    inst2 = CreatePSFLibrary(instrument="NIRISS", filters="F090W", detectors="NIS", num_psfs=1, add_distortion=True,
-                             oversample=oversample, fov_pixels=fov_pixels, psf_location=(0, 10), save=False)
+    inst2 = CreatePSFLibrary(instrument="NIRISS", filters="F090W", detectors="NIS",
+                             num_psfs=1, add_distortion=True, oversample=oversample,
+                             fov_pixels=fov_pixels, psf_location=(0, 10), save=False)
     grid2 = inst2.create_files()
 
     assert grid1[0][0].header["DET_YX0"] == "(1024, 1024)"  # the default is the center of the NIS aperture

--- a/tests/test_psf_library.py
+++ b/tests/test_psf_library.py
@@ -77,7 +77,6 @@ def test_compare_to_calc_psf():
     convpsf = astropy.convolution.convolve(calcpsf, kernel)
 
     # Compare to make sure they are in fact the same PSF
-    assert gridpsf.shape == calcpsf.shape
     assert np.array_equal(gridpsf, convpsf)
 
 
@@ -165,6 +164,9 @@ def test_saving(tmpdir):
     with fits.open(os.path.join(path, "fgs_fgs_fovp10_samp2_npsf4.fits")) as infile:
         assert infile[0].header == grid[0][0].header
         assert np.array_equal(infile[0].data, grid[0][0].data)
+
+    # Remove temp directory
+    tmpdir.remove()
 
 
 def test_setting_inputs():


### PR DESCRIPTION
The PSFs locations in the header were not quite correct for PSFs with even-length arrays. There is a subtle change inside calc_psf that shifts even length arrays by 0.5 to center them correctly, and while this change was happening inside calc_psf, it wasn't being documented in the header of the final grid  object. I have now updated the header and updated 2 of the tests to reflect this. 

I also switched the default center location of the num_psfs=1 case to (1023,1023). The technically "correct" center is (1023.5, 1023.5), so before this 0.5 shift update above, the center being (1024,1024) was fine because it was just off by 0.5 (and would be no matter what). But now that that shift is added, the case of a single even-length array PSF would be centered on (1024.5, 1024.5), which is not the most accurate option. So I changed the default center so that a single centered PSF would either be located at (1023, 1023) if odd or (1023.5, 1023.5) if even.

A side effect is that now instead of the header reading DET_YX0 = (1023,1023), it will look like a float and read (1023.0, 1023.0) (or if it's an even length array, (1023.5, 1023.5)).

I also made a bunch of PEP8 updates and clean up to the code.