### PR TITLE
Remove oversampling**2 scaling from evaluation of PSF libraries

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2120,15 +2120,9 @@ class Catalog_seed():
                                                           coord_sys='full_frame',
                                                           ignore_detector=ignore_detector)
 
-            # PSFs in GriddedPSFModel by default have a total signal equal
-            # to the square of the oversampling factor. They must be scaled
-            # down by that factor to be equivalent to the webbpsf output,
-            # where the summed signal is close to 1.0
-            flux_scaling_factor = self.psf_library_oversamp**2
-
             # Step 4
-            full_psf = library.evaluate(x=xpts_core, y=ypts_core, flux=flux_scaling_factor,
-                                                 x_0=xc_core, y_0=yc_core)
+            full_psf = library.evaluate(x=xpts_core, y=ypts_core, flux=1.0,
+                                        x_0=xc_core, y_0=yc_core)
             k1 = k1c
             l1 = l1c
 
@@ -2187,14 +2181,8 @@ class Catalog_seed():
                                                               psf_core_half_width_x, psf_core_half_width_y,
                                                               coord_sys='full_frame', ignore_detector=ignore_detector)
 
-                # PSFs in GriddedPSFModel by default have a total signal equal
-                # to the square of the oversampling factor. They must be scaled
-                # down by that factor to be equivalent to the webbpsf output,
-                # where the summed signal is close to 1.0
-                flux_scaling_factor = self.psf_library_oversamp**2
-
                 # Step 4
-                psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=flux_scaling_factor,
+                psf = self.psf_library.evaluate(x=xpts_core, y=ypts_core, flux=1.,
                                                 x_0=xc_core, y_0=yc_core)
 
                 # Step 5


### PR DESCRIPTION
This PR changes the flux scaling in the evaluation of the gridded PSF libraries from the square of the oversampling to 1.0. This is to bring Mirage in-line with the scaling now done in WebbPSF at the time of library creation after the merge of https://github.com/spacetelescope/webbpsf/pull/311. 

Now that Mirage's gridded PSF libraries have been re-created using the latest version of WebbPSF, this fix is critical.