### PR TITLE
Yaml generator environment variable check

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -50,14 +50,7 @@ class DarkPrep():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = os.environ.get(self.env_var)
-        if datadir is None:
-            raise ValueError(("WARNING: {} environment variable is not set."
-                              "This must be set to the base directory"
-                              "containing the darks, cosmic ray, PSF, etc"
-                              "input files needed for the simulation."
-                              "These files must be downloaded separately"
-                              "from the Mirage package.".format(self.env_var)))
+        datadir = utils.expand_environment_variable(self.env_var)
 
     def check_params(self):
         """Check for acceptible values for the input parameters in the

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -40,8 +40,15 @@ INST_LIST = ['nircam', 'niriss', 'fgs']
 
 
 class DarkPrep():
+    def __init__(self, offline=False):
+        """Instantiate DarkPrep object.
 
-    def __init__(self):
+        Parameters
+        ----------
+        offline : bool
+            If True, the check for the existence of the MIRAGE_DATA
+            directory is skipped. This is primarily for Travis testing
+        """
         # Locate the module files, so that we know where to look
         # for config subdirectory
         self.modpath = pkg_resources.resource_filename('mirage', '')
@@ -50,7 +57,7 @@ class DarkPrep():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = utils.expand_environment_variable(self.env_var)
+        datadir = utils.expand_environment_variable(self.env_var, offline=offline)
 
     def check_params(self):
         """Check for acceptible values for the input parameters in the

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -73,14 +73,7 @@ class Observation():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = os.environ.get(self.env_var)
-        if datadir is None:
-            raise ValueError(("WARNING: {} environment variable is not set."
-                              "This must be set to the base directory"
-                              "containing the darks, cosmic ray, PSF, etc"
-                              "input files needed for the simulation."
-                              "These files must be downloaded separately"
-                              "from the Mirage package.".format(self.env_var)))
+        datadir = utils.expand_environment_variable(self.env_var)
 
     def add_crosstalk(self, exposure):
         """Add crosstalk effects to the input exposure

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -52,7 +52,15 @@ MODES = {"nircam": ["imaging", "ts_imaging", "wfss", "ts_wfss"],
 
 
 class Observation():
-    def __init__(self):
+    def __init__(self, offline=False):
+        """Instantiate the Observation class
+
+        Parameters
+        ----------
+        offline : bool
+            If True, the check for the existence of the MIRAGE_DATA
+            directory is skipped. This is primarily for Travis testing
+        """
         self.linDark = None
         self.seed = None
         self.segmap = None
@@ -73,7 +81,7 @@ class Observation():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = utils.expand_environment_variable(self.env_var)
+        datadir = utils.expand_environment_variable(self.env_var, offline=offline)
 
     def add_crosstalk(self, exposure):
         """Add crosstalk effects to the input exposure

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -57,15 +57,7 @@ class Catalog_seed():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = os.environ.get(self.env_var)
-
-        if datadir is None:
-            raise ValueError(("WARNING: {} environment variable is not set."
-                              "This must be set to the base directory"
-                              "containing the darks, cosmic ray, PSF, etc"
-                              "input files needed for the simulation."
-                              "These files must be downloaded separately"
-                              "from the Mirage package.".format(self.env_var)))
+        datadir = utils.expand_environment_variable(self.env_var)
 
         # if a grism signal rate image is requested, expand
         # the width and height of the signal rate image by this

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -48,7 +48,15 @@ WFEGROUP_OPTIONS = np.arange(5)
 
 
 class Catalog_seed():
-    def __init__(self):
+    def __init__(self, offline=False):
+        """Instantiate the Catalog_seed class
+
+        Parameters
+        ----------
+        offline : bool
+            If True, the check for the existence of the MIRAGE_DATA
+            directory is skipped. This is primarily for Travis testing
+        """
         # Locate the module files, so that we know where to look
         # for config subdirectory
         self.modpath = pkg_resources.resource_filename('mirage', '')
@@ -57,7 +65,7 @@ class Catalog_seed():
         # variable, so we know where to look for darks, CR,
         # PSF files, etc later
         self.env_var = 'MIRAGE_DATA'
-        datadir = utils.expand_environment_variable(self.env_var)
+        datadir = utils.expand_environment_variable(self.env_var, offline=offline)
 
         # if a grism signal rate image is requested, expand
         # the width and height of the signal rate image by this

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -157,7 +157,7 @@ def ensure_dir_exists(fullpath):
         os.makedirs(fullpath)
 
 
