### PR TITLE
Update obs_generator.py to get the CR rate correct.

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1017,9 +1017,6 @@ class Observation():
         # Calculate the rate of cosmic ray hits expected per frame
         self.get_cr_rate()
 
-        # Multiply by the frametime to get probability per pixel per frame
-        self.crrate = self.crrate * self.frametime
-
         # Read in saturation file
         if self.params['Reffiles']['saturation'] is not None:
             self.read_saturation_file()


### PR DESCRIPTION
As discovered by Chris Willott, the code was multiplying the cosmic ray rate per pixel per second by the frame time twice, once on line 938 and once on line 1021.  Hence the rates are too high for full frame and too low for small subarrays.  The new change removes the second multiplication by the frame time.