### PR TITLE
Change default CR rate to SUNMAX

### DIFF
--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1356,8 +1356,8 @@ class SimInput:
             f.write('cosmicRay:\n')
             cosmic_ray_path = os.path.join(self.datadir, instrument.lower(), 'cosmic_ray_library')
             f.write('  path: {}               # Path to CR library\n'.format(cosmic_ray_path))
-            f.write('  library: SUNMIN    # Type of cosmic rayenvironment (SUNMAX, SUNMIN, FLARE)\n')
-            f.write('  scale: 1.5     # Cosmic ray scaling factor\n')
+            f.write('  library: SUNMAX    # Type of cosmic rayenvironment (SUNMAX, SUNMIN, FLARE)\n')
+            f.write('  scale: 1.0     # Cosmic ray scaling factor\n')
             # temporary tweak here to make it work with NIRISS
             detector_label = input['detector']
 


### PR DESCRIPTION
This PR updates the default CR rate placed in the yaml files by the `yaml_generator` to be 1.0 * the SUNMAX. This is lower than the previous default, which was 1.5*SUNMIN.  The updated value will allow the pipeline ramp-fitting step to run more quickly.