### PR TITLE
Extended source countrates

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -525,12 +525,14 @@ class Catalog_seed():
                                        'Reffiles-flux_cal': 'niriss_zeropoints.list',
                                        'Reffiles-crosstalk': 'niriss_xtalk_zeros.txt',
                                        'Reffiles-readpattdefs': 'niriss_readout_pattern.txt',
-                                       'Reffiles-filter_throughput': 'placeholder.txt'},
+                                       'Reffiles-filter_throughput': 'placeholder.txt',
+                                       'simSignals-psf_wing_threshold_file': 'niriss_psf_wing_rate_thresholds.txt'},
                             'fgs': {'Reffiles-subarray_defs': 'guider_subarrays.list',
                                     'Reffiles-flux_cal': 'guider_zeropoints.list',
                                     'Reffiles-crosstalk': 'guider_xtalk_zeros.txt',
                                     'Reffiles-readpattdefs': 'guider_readout_pattern.txt',
-                                    'Reffiles-filter_throughput': 'placeholder.txt'}}
+                                    'Reffiles-filter_throughput': 'placeholder.txt',
+                                    'simSignals-psf_wing_threshold_file': 'fgs_psf_wing_rate_thresholds.txt'}}
         config_files = all_config_files[self.params['Inst']['instrument'].lower()]
 
         for key1 in pathdict:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2986,7 +2986,7 @@ class Catalog_seed():
 
             # First create the galaxy
             stamp = self.create_galaxy(entry['radius'], entry['ellipticity'], entry['sersic_index'],
-                                       xposang*np.pi/180., entry['counts_per_frame_e'])
+                                       xposang*np.pi/180., entry['countrate_e/s'])
 
             # If the stamp image is smaller than the PSF in either
             # dimension, embed the stamp in an array that matches
@@ -3300,7 +3300,7 @@ class Catalog_seed():
         for entry, stamp in zip(extSources, extStamps):
             stamp_dims = stamp.shape
 
-            stamp *= entry['counts_per_frame_e']
+            stamp *= entry['countrate_e/s']
 
             # If the stamp needs to be convolved with the NIRCam PSF,
             # create the correct PSF  here and read it in


### PR DESCRIPTION
This PR fixes a bug in which the count rates of the galaxy and extended stamp images were being set to the number of counts per frame. The code has been updated to use counts per second instead, in line with the point sources and what Mirage expects.

Closes #329 