### PR TITLE
Add explicit call to disperse method

### DIFF
--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -174,6 +174,7 @@ class WFSSSim():
                                extrapolate_SED=self.extrapolate_SED, SED_file=self.SED_file,
                                SBE_save=self.source_stamps_file)
         disp_seed.observation(orders=orders)
+        disp_seed.disperse(orders=orders)
         disp_seed.finalize(Back=background_file)
 
         # Get gain map


### PR DESCRIPTION
This PR updates the wfss_simulator to include an explicit call to the `disperse` method. This is necessary due to an update to the NIRCAM_Gsim package in order to allow for cached results.