### PR TITLE
[WIP] Update setup.py to avoid future conda vs pip installation collisions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,13 +128,14 @@ setup(
                   },
     install_requires=[
         'astropy>=3.1',
-        'numpy>=1.13',
-        'matplotlib>=1.4.3',
+        'numpy==1.15.4',
+        'matplotlib>=3.0.2',
         'lxml>=3.6.4',
         'asdf>=2.3.2',
         'scipy>=1.0',
         'photutils>=0.6.0',
         'pysiaf>=0.2.5',
+        'pyyaml>=3.10',
         'jwst @ git+https://github.com/spacetelescope/jwst@stable#egg=jwst'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -83,17 +83,17 @@ class PyTest(TestCommand):
 
 
 # make sure jwst is available
-try:
-    import jwst
-except ImportError:
-    try:
-        subprocess.check_call(['git', 'clone',
-                               'https://github.com/spacetelescope/jwst.git'])
-        sys.path.insert(1, 'jwst')
-        # import jwst
-    except subprocess.CalledProcessError as e:
-        print(e)
-        exit(1)
+#try:
+#    import jwst
+#except ImportError:
+#    try:
+#        subprocess.check_call(['git', 'clone',
+#                               'https://github.com/spacetelescope/jwst.git'])
+#        sys.path.insert(1, 'jwst')
+#        # import jwst
+#    except subprocess.CalledProcessError as e:
+#        print(e)
+#        exit(1)
 
 
 setup(
@@ -127,15 +127,19 @@ setup(
                              'config/*.*']
                   },
     install_requires=[
-        'astropy>=1.2',
-        'numpy<=1.15',
+        'astropy>=3.1',
+        'numpy>=1.13',
         'matplotlib>=1.4.3',
         'lxml>=3.6.4',
-        'asdf>=1.2.0',
-        'scipy>=0.17',
-        'photutils>=0.4.0',
-        'pysiaf>=0.1.11'
+        'asdf>=2.3.2',
+        'scipy>=1.0',
+        'photutils>=0.6.0',
+        'pysiaf>=0.2.5',
+        'jwst @ git+https://github.com/spacetelescope/jwst@stable#egg=jwst'
     ],
+
+    tests_require=['pytest'],
+
     include_package_data=True,
     cmdclass={
         'test': PyTest,


### PR DESCRIPTION
I'm playing around in this PR to try and limit conda vs pip installation collisions, which just gave us some trouble in the previous PR (). Apparently astropy ci-helpers installs a bunch of packages via conda, but other packages (in `install_requires` in setup.py) are being installed via pip. In some cases the code is installed in different locations, which can lead to a case of python not being able to find a package. 

I'm testing out moving installations to `install_requires` and hoping that nothing else breaks. 