### PR TITLE
Use dev versions of webbpsf and poppy: Update travis and install docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ before_install:
 
 install:
     - conda env update -f=environment.yml
+    # Install development versions of webbpsf and poppy
+    - git clone git://github.com/spacetelescope/poppy.git
+    - git clone git://github.com/spacetelescope/webbpsf.git
+    - pip install -e poppy/
+    - pip install -e webbpsf/
+    # Install MIRaGe package
     - pip install -e .
 
 script:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,10 +21,26 @@ Once the environment is built, activate it.::
     conda activate mirage
 
 
+Install Development-Version Dependencies
+----------------------------------------
+
+Unfortunately, there are conflicts with some of MIRaGe's dependencies that have not been addressed in the latest pip and conda versions. So, in order for MIRaGe to work, we need to download and install the development versions of those packages. (This will no longer be necessary once both packages make new releases.)
+
+To do this, first clone the git repositories for both the ``poppy`` and ``webbpsf`` packages somewhere on your computer::
+
+    git clone git://github.com/spacetelescope/poppy.git
+    git clone git://github.com/spacetelescope/webbpsf.git
+
+Then, install both ``poppy`` and ``webbpsf``::
+
+    pip install -e /path/to/poppy/
+    pip install -e /path/to/webbpsf/
+
+
 Install MIRaGe
 --------------
 
-To install the `mirage` package, first clone the repository:::
+Finally, to install the `mirage` package itself, first clone the repository:::
 
     git clone https://github.com/spacetelescope/mirage.git
 


### PR DESCRIPTION
This PR addresses a problem installing MIRaGe that was brought to my attention by @NorPirzkal.

Until @shanosborne and @mperrin publish the latest releases of `webbpsf` and `poppy`, MIRaGe has to install the dev versions of those two packages. Otherwise `poppy` throws and error with the dev version of `astropy`.

I have updated the Travis file to reflect this (should solve all of the commits that have been failing) and updated the installation docs, as well.