-def expand_environment_variable(variable_name):
+def expand_environment_variable(variable_name, offline=False):
     """ Expand an environment variable and check that the directory exists
 
     Parameters
@@ -178,10 +178,11 @@ def expand_environment_variable(variable_name):
                           "input files needed for the simulation. "
                           "These files must be downloaded separately "
                           "from the Mirage package.".format(variable_name)))
-    if not os.path.isdir(variable_directory):
-        raise FileNotFoundError(("The directory contained in the {} "
-                                 "environment variable: {} does not exist or "
-                                 "is not accessible.".format(variable_name, variable_directory)))
+    if not offline:
+        if not os.path.isdir(variable_directory):
+            raise FileNotFoundError(("The directory contained in the {} "
+                                     "environment variable: {} does not exist or "
+                                     "is not accessible.".format(variable_name, variable_directory)))
     return variable_directory
 
 

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -157,6 +157,34 @@ def ensure_dir_exists(fullpath):
         os.makedirs(fullpath)
 
 
+def expand_environment_variable(variable_name):
+    """ Expand an environment variable and check that the directory exists
+
+    Parameters
+    ----------
+    variable_name : str
+        Environment variable name
+
+    Returns
+    -------
+    variable_directory : str
+        Path pointed to by the environment variable
+    """
+    variable_directory = os.environ.get(variable_name)
+    if variable_directory is None:
+        raise ValueError(("WARNING: {} environment variable is not set. "
+                          "This must be set to the base directory "
+                          "containing the darks, cosmic ray, PSF, etc "
+                          "input files needed for the simulation. "
+                          "These files must be downloaded separately "
+                          "from the Mirage package.".format(variable_name)))
+    if not os.path.isdir(variable_directory):
+        raise FileNotFoundError(("WARNING: The directory contained in the {} "
+                                 "environment variable: {} does not exist or "
+                                 "is not accessible.".format(variable_name, variable_directory)))
+    return variable_directory
+
+
 def get_siaf():
     '''Return a dictionary that holds the contents of the SIAF config
     file.

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -172,14 +172,14 @@ def expand_environment_variable(variable_name):
     """
     variable_directory = os.environ.get(variable_name)
     if variable_directory is None:
