### PR TITLE
Add a check for colons in some text entries of yaml file

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2773,19 +2773,52 @@ class Catalog_seed():
             qy = [float(s) for s in strinstrumentqy]
             self.countvalues = dict(zip(instrumentfilternames, instrumentmag15countrates))
             self.qydict = dict(zip(instrumentfilternames, qy))
-
         except:
-            print("WARNING: Unable to read in {}.".format(self.params['Reffiles']['phot']))
-            sys.exit()
+            raise IOError("WARNING: Unable to read in {}.".format(self.params['Reffiles']['phot']))
 
     def readParameterFile(self):
-        # read in the parameter file
+        """Read in the parameter file"""
+        # List of fields in the yaml file to check for extra colons
+        search_cats = ['title:', 'PI_Name:', 'Science_category:', 'observation_label:']
+
+        # Open the yaml file and check for the presence of extra colons
+        adjust_file = False
+        with open(self.paramfile) as infile:
+            read_data = infile.readlines()
+            for i, line in enumerate(read_data):
+                for search_term in search_cats:
+                    if search_term in line:
+                        idx = []
+                        hashidx = [200]
+                        for m in re.finditer(':', line):
+                            idx.append(m.start())
+                        for mm in re.finditer('#', line):
+                            hashidx.append(mm.start())
+                        num = np.sum(np.array(idx) < min(hashidx))
+                        if num > 1:
+                            adjust_file = True
+                            later_string = line[idx[0]+1:]
+                            later_string = later_string.replace(':', ',')
+                            newline = line[0: idx[0]+1] + later_string
+                            read_data[i] = newline
+
+        if adjust_file:
+            # Make a copy of the original file and then delete it
+            yaml_copy = 'orig_{}'.format(self.paramfile)
+            shutil.copy2(self.paramfile, yaml_copy)
+            os.remove(self.paramfile)
+
+            # Write the adjusted lines to a new copy of the input file
+            with open(self.paramfile, 'w') as f:
+                for item in read_data:
+                    f.write("{}\n".format(item))
+
+        # Load the yaml file
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.load(infile)
-        except:
-            print("WARNING: unable to open {}".format(self.paramfile))
-            sys.exit()
+        except (ScannerError, FileNotFoundError, IOError) as e:
+            print(e)
 
     def check_params(self):
         """Check input parameters for expected datatypes, values"""

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2813,7 +2813,7 @@ class Catalog_seed():
             # Write the adjusted lines to a new copy of the input file
             with open(self.paramfile, 'w') as f:
                 for item in read_data:
-                    f.write("{}\n".format(item))
+                    f.write("{}".format(item))
 
         # Load the yaml file
         try:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -12,6 +12,8 @@ import sys
 import glob
 import os
 import copy
+import re
+import shutil
 
 import math
 import yaml


### PR DESCRIPTION
Any colons in the Proposal title will cause `yaml.load` to fail.