### PR TITLE
Remove oversampling squared flux scaling in gridded library

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2064,14 +2064,8 @@ class Catalog_seed():
                                                           coord_sys='full_frame',
                                                           ignore_detector=ignore_detector)
 
-            # PSFs in GriddedPSFModel by default have a total signal equal
-            # to the square of the oversampling factor. They must be scaled
-            # down by that factor to be equivalent to the webbpsf output,
-            # where the summed signal is close to 1.0
-            flux_scaling_factor = self.psf_library.oversampling**2
-
             # Step 4
-            full_psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=flux_scaling_factor,
+            full_psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=1.0,
                                                  x_0=xc_core, y_0=yc_core)
             k1 = k1c
             l1 = l1c
@@ -2131,14 +2125,8 @@ class Catalog_seed():
                                                               psf_core_half_width_x, psf_core_half_width_y,
                                                               coord_sys='full_frame', ignore_detector=ignore_detector)
 
-                # PSFs in GriddedPSFModel by default have a total signal equal
-                # to the square of the oversampling factor. They must be scaled
-                # down by that factor to be equivalent to the webbpsf output,
-                # where the summed signal is close to 1.0
-                flux_scaling_factor = self.psf_library.oversampling**2
-
                 # Step 4
-                psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=flux_scaling_factor,
+                psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=1.0,
                                                 x_0=xc_core, y_0=yc_core)
 
                 # Step 5


### PR DESCRIPTION
This PR changes the flux scaling that is done to the gridded PSF library that is read in. Previously, there was a discrepancy between the assumption in `photutils` that a gridded PSF library has a total signal level of `oversampling^2`, while libraries produced by `webbpsf` had a total signal of 1.0. In that case, Mirage would read in a Webbpsf-generated library and scale the PSF by a factor of oversampling^2.

Webbpsf has now been updated to scale the signal in the library when it is created, so this scaling is no longer necessary in Mirage.

See [webbpsf PR 311](https://github.com/spacetelescope/webbpsf/pull/311) for details.

Along with this update, the gridded PSF libraries that Mirage uses will have to be updated.