### PR TITLE
Fix pointing info and NIRISS PSF wings

### DIFF
--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -274,6 +274,9 @@ def get_library_file(instrument, detector, filt, pupil, wfe, wfe_group,
     pupil = pupil.upper()
     wfe = wfe.lower()
 
+    # set default
+    file_wfe = ''
+
     # handle the NIRISS NRM case
     if pupil == 'NRM':
         pupil = 'MASK_NRM'

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -437,7 +437,6 @@ def get_psf_wings(instrument, detector, filtername, pupilname, wavefront_error, 
     # opening and examining all files in the library.
     if wings_file is None:
         # Find the file containing the PSF wings
-        print('Looking for PSF wings file')
         wings_file = get_library_file(instrument, detector, filtername, pupilname,
                                       wavefront_error, wavefront_error_group, library_path, wings=True)
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -40,6 +40,7 @@ import numpy as np
 from astropy.io import fits, ascii
 from astropy.table import Table
 from astropy.time import Time, TimeDelta
+import pysiaf
 
 from . import unlinearize
 from ..utils import read_fits, utils, siaf_interface
@@ -2585,8 +2586,10 @@ class Observation():
         outModel.meta.target.dec = self.dec
 
         # ra_v1, dec_v1, and pa_v3 are not used by the level 2 pipelines
-        outModel.meta.pointing.ra_v1 = self.ra
-        outModel.meta.pointing.dec_v1 = self.dec
+        # compute pointing of V1 axis
+        pointing_ra_v1, pointing_dec_v1 = pysiaf.rotations.pointing(self.attitude_matrix, 0., 0.) 
+        outModel.meta.pointing.ra_v1 = pointing_ra_v1
+        outModel.meta.pointing.dec_v1 = pointing_dec_v1
         outModel.meta.pointing.pa_v3 = self.params['Telescope']['rotation']
 
         ramptime = self.frametime * (1 + self.params['Readout']['ngroup'] *

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2587,7 +2587,7 @@ class Observation():
 
         # ra_v1, dec_v1, and pa_v3 are not used by the level 2 pipelines
         # compute pointing of V1 axis
-        pointing_ra_v1, pointing_dec_v1 = pysiaf.rotations.pointing(self.attitude_matrix, 0., 0.) 
+        pointing_ra_v1, pointing_dec_v1 = pysiaf.rotations.pointing(self.attitude_matrix, 0., 0.)
         outModel.meta.pointing.ra_v1 = pointing_ra_v1
         outModel.meta.pointing.dec_v1 = pointing_dec_v1
         outModel.meta.pointing.pa_v3 = self.params['Telescope']['rotation']
@@ -2866,8 +2866,10 @@ class Observation():
         outModel[0].header['TARG_DEC'] = self.dec  # not correct
 
         # ra_v1, dec_v1, and pa_v3 are not used by the level 2 pipelines
-        outModel[0].header['RA_V1'] = self.ra
-        outModel[0].header['DEC_V1'] = self.dec
+        # compute pointing of V1 axis
+        pointing_ra_v1, pointing_dec_v1 = pysiaf.rotations.pointing(self.attitude_matrix, 0., 0.)
+        outModel[0].header['RA_V1'] = pointing_ra_v1
+        outModel[0].header['DEC_V1'] = pointing_dec_v1
         outModel[0].header['PA_V3'] = self.params['Telescope']['rotation']
 
         ramptime = self.frametime * (1 + self.params['Readout']['ngroup'] *

--- a/mirage/utils/set_telescope_pointing_separated.py
+++ b/mirage/utils/set_telescope_pointing_separated.py
@@ -490,7 +490,7 @@ def get_pointing_stub(obstart, obsend):
 
 def compute_local_roll(pa_v3, ra_ref, dec_ref, v2_ref, v3_ref):
     """
-    Computes the position angle of V3 (measured N to E) at the center af an aperture.
+    Computes the position angle of V3 (measured N to E) at the reference point of an aperture.
 
     Parameters
     ----------

--- a/mirage/utils/set_telescope_pointing_separated.py
+++ b/mirage/utils/set_telescope_pointing_separated.py
@@ -71,6 +71,7 @@ import sys
 
 import astropy.io.fits as fits
 import numpy as np
+import pysiaf
 #from jwst.lib.engdb_tools import (
 #    ENGDB_BASE_URL,
 #    ENGDB_Service,
@@ -90,15 +91,23 @@ Pointing_Quaternions = namedtuple(
 )
 
 
-def add_wcs(filename,roll=0.):
-    '''
+def add_wcs(filename, roll=0.):
+    """
     Given the name of a valid partially populated level 1b JWST file,
     determine the simple WCS parameters from the SIAF keywords in that
     file and the engineering parameters that contain information about
     the telescope pointing.
 
     It presumes all the accessed keywords are present (see first block).
-    '''
+
+    Parameters
+    ----------
+    filename : str
+        file name
+    roll : float
+        PA_V3 in degrees
+
+    """
     hdulist = fits.open(filename, 'update')
     pheader = hdulist[0].header
     fheader = hdulist[1].header
@@ -139,9 +148,13 @@ def add_wcs(filename,roll=0.):
 
     local_roll = compute_local_roll(roll, ra, dec, v2ref, v3ref)
     wcsinfo = (ra, dec, local_roll)
-    vinfo = (ra, dec, roll)
     crval1, crval2, pa_aper_deg = wcsinfo
-    v1_ra_deg, v1_dec_deg, v3_pa_deg = vinfo
+
+    # compute pointing of V1 axis
+    attitude_matrix = pysiaf.rotations.attitude(v2ref, v3ref, ra, dec, local_roll)
+    v1_ra_deg, v1_dec_deg = pysiaf.rotations.pointing(attitude_matrix, 0., 0.)
+    v3_pa_deg = roll
+
     pa_aper_deg = local_roll - vparity * v3idlyang
     #else:
     #    # compute relevant WCS information

--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -71,7 +71,7 @@ def get_siaf_information(siaf_instance, aperture_name, ra, dec, telescope_roll, 
         Dec value of pointing in degrees
 
     telescope_roll : float
-        Position angle of the telescope in degrees
+        PA_V3, Position angle of the telescope in degrees
 
     v2_arcsec : float
         The V2 value in arcseconds of the reference location for the

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1524,7 +1524,7 @@ class SimInput:
                 pav3_value = input['pav3']
             else:
                 pav3_value = input['PAV3']
-            f.write('  rotation: {}                    # y axis rotation (degrees E of N)\n'.format(pav3_value))
+            f.write('  rotation: {}                    # PA_V3 in degrees, i.e. the position angle of the V3 axis at V1 (V2=0, V3=0) measured from N to E.\n'.format(pav3_value))
             f.write('  tracking: {}   #Telescope tracking. Can be sidereal or non-sidereal\n'.format(self.tracking))
             f.write('\n')
             f.write('newRamp:\n')


### PR DESCRIPTION
This PR introduces a fix to the values of RA_V1 and DEC_V1 header values.

It also fixes a problem with the selection of NIRISS PSF wing files. This may have untested side-effects when simulating data with NIRCam. I verified that the code works for NIRISS and FGS.