### PR TITLE
Clarify required dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ pip install .
 
 ## Dependencies
 
+``pip`` should install all required dependencies, but if desired, the list of packages required for MIRaGE can 
+be viewed in the ``install_requires`` part of this repository's [setup.py file](setup.py).
+
+### Optional dependencies
+
 To simulate wide field slitless spectroscopy (WFSS) data:
 
 * [NIRCam_Gsim][d1]: to disperse imaging data


### PR DESCRIPTION
I was slightly confused by this: the dependencies listed in the README look to actually be *optional* dependencies, and there's (quite sensibly) a required list in the ``setup.py``.  This just clarifies the situation in the README via linking to the ``setup.py``.