### PR TITLE
Speed up siaf interface

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -282,7 +282,6 @@ class AptInput:
         #     readxml_obj = read_apt_xml.ReadAPTXML()
         #     tab = readxml_obj.read_xml(self.input_xml)
 
-
         # This affects on NIRCam exposures (right?)
         # If the number of dithers is set to '3TIGHT'
         # (currently only used in NIRCam)
@@ -303,7 +302,9 @@ class AptInput:
 
         # Check that the .xml and .pointing files agree
         assert len(self.apt_xml_dict['ProposalID']) == len(pointing_dictionary['obs_num']),\
-            'Inconsistent table size from XML file ({}) and pointing file ({}). Something was not processed correctly in apt_inputs.'.format(len(self.apt_xml_dict['ProposalID']), len(pointing_dictionary['obs_num']))
+            ('Inconsistent table size from XML file ({}) and pointing file ({}). Something was not '
+             'processed correctly in apt_inputs.'.format(len(self.apt_xml_dict['ProposalID'])),
+             len(pointing_dictionary['obs_num']))
 
         # Combine the dictionaries
         observation_dictionary = self.combine_dicts(self.apt_xml_dict, pointing_dictionary)
@@ -327,6 +328,16 @@ class AptInput:
 
         ascii.write(Table(self.exposure_tab), detectors_file, format='csv', overwrite=True)
         print('Wrote exposure table to {}'.format(detectors_file))
+
+        # Create a pysiaf.Siaf instance for each instrument in the proposal
+        self.siaf = {}
+        for inst in np.unique(observation_dictionary['Instrument']):
+            instrument_name = inst
+            if inst == 'NIRCAM':
+                instrument_name = 'NIRCam'
+            if inst == 'NIRSPEC':
+                instrument_name = 'NIRSPec'
+            self.siaf[instrument_name] = siaf_interface.get_instance(instrument_name)
 
         # Calculate the correct V2, V3 and RA, Dec for each exposure/detector
         self.ra_dec_update()
@@ -398,16 +409,15 @@ class AptInput:
                     detectors = ['G1']
                 elif 'FGS2' in input_dictionary['aperture'][index]:
                     detectors = ['G2']
-            elif instrument== 'miri':
+            elif instrument == 'miri':
                 detectors = ['MIR']
-
 
             n_detectors = len(detectors)
             for key in input_dictionary:
                 observation_dictionary[key].extend(([input_dictionary[key][index]] * n_detectors))
             observation_dictionary['detector'].extend(detectors)
 
-        #correct NIRCam aperture names
+        # correct NIRCam aperture names
         for index, instrument in enumerate(observation_dictionary['Instrument']):
             instrument = instrument.lower()
             if instrument == 'nircam':
@@ -435,8 +445,6 @@ class AptInput:
                 else:
                     aperture_name = detector + '_' + sub
                 observation_dictionary['aperture'][index] = aperture_name
-
-
         return observation_dictionary
 
     def extract_value(self, line):
@@ -535,7 +543,7 @@ class AptInput:
         with open(file) as f:
             for line in f:
 
-                #skip comments and new lines
+                # skip comments and new lines
                 if (line[0] == '#') or (line in ['\n']) or ('=====' in line):
                     continue
                 # extract proposal ID
@@ -544,12 +552,11 @@ class AptInput:
                     try:
                         propid = np.int(propid_header)
                     except ValueError:
-                        #adopt value passed to function
+                        # adopt value passed to function
                         pass
                     if verbose:
                         print('Extracted proposal ID {}'.format(propid))
                     continue
-
 
                 elif (len(line) > 1):
                     elements = line.split()
@@ -707,6 +714,8 @@ class AptInput:
             siaf_instrument = self.exposure_tab["Instrument"][i]
             if siaf_instrument == 'NIRSPEC':
                 siaf_instrument = 'NIRSpec'
+            if siaf_instrument == 'NIRCAM':
+                siaf_instrument = 'NIRCam'
 
             aperture_name = self.exposure_tab['aperture'][i]
             pointing_ra = np.float(self.exposure_tab['ra'][i])
@@ -721,10 +730,12 @@ class AptInput:
 
             telescope_roll = pav3
 
