### PR TITLE
Add psf wing files for niriss and fgs

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -525,12 +525,14 @@ class Catalog_seed():
                                        'Reffiles-flux_cal': 'niriss_zeropoints.list',
                                        'Reffiles-crosstalk': 'niriss_xtalk_zeros.txt',
                                        'Reffiles-readpattdefs': 'niriss_readout_pattern.txt',
-                                       'Reffiles-filter_throughput': 'placeholder.txt'},
+                                       'Reffiles-filter_throughput': 'placeholder.txt',
+                                       'simSignals-psf_wing_threshold_file': 'niriss_psf_wing_rate_thresholds.txt'},
                             'fgs': {'Reffiles-subarray_defs': 'guider_subarrays.list',
                                     'Reffiles-flux_cal': 'guider_zeropoints.list',
                                     'Reffiles-crosstalk': 'guider_xtalk_zeros.txt',
                                     'Reffiles-readpattdefs': 'guider_readout_pattern.txt',
-                                    'Reffiles-filter_throughput': 'placeholder.txt'}}
+                                    'Reffiles-filter_throughput': 'placeholder.txt',
+                                    'simSignals-psf_wing_threshold_file': 'fgs_psf_wing_rate_thresholds.txt'}}
         config_files = all_config_files[self.params['Inst']['instrument'].lower()]
 
         for key1 in pathdict:


### PR DESCRIPTION
This PR adds references to the PSF wing files necessary for NIRISS and FGS simulations that use the gridded PSF libraries.

@KevinVolkSTScI, I just used this branch and ran NIRISS simulations using a pupil wheel filter and a filter wheel filter. In both cases the correct PSF files were selected. Can you confirm that this is true with your test case? I didn't make any changes to the psf selection code from what is currently in the master branch.

Closes #322 