### PR TITLE
Slight re-order, and make installation instructions more explicit.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,13 +12,22 @@ First, be sure that your conda installation is up to date. Exit any currently ac
     conda deactivate
     conda update conda
 
-Next, use the environment file to create a new environment. Give your environment a name you will recognize (here we chose just ``mirage``).::
+Get a copy of the MIRaGe repository::
 
+    git clone https://github.com/spacetelescope/mirage.git
+
+Move into the mirage directory and use the environment file to create a new environment. Give your environment a name you will recognize (here we choose ``mirage``)::
+
+    cd mirage
     conda env create -f environment.yml -n mirage
 
 Once the environment is built, activate it.::
 
     conda activate mirage
+
+Move out of the mirage directory before cloning and installing any of the depenencies.::
+
+    cd ../
 
 
 Install Development-Version Dependencies
@@ -26,28 +35,36 @@ Install Development-Version Dependencies
 
 Unfortunately, there are conflicts with some of MIRaGe's dependencies that have not been addressed in the latest pip and conda versions. So, in order for MIRaGe to work, we need to download and install the development versions of those packages. (This will no longer be necessary once both packages make new releases.)
 
-To do this, first clone the git repositories for both the ``poppy`` and ``webbpsf`` packages somewhere on your computer::
+If you do not have a copy of the ``poppy`` or ``webbpsf`` git repositories, clone them::
 
     git clone git://github.com/spacetelescope/poppy.git
     git clone git://github.com/spacetelescope/webbpsf.git
 
+If you already have a local copy of these packages, first make sure you have the most up-to-date version. Here we assume that you have previously cloned
+the repository and that the ``origin`` remote points to the package. This is git's default behavior. If in doubt, simply delete the local copies and re-clone
+using the commands above.::
+
+    cd poppy
+    git fetch origin master
+    git pull origin master
+
+    cd ../webbpsf
+    git fetch origin master
+    git pull origin master
+    cd ../
+
 Then, install both ``poppy`` and ``webbpsf``::
 
-    pip install -e /path/to/poppy/
-    pip install -e /path/to/webbpsf/
+    pip install -e poppy
+    pip install -e webbpsf
 
 
 Install MIRaGe
 --------------
 
-Finally, to install the `mirage` package itself, first clone the repository:::
+Next, install MIRaGe::
 
-    git clone https://github.com/spacetelescope/mirage.git
-
-Then, install the package:::
-
-    cd mirage
-    pip install .
+    pip install -e mirage
 
 This ``pip`` command will also always install all required dependencies (though in this case, they were already installed when we built our conda environment). If you want to know what dependencies MIRaGe requires,, the list of packages can
 be viewed in the ``install_requires`` part of this repository's `setup.py file <../setup.py>`_.
@@ -60,9 +77,29 @@ If you plan to use MIRaGe to simulate **Wide Field Slitless (WFSS)** observation
 - `NIRCam_Gsim <https://github.com/npirzkal/NIRCAM_Gsim>`_
 - `GRISMCONF <https://github.com/npirzkal/GRISMCONF>`_
 
-For each of these packages, clone or download the linked repository, cd into the top-level directory, and then install using:::
+For each of these packages, download the repository if you do not have a local copy::
 
-    pip install .
+    git clone https://github.com/npirzkal/NIRCAM_Gsim.git
+    git clone https://github.com/npirzkal/GRISMCONF.git
+
+Or, if you already have a local copy, make sure you have the most recent version. Here we assume that you have previously cloned
+the repository and that the ``origin`` remote points to the package. This is git's default behavior. If in doubt, simply delete the local copies and re-clone
+using the commands above.::
+
+    cd ../NIRCAM_Gsim
+    git fetch upstream master
+    git pull upstream master
+    cd ../
+
+    cd ../GRISMCONF
+    git fetch upstream master
+    git pull upstream master
+    cd ../
+
+Then install::
+
+    pip install -e NIRCAM_Gsim
+    pip install -e GRISMCONF
 
 .. _reference_files:
 


### PR DESCRIPTION
This PR makes some changes to the installation instructions on ReadTheDocs based on observations when sitting with @swara13 and creating a new environment from scratch.

I've moved up the command that clones the Mirage repo, since this needs to be done before using the environment file to create an environment. 

I've also added some commands that describe how to update already-cloned copies of dependencies. This is based on me attempting to follow the installation instructions using my local copies of poppy and webbpsf, where I forgot to first pull down the latest changes.

@laurenmarietta what do you think of this? I wanted to add some text about updating existing local copies of dependencies, but this can quickly go down the rabbit hole of explaining various details about git, which I wasn't excited about. So I tried to write some text that can cover the basics and then I put in the idea that if you're confused you can delete and re-clone.