-            aperture, local_roll, attitude_matrix, fullframesize, subarray_boundaries = \
-                siaf_interface.get_siaf_information(
-                siaf_instrument, aperture_name, pointing_ra, pointing_dec, telescope_roll,
-                    v2_arcsec=pointing_v2, v3_arcsec=pointing_v3)
+            aperture = self.siaf[siaf_instrument][aperture_name]
+
+            local_roll, attitude_matrix, fullframesize, subarray_boundaries = \
+                siaf_interface.get_siaf_information(self.siaf[siaf_instrument], aperture_name,
+                                                    pointing_ra, pointing_dec, telescope_roll,
+                                                    v2_arcsec=pointing_v2, v3_arcsec=pointing_v3)
 
             # calculate RA, Dec of reference location for the detector
             ra, dec = rotations.pointing(attitude_matrix, aperture.V2Ref, aperture.V3Ref)
@@ -739,8 +750,11 @@ class AptInput:
             parser = argparse.ArgumentParser(usage=usage, description='Simulate JWST ramp')
         parser.add_argument("input_xml", help='XML file from APT describing the observations.')
         parser.add_argument("pointing_file", help='Pointing file from APT describing observations.')
-        parser.add_argument("--output_csv", help="Name of output CSV file containing list of observations.", default=None)
-        parser.add_argument("--observation_list_file", help='Ascii file containing a list of observations, times, and roll angles, catalogs', default=None)
+        parser.add_argument("--output_csv", help="Name of output CSV file containing list of observations.",
+                            default=None)
+        parser.add_argument("--observation_list_file", help=('Ascii file containing a list of '
+                                                             'observations, times, and roll angles, '
+                                                             'catalogs'), default=None)
         return parser
 
 

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -750,7 +750,7 @@ class AptInput:
             parser = argparse.ArgumentParser(usage=usage, description='Simulate JWST ramp')
         parser.add_argument("input_xml", help='XML file from APT describing the observations.')
         parser.add_argument("pointing_file", help='Pointing file from APT describing observations.')
