### PR TITLE
Fix CR rate: multiply by frametime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
     global:
         - MAIN_CMD='python setup.py'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx'
+        - CONDA_DEPENDENCIES='pytest sphinx'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -957,6 +957,9 @@ class Observation():
         # Calculate the rate of cosmic ray hits expected per frame
         self.get_cr_rate()
 
+        # Multiply by the frametime to get probability per pixel per frame
+        self.crrate = self.crrate * self.frametime
+
         # Read in saturation file
         if self.params['Reffiles']['saturation'] is not None:
             self.read_saturation_file()
@@ -1793,7 +1796,6 @@ class Observation():
         if "FLARES" in self.params["cosmicRay"]["library"]:
             self.crrate = 0.10546
 
-        self.crrate = self.crrate/self.frametime
         if self.crrate > 0.:
             print("Base cosmic ray probability per pixel per second: {}".format(self.crrate))
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
                   },
     install_requires=[
         'astropy>=1.2',
-        'numpy>=1.9',
+        'numpy<=1.15',
         'matplotlib>=1.4.3',
         'lxml>=3.6.4',
         'asdf>=1.2.0',


### PR DESCRIPTION
This PR fixes a typo in determining the cosmic ray rate. Previously the rate (CR/pixel/second) was being divided by the single frame exposure time. This changes it so that Mirage is multiplying by the frame time in order to arrive at the CR rate per pixel per frame.

Closes #267 