### PR TITLE
Add support for 8NIRSPEC dither pattern

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -490,6 +490,10 @@ class ReadAPTXML():
                 if observation_dict[dither_key_name] in ['2TIGHTGAPS']:
                     number_of_primary_dithers = observation_dict[dither_key_name][0]
 
+                # Special case for 8NIRSPEC dither pattern
+                if number_of_primary_dithers == '8NIRSPEC':
+                    number_of_primary_dithers = '8'
+
             else:
                 print('Primary dither element {} not found, use default primary dithers value (1).'.format(dither_key_name))
 


### PR DESCRIPTION
This PR introduces new code to allow the APT reader to read in observations made using the 8NIRSPEC dither pattern.