-        parser.add_argument("--output_csv", help="Name of output CSV file containing list of observations.",
+        parser.add_argument("--output_csv", help="Name of output file containing list of observations.",
                             default=None)
         parser.add_argument("--observation_list_file", help=('Ascii file containing a list of '
                                                              'observations, times, and roll angles, '

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -336,7 +336,7 @@ class AptInput:
             if inst == 'NIRCAM':
                 instrument_name = 'NIRCam'
             if inst == 'NIRSPEC':
-                instrument_name = 'NIRSPec'
+                instrument_name = 'NIRSpec'
             self.siaf[instrument_name] = siaf_interface.get_instance(instrument_name)
 
         # Calculate the correct V2, V3 and RA, Dec for each exposure/detector

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -671,8 +671,10 @@ class DarkPrep():
         siaf_inst = self.params['Inst']['instrument']
         if siaf_inst.lower() == 'nircam':
             siaf_inst = 'NIRCam'
-        self.siaf, junk0, junk1, self.ffsize, \
-            self.subarray_bounds = siaf_interface.get_siaf_information(siaf_inst,
+        instrument_siaf = siaf_interface.get_instance(siaf_inst)
+        self.siaf = instrument_siaf[self.params['Readout']['array_name']]
+        junk0, junk1, self.ffsize, \
+            self.subarray_bounds = siaf_interface.get_siaf_information(instrument_siaf,
                                                                        self.params['Readout']['array_name'],
                                                                        0.0, 0.0,
                                                                        self.params['Telescope']['rotation'])

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -752,8 +752,10 @@ class Observation():
         siaf_inst = self.params['Inst']['instrument']
         if siaf_inst.lower() == 'nircam':
             siaf_inst = 'NIRCam'
-        self.siaf, self.local_roll, self.attitude_matrix, self.ffsize, \
-            self.subarray_bounds = siaf_interface.get_siaf_information(siaf_inst,
+        instrument_siaf = siaf_interface.get_instance(siaf_inst)
+        self.siaf = instrument_siaf[self.params['Readout']['array_name']]
+        self.local_roll, self.attitude_matrix, self.ffsize, \
+            self.subarray_bounds = siaf_interface.get_siaf_information(instrument_siaf,
                                                                        self.params['Readout']['array_name'],
                                                                        self.ra, self.dec,
                                                                        self.params['Telescope']['rotation'])

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1341,14 +1341,14 @@ class Catalog_seed():
         # Read in the list of point sources to add
         # Adjust point source locations using astrometric distortion
         # Translate magnitudes to counts in a single frame
-        if self.runStep['pointsource'] == True:
+        if self.runStep['pointsource'] is True:
             pslist = self.getPointSourceList(self.params['simSignals']['pointsource'])
 
             # translate the point source list into an image
             psfimage, ptsrc_segmap = self.makePointSourceImage(pslist)
 
             # save the point source image for examination by user
-            if self.params['Output']['save_intermediates'] == True:
+            if self.params['Output']['save_intermediates'] is True:
                 psfImageName = self.basename + '_pointSourceRateImage_adu_per_sec.fits'
                 h0 = fits.PrimaryHDU(psfimage)
                 h1 = fits.ImageHDU(ptsrc_segmap)
@@ -1367,7 +1367,7 @@ class Catalog_seed():
         # Simulated galaxies
         # Read in the list of galaxy positions/magnitudes to simulate
         # and create a countrate image of those galaxies.
-        if self.runStep['galaxies'] == True:
+        if self.runStep['galaxies'] is True:
             galaxyCRImage, galaxy_segmap = self.makeGalaxyImage(self.params['simSignals']['galaxyListFile'], self.centerpsf)
 
             # Multiply by the pixel area map
@@ -1377,7 +1377,7 @@ class Catalog_seed():
             segmentation_map += galaxy_segmap
 
             # save the galaxy image for examination by the user
-            if self.params['Output']['save_intermediates'] == True:
+            if self.params['Output']['save_intermediates'] is True:
                 galImageName = self.basename + '_galaxyRateImage_adu_per_sec.fits'
                 h0 = fits.PrimaryHDU(galaxyCRImage)
                 h1 = fits.ImageHDU(galaxy_segmap)
@@ -1390,7 +1390,7 @@ class Catalog_seed():
             signalimage = signalimage + galaxyCRImage
 
         # read in extended signal image and add the image to the overall image
-        if self.runStep['extendedsource'] == True:
+        if self.runStep['extendedsource'] is True:
             extlist, extstamps = self.getExtendedSourceList(self.params['simSignals']['extended'])
 
             # translate the extended source list into an image
@@ -1419,7 +1419,7 @@ class Catalog_seed():
             signalimage = signalimage + extimage
 
         # ZODIACAL LIGHT
-        if self.runStep['zodiacal'] == True:
+        if self.runStep['zodiacal'] is True:
             #zodiangle = self.eclipticangle() - self.params['Telescope']['rotation']
             zodiangle = self.params['Telescope']['rotation']
             zodiacalimage, zodiacalheader = self.getImage(self.params['simSignals']['zodiacal'], arrayshape, True, zodiangle, arrayshape/2)
@@ -3029,9 +3029,10 @@ class Catalog_seed():
         siaf_inst = self.params['Inst']['instrument']
         if siaf_inst.lower() == 'nircam':
             siaf_inst = 'NIRCam'
-        self.siaf = siaf_interface.get_instance(siaf_inst)
+        instrument_siaf = siaf_interface.get_instance(siaf_inst)
+        self.siaf = instrument_siaf[self.params['Readout']['array_name']]
         self.local_roll, self.attitude_matrix, self.ffsize, \
-            self.subarray_bounds = siaf_interface.get_siaf_information(self.siaf,
+            self.subarray_bounds = siaf_interface.get_siaf_information(instrument_siaf,
                                                                        self.params['Readout']['array_name'],
                                                                        self.ra, self.dec,
                                                                        self.params['Telescope']['rotation'])

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -168,43 +168,43 @@ class Catalog_seed():
         if ((self.params['Inst']['mode'] in ['wfss','ts_wfss']) & \
             ('FULL' not in self.params['Readout']['array_name'])):
             self.seedimage, self.seed_segmap = self.pad_wfss_subarray(self.seedimage, self.seed_segmap)
-         
+
         # Save the combined static + moving targets ramp
         self.saveSeedImage()
-       
+
         if self.params['Inst']['mode'] in ["pom"]:
             self.seedimage, self.seed_segmap = self.extract_full_from_pom(self.seedimage, self.seed_segmap)
-         
+
         # Return info in a tuple
         # return (self.seedimage, self.seed_segmap, self.seedinfo)
-         
+
     def extract_full_from_pom(self,seedimage,seed_segmap):
-        """ Given the seed image and segmentation images for the NIRISS POM field of view, 
-        extract the central 2048x2048 pixel area where the detector sits.  The routine is only 
-        called when the mode is "pom".  The mode is set to "imaging" in these routine, as after 
-        the routine is called the subsequent results are the same as when the mode is set to 
+        """ Given the seed image and segmentation images for the NIRISS POM field of view,
+        extract the central 2048x2048 pixel area where the detector sits.  The routine is only
+        called when the mode is "pom".  The mode is set to "imaging" in these routine, as after
+        the routine is called the subsequent results are the same as when the mode is set to
         "imaging" in the parameter file.
-        
+
         Parameters:
         -----------
-        
+
         seedimage : numpy.ndarray (float)   dimension 2322x2322 pixels
         seed_segmap : numpy.ndarray (int)    dimension 2322x2322 pixels
-        
+
         Returns:
         ---------
-        
+
         newseedimage : numpy.ndarray (float)  dimension 2048x2048
         newseed_segmap : numpy.ndarray (int)   dimension 2048x2048
-        
+
         """
-        # For the NIRISS POM mode, extact the central 2048x2048 pixels for the 
+        # For the NIRISS POM mode, extact the central 2048x2048 pixels for the
         # ramp simulation.  Set the mode back to "imaging".
         newseedimage = np.copy(seedimage[self.coord_adjust['yoffset']:self.coord_adjust['yoffset']+2048,self.coord_adjust['xoffset']:self.coord_adjust['xoffset']+2048])
         newseed_segmap = np.copy(seed_segmap[self.coord_adjust['yoffset']:self.coord_adjust['yoffset']+2048,self.coord_adjust['xoffset']:self.coord_adjust['xoffset']+2048])
-        self.params['Inst']['mode'] = "imaging" 
+        self.params['Inst']['mode'] = "imaging"
         return newseedimage, newseed_segmap
-         
+
     def add_detector_to_zeropoints(self, detector):
         """Manually add detector dependence to the zeropoint table for
         NIRCam and NIRISS simualtions. This is being done as a placeholder
@@ -568,7 +568,7 @@ class Catalog_seed():
             self.coord_adjust['yoffset'] = np.int((self.grism_direct_factor - 1.) *
                                                   (self.subarray_bounds[3] -
                                                    self.subarray_bounds[1] + 1) / 2.)
-                  
+
         if self.params['Inst']['mode'] in ["pom"]:
             # change the values for the NIRISS/POM mode.  Add 137 pixels extra space around the main image area, full frame.
             self.output_dims = [2322,2322]
@@ -3029,8 +3029,9 @@ class Catalog_seed():
         siaf_inst = self.params['Inst']['instrument']
         if siaf_inst.lower() == 'nircam':
             siaf_inst = 'NIRCam'
-        self.siaf, self.local_roll, self.attitude_matrix, self.ffsize, \
-            self.subarray_bounds = siaf_interface.get_siaf_information(siaf_inst,
+        self.siaf = siaf_interface.get_instance(siaf_inst)
+        self.local_roll, self.attitude_matrix, self.ffsize, \
+            self.subarray_bounds = siaf_interface.get_siaf_information(self.siaf,
                                                                        self.params['Readout']['array_name'],
                                                                        self.ra, self.dec,
                                                                        self.params['Telescope']['rotation'])

--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -6,6 +6,7 @@ Authors
 -------
 
     - Johannes Sahlmann
+    - Bryan Hilbert
 
 Use
 ---
@@ -27,27 +28,59 @@ from ..utils import rotations
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 
 
-def get_siaf_information(instrument, aperture_name, ra, dec, telescope_roll, v2_arcsec=None, v3_arcsec=None, verbose=False):
-    """Use pysiaf to get aperture information.
+def get_instance(instrument):
+    """Return an instance of a pysiaf.Siaf object for the given instrument
 
     Parameters
     ----------
     instrument : str
-        Instrument name.
+        Name of instrument
+
+    Returns
+    -------
+    siaf : pysiaf.Siaf
+        Siaf object for the requested instrument
+    """
+    if instrument.lower() == 'nircam':
+        print("NOTE: Using pre-delivery SIAF data for {}".format(instrument))
+        siaf_instrument = 'NIRCam'
+        pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, 'NIRCam')
+        siaf = pysiaf.Siaf(siaf_instrument, basepath=pre_delivery_dir)
+    else:
+        siaf_instrument = instrument
+        siaf = pysiaf.Siaf(siaf_instrument)
+    return siaf
+
+
+def get_siaf_information(siaf_instance, aperture_name, ra, dec, telescope_roll, v2_arcsec=None,
+                         v3_arcsec=None, verbose=False):
+    """Use pysiaf to get aperture information.
+
+    Parameters
+    ----------
+    siaf_instance : pysiaf.Siaf
+        Instance of SIAF for a single instrument
 
     aperture_name : str
         Aperture name (e.g. "NRCA1_FULL")
+
+    Returns
+    -------
+    local_roll : float
+        Local roll angle at the reference location of the aperture
+
+    att_matrix : matrix
+        Attitude matrix used to relate RA, Dec, local roll angle to V2, V3
+
+    fullframesize : int
+        Number of columns in the  given aperture
+
+    subarray_boundaries : list
+        List of full-frame coordinates corresponding to the minimum and maximum
+        values of x and y in the given aperture
     """
-    # Temporary fix to access good NIRCam distortion coefficients which
-    # which are not yet in the PRD
-    if instrument.lower() == 'nircam':
-        print("NOTE: Using pre-delivery SIAF data for {}".format(aperture_name))
-        siaf_instrument = 'NIRCam'
-        pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, 'NIRCam')
-        siaf = pysiaf.Siaf(siaf_instrument, basepath=pre_delivery_dir)[aperture_name]
-    else:
-        siaf_instrument = instrument
-        siaf = pysiaf.Siaf(siaf_instrument)[aperture_name]
+    # Select the correct aperture
+    siaf = siaf_instance[aperture_name]
 
     if v2_arcsec is None:
         v2_arcsec = siaf.V2Ref
@@ -65,16 +98,16 @@ def get_siaf_information(instrument, aperture_name, ra, dec, telescope_roll, v2_
 
     # Subarray boundaries in full frame coordinates
     try:
-        xcorner, ycorner = sci_subarray_corners(siaf_instrument, aperture_name)
+        xcorner, ycorner = sci_subarray_corners(siaf_instance.instrument, aperture_name, siaf=siaf_instance)
         subarray_boundaries = [xcorner[0], ycorner[0], xcorner[1], ycorner[1]]
-    except (RuntimeError, TypeError) as e: # e.g. NIRSpec NRS_FULL_MSA aperture
+    except (RuntimeError, TypeError) as e:  # e.g. NIRSpec NRS_FULL_MSA aperture
         if verbose:
             print('get_siaf_information raised error:\n{}\nIgnoring it.'.format(e))
         subarray_boundaries = [0, 0, 0, 0]
-    return siaf, local_roll, att_matrix, fullframesize, subarray_boundaries
+    return local_roll, att_matrix, fullframesize, subarray_boundaries
 
 
-def sci_subarray_corners(instrument, aperture_name, verbose=False):
+def sci_subarray_corners(instrument, aperture_name, siaf=None, verbose=False):
     """Return the two opposing aperture corners in the SIAF Science frame of the full-frame SCA.
 
     This function serves as interface between the SIAF information accessible via the pysiaf package
@@ -86,6 +119,8 @@ def sci_subarray_corners(instrument, aperture_name, verbose=False):
         JWST instrument name with correct capitalization
     aperture_name : str
         SIAF aperture name
+    siaf : pysiaf.Siaf
+        SIAF instance for a single instrument
     verbose : bool
         Verbose output on/off
 
@@ -96,7 +131,8 @@ def sci_subarray_corners(instrument, aperture_name, verbose=False):
 
     """
     # get SIAF
-    siaf = pysiaf.Siaf(instrument)
+    if siaf is None:
+        siaf = pysiaf.Siaf(instrument)
 
     # get master aperture names
     siaf_detector_layout = iando.read.read_siaf_detector_layout()

--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -64,6 +64,26 @@ def get_siaf_information(siaf_instance, aperture_name, ra, dec, telescope_roll, 
     aperture_name : str
         Aperture name (e.g. "NRCA1_FULL")
 
+    ra : float
+        RA value of pointing in degrees
+
+    dec : float
+        Dec value of pointing in degrees
+
+    telescope_roll : float
+        Position angle of the telescope in degrees
+
+    v2_arcsec : float
+        The V2 value in arcseconds of the reference location for the
+        instrument aperture
+
+    v3_arcsecc : float
+        The V3 value in arcseconds of the reference location for the
+        instrument aperture
+
+    verbose : bool
+        Print extra information to the screen
+
     Returns
     -------
     local_roll : float


### PR DESCRIPTION
These edits speed up the use of `siaf_interface` when running Mirage. Currently a new instance of pysiaf.Siaf() is created for each exposure when running the `yaml_generator`, which takes a lot of time. 

With these updates, Mirage creates a single instance of the siaf for each instrument in the proposal, and uses these when looping through the exposures.