### PR TITLE
Update pysiaf in environment files to 0.2.5

### DIFF
--- a/mirage_environment_linux.yml
+++ b/mirage_environment_linux.yml
@@ -206,7 +206,7 @@ dependencies:
     - msgpack==0.5.6
     - openpyxl==2.5.8
     - poppy==0.7.0
-    - pysiaf==0.2.4
+    - pysiaf==0.2.5
     - relic==1.1.2
     - webbpsf==0.7.0
 

--- a/mirage_environment_osx.yml
+++ b/mirage_environment_osx.yml
@@ -195,6 +195,6 @@ dependencies:
     - msgpack==0.5.6
     - openpyxl==2.5.8
     - poppy==0.7.0
-    - pysiaf==0.2.4
+    - pysiaf==0.2.5
     - relic==1.1.2
     - webbpsf==0.7.0


### PR DESCRIPTION
This PR updates the version of pysiaf listed in the environment files to 0.2.5, which is the version that is insensitive to case in the instrument names. Mirage code has already been updated to use this version.