### PR TITLE
Support use of WLP4 filter and weak lens PSFs

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -850,6 +850,10 @@ def get_filters(pointing_info):
     """Return a dictionary of instruments and filters contained within a
     pointing dictionary from an APT file.
 
+    This function is aware that sometimes filters are installed in pupil wheels,
+    and also that some wheels contain non-filter items such as the NIRCam
+    weak lenses. It will return a list of those items that are indeed spectral bandpass filters.
+
     Parameters
     ----------
     pointing_info : dict
@@ -878,6 +882,9 @@ def get_filters(pointing_info):
 
             filter_list = list(set(short_pupils))
             filter_list.remove('CLEAR')
+            for wfsc_optic in  ['WLP8', 'WLM8', 'GDHS0', 'GDHS60']:
+                if wfsc_optic in filter_list:
+                    filter_list.remove(wfsc_optic)
 
             filter_list.extend(list(set(long_pupils)))
             filter_list.remove('CLEAR')

--- a/mirage/catalogs/create_catalog.py
+++ b/mirage/catalogs/create_catalog.py
@@ -1338,7 +1338,7 @@ def make_filter_names(instrument, filters):
     niriss_filter_names = ['niriss_{}_magnitude'.format(filt.lower()) for filt in niriss_filters]
     nircam_filters = ['F070W', 'F090W', 'F115W', 'F140M', 'F150W', 'F150W2',
                       'F162M', 'F164N', 'F182M', 'F187N', 'F200W', 'F210M',
-                      'F212N', 'F250M', 'F277W', 'F300M', 'F322W2', 'F323N',
+                      'F212N', 'WLP4',  'F250M', 'F277W', 'F300M', 'F322W2', 'F323N',
                       'F335M', 'F356W', 'F360M', 'F405N', 'F410M', 'F430M',
                       'F444W', 'F460M', 'F466N', 'F470N', 'F480M']
     nircam_filter_names = ['nircam_{}_magnitude'.format(filt.lower()) for filt in nircam_filters]

--- a/mirage/config/nircam_filter_pupil_pairings.list
+++ b/mirage/config/nircam_filter_pupil_pairings.list
@@ -12,6 +12,7 @@ F187N    F187N           CLEAR
 F200W    F200W           CLEAR
 F210M    F210M           CLEAR
 F212N    F212N           CLEAR
+WLP4     WLP4            CLEAR
 F250M    F250M           CLEAR
 F277W    F277W           CLEAR
 F300M    F300M           CLEAR

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -291,7 +291,7 @@ def get_library_file(instrument, detector, filt, pupil, wfe, wfe_group,
             file_filt = header['FILTER'].upper()
 
             try:
-                file_pupil = header['PUPIL_MASK'].upper()
+                file_pupil = header['PUPIL'].upper()
             except KeyError:
                 # If no pupil mask value is present, then assume the CLEAR is
                 # being used


### PR DESCRIPTION
 - Add WLP4 to a list of NIRCam filters in two different places
 - Ignore weak lenses +8 and -8 and the DHS gratings when finding lists of filter names. 

Related to #340  and #341.  This still won't work on its own until the rest of #340 is taken care of. 