-        raise ValueError(("WARNING: {} environment variable is not set. "
+        raise ValueError(("{} environment variable is not set. "
                           "This must be set to the base directory "
                           "containing the darks, cosmic ray, PSF, etc "
                           "input files needed for the simulation. "
                           "These files must be downloaded separately "
                           "from the Mirage package.".format(variable_name)))
     if not os.path.isdir(variable_directory):
-        raise FileNotFoundError(("WARNING: The directory contained in the {} "
+        raise FileNotFoundError(("The directory contained in the {} "
                                  "environment variable: {} does not exist or "
                                  "is not accessible.".format(variable_name, variable_directory)))
     return variable_directory

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -165,7 +165,7 @@ class SimInput:
         self.tracking = 'sidereal'
 
         # Expand the MIRAGE_DATA environment variable
-        self.datadir = expand_environment_variable(ENV_VAR)
+        self.datadir = expand_environment_variable(ENV_VAR, offline=offline)
 
         # Get the path to the 'MIRAGE' package
         self.modpath = pkg_resources.resource_filename('mirage', '')

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -555,12 +555,16 @@ class SimInput:
         """
         self.datadir = os.environ.get(ENV_VAR)
         if self.datadir is None:
-            raise ValueError(("WARNING: {} environment variable is not set."
-                              "This must be set to the base directory"
-                              "containing the darks, cosmic ray, PSF, etc"
-                              "input files needed for the simulation."
-                              "These files must be downloaded separately"
+            raise ValueError(("WARNING: {} environment variable is not set. "
+                              "This must be set to the base directory "
+                              "containing the darks, cosmic ray, PSF, etc "
+                              "input files needed for the simulation. "
+                              "These files must be downloaded separately "
                               "from the Mirage package.".format(ENV_VAR)))
+        if not os.path.isdir(self.datadir):
+            raise FileNotFoundError(("WARNING: The directory contained in the {} "
+                                     "environment variable: {} does not exist or "
+                                     "is not accessible.".format(ENV_VAR, self.datadir)))
 
     def find_ipc_file(self, inputipc):
         """Given a list of potential IPC kernel files for a given

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -104,7 +104,7 @@ import pkg_resources
 import pysiaf
 
 from ..apt import apt_inputs
-from ..utils.utils import calc_frame_time, ensure_dir_exists
+from ..utils.utils import calc_frame_time, ensure_dir_exists, expand_environment_variable
 from .generate_observationlist import get_observation_dict
 from ..constants import NIRISS_PUPIL_WHEEL_ELEMENTS, NIRISS_FILTER_WHEEL_ELEMENTS
 
@@ -165,7 +165,7 @@ class SimInput:
         self.tracking = 'sidereal'
 
         # Expand the MIRAGE_DATA environment variable
-        self.expand_env_var()
+        self.datadir = expand_environment_variable(ENV_VAR)
 
         # Get the path to the 'MIRAGE' package
         self.modpath = pkg_resources.resource_filename('mirage', '')
@@ -548,23 +548,6 @@ class SimInput:
                                             visit_group, parallel_sequence_id, activity_id,
                                             exposure)
         return base
-
-    def expand_env_var(self):
-        """ Expand the MIRAGE_DATA environment variable
-        so that reference files can be found
-        """
-        self.datadir = os.environ.get(ENV_VAR)
-        if self.datadir is None:
-            raise ValueError(("WARNING: {} environment variable is not set. "
-                              "This must be set to the base directory "
-                              "containing the darks, cosmic ray, PSF, etc "
-                              "input files needed for the simulation. "
-                              "These files must be downloaded separately "
-                              "from the Mirage package.".format(ENV_VAR)))
-        if not os.path.isdir(self.datadir):
-            raise FileNotFoundError(("WARNING: The directory contained in the {} "
-                                     "environment variable: {} does not exist or "
-                                     "is not accessible.".format(ENV_VAR, self.datadir)))
 
     def find_ipc_file(self, inputipc):
         """Given a list of potential IPC kernel files for a given

--- a/tests/test_fgs_imaging.py
+++ b/tests/test_fgs_imaging.py
@@ -21,6 +21,6 @@ os.environ['TEST_FGS_DATA'] = os.path.join(os.path.dirname(__file__), 'test_data
 
 
 def test_fgs_imaging():
-    m = im.ImgSim()
+    m = im.ImgSim(offline=True)
     m.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/FGS/fgs_imaging_example.yaml')
     m.create()

--- a/tests/test_nircam_imaging.py
+++ b/tests/test_nircam_imaging.py
@@ -22,6 +22,6 @@ os.environ['TEST_NIRCAM_DATA'] = os.path.join(os.path.dirname(__file__), 'test_d
 
 
 def test_nircam_imaging():
-    m = im.ImgSim()
+    m = im.ImgSim(offline=True)
     m.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRCam/nircam_imaging_example.yaml')
     m.create()

--- a/tests/test_niriss_imaging.py
+++ b/tests/test_niriss_imaging.py
@@ -21,6 +21,6 @@ os.environ['TEST_NIRISS_DATA'] = os.path.join(os.path.dirname(__file__), 'test_d
 
 
 def test_niriss_imaging():
-    m = im.ImgSim()
+    m = im.ImgSim(offline=True)
     m.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS/niriss_imaging_example.yaml')
     m.create()

--- a/tests/test_niriss_imaging_modes.py
+++ b/tests/test_niriss_imaging_modes.py
@@ -11,14 +11,14 @@ Use
 Description of the test:
 ------------------------
 
-The test runs mirage for the same NIRISs imaging scene in regular imaging and 
-in the NRM imaging mode.  There is only one star in the scene of the same 
-magnitude in both instances.  The code reads the two pointsource output list 
-files to get the count rates for the two cases and verifies that the proper 
-scaling has been used.  The count rate ratio should be exactly 0.15/0.84 
-between the NRM case and the regular imaging case.  Due to limitations on the 
-precision of the output format, the values differ by a fraction amount of 
-about 1.e-08 in my test.  Here the threhsold for agreement is a deviaiton of 
+The test runs mirage for the same NIRISs imaging scene in regular imaging and
+in the NRM imaging mode.  There is only one star in the scene of the same
+magnitude in both instances.  The code reads the two pointsource output list
+files to get the count rates for the two cases and verifies that the proper
+scaling has been used.  The count rate ratio should be exactly 0.15/0.84
+between the NRM case and the regular imaging case.  Due to limitations on the
+precision of the output format, the values differ by a fraction amount of
+about 1.e-08 in my test.  Here the threhsold for agreement is a deviaiton of
 less than 1.e-06.
 
 """
@@ -27,13 +27,13 @@ import os
 import pytest
 import numpy
 
-from mirage import imaging_simulator 
+from mirage import imaging_simulator
 
 # os.environ['MIRAGE_DATA'] = ''
 os.environ['TEST_DATA'] = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS')
 
 def test_niriss_imaging():
-    nis = imaging_simulator.ImgSim()
+    nis = imaging_simulator.ImgSim(offline=True)
     nis.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS/niriss_imaging_test.yaml')
     nis.create()
     nis.paramfile = os.path.join(os.path.dirname(__file__), 'test_data/NIRISS/niriss_nrm_test.yaml')


### PR DESCRIPTION
This PR pushes the MIRAGE_DATA environment variable expansion function into `utils.py`, as it is called in multiple places within Mirage. It also adds a check that the directory specified by the environment variable exists. It was previously checking that the environment variable was set, but in the case where the specified directory didn't exist (or wasn't accessible due to forgetting to log in to the VPN), the resulting exception wasn't very helpful. This PR changes that so that a more informative error statement is given.