### PR TITLE
Niriss config

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2257,12 +2257,12 @@ class Observation():
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.safe_load(infile)
-                if self.params['Inst']['instrument'].lower() == 'niriss':
-                    newfilter,newpupil = utils.check_niriss_filter(self.params['Readout']['filter'],self.params['Readout']['pupil'])
-                    self.params['Readout']['filter'] = newfilter
-                    self.params['Readout']['pupil'] = newpupil
         except FileNotFoundError as e:
             print("WARNING: unable to open {}".format(self.paramfile))
+        if self.params['Inst']['instrument'].lower() == 'niriss':
+            newfilter,newpupil = utils.check_niriss_filter(self.params['Readout']['filter'],self.params['Readout']['pupil'])
+            self.params['Readout']['filter'] = newfilter
+            self.params['Readout']['pupil'] = newpupil
 
     def read_saturation_file(self):
         """Read in saturation map from fits file"""

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -44,7 +44,7 @@ import pysiaf
 
 from mirage.ramp_generator import unlinearize
 from mirage.reference_files import crds_tools
-from mirage.utils import read_fits, utils, siaf_interface, check_niriss_filter
+from mirage.utils import read_fits, utils, siaf_interface
 from mirage.utils import set_telescope_pointing_separated as stp
 from mirage.utils.constants import EXPTYPES
 from mirage import version
@@ -2257,7 +2257,7 @@ class Observation():
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.safe_load(infile)
-                check_niriss_filter()
+                utils.check_niriss_filter()
         except FileNotFoundError as e:
             print("WARNING: unable to open {}".format(self.paramfile))
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -44,7 +44,7 @@ import pysiaf
 
 from mirage.ramp_generator import unlinearize
 from mirage.reference_files import crds_tools
-from mirage.utils import read_fits, utils, siaf_interface
+from mirage.utils import read_fits, utils, siaf_interface, check_niriss_filter
 from mirage.utils import set_telescope_pointing_separated as stp
 from mirage.utils.constants import EXPTYPES
 from mirage import version
@@ -2257,39 +2257,7 @@ class Observation():
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.safe_load(infile)
-                
-            # When the instrument is NIRISS, look at the FILTER/PUPIL combinations
-            # and make these work properly, the idea being that the user can put
-            # any of the 12 allowed filter names in the FILTER keyword and the code
-            # will take care of tracking which are actually in the FILTER wheel and
-            # which are in the PUPIL wheel.  Similarly, the PUPIL item can be
-            # CLEAR or CLEARP and the code will keep track of whether it 
-            # needs to be CLEAR or CLEARP for regular imaging.  One should be able
-            # to put NRM or GR150C or GR150R in the PUPIL parameter and the filter
-            # name in the FILTER parameter and get the right values out.
-            #
-            # There is a check on CLEARP plus pupil wheel filters because that would
-            # be an easy mistake to make when making files by hand as opposed to
-            # from an APT file.
-            #
-            # Note that this block of code also is found in catalog_seed_image.py as
-            # the .yaml file is read in again there.
-
-            if self.params['Inst']['instrument'].lower() == 'niriss':
-                pupil_slots = ['F090W','F115W','F140M','F150W','F158M','F200W']
-                filter_slots = ['F277W','F356W','F380M','F430M','F444W','F480M']
-                str1 = self.params['Readout']['filter']
-                str2 = self.params['Readout']['pupil']
-                if self.params['Readout']['filter'] in pupil_slots:
-                    self.params['Readout']['filter'] = str2
-                    self.params['Readout']['pupil'] = str1
-                    if self.params['Readout']['filter'] == 'CLEARP':
-                        self.params['Readout']['filter'] = 'CLEAR'
-                if self.params['Readout']['filter'] in filter_slots:
-                    if str2 == 'CLEAR':
-                        self.params['Readout']['pupil'] = 'CLEARP'
-
-                
+                check_niriss_filter()
         except FileNotFoundError as e:
             print("WARNING: unable to open {}".format(self.paramfile))
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2257,7 +2257,10 @@ class Observation():
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.safe_load(infile)
-                utils.check_niriss_filter()
+                if self.params['Inst']['instrument'].lower() == 'niriss':
+                    newfilter,newpupil = utils.check_niriss_filter(self.params['Readout']['filter'],self.params['Readout']['pupil'])
+                    self.params['Readout']['filter'] = newfilter
+                    self.params['Readout']['pupil'] = newpupil
         except FileNotFoundError as e:
             print("WARNING: unable to open {}".format(self.paramfile))
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2257,6 +2257,39 @@ class Observation():
         try:
             with open(self.paramfile, 'r') as infile:
                 self.params = yaml.safe_load(infile)
+                
+            # When the instrument is NIRISS, look at the FILTER/PUPIL combinations
+            # and make these work properly, the idea being that the user can put
+            # any of the 12 allowed filter names in the FILTER keyword and the code
+            # will take care of tracking which are actually in the FILTER wheel and
+            # which are in the PUPIL wheel.  Similarly, the PUPIL item can be
+            # CLEAR or CLEARP and the code will keep track of whether it 
+            # needs to be CLEAR or CLEARP for regular imaging.  One should be able
+            # to put NRM or GR150C or GR150R in the PUPIL parameter and the filter
+            # name in the FILTER parameter and get the right values out.
+            #
+            # There is a check on CLEARP plus pupil wheel filters because that would
+            # be an easy mistake to make when making files by hand as opposed to
+            # from an APT file.
+            #
+            # Note that this block of code also is found in catalog_seed_image.py as
+            # the .yaml file is read in again there.
+
+            if self.params['Inst']['instrument'].lower() == 'niriss':
+                pupil_slots = ['F090W','F115W','F140M','F150W','F158M','F200W']
+                filter_slots = ['F277W','F356W','F380M','F430M','F444W','F480M']
+                str1 = self.params['Readout']['filter']
+                str2 = self.params['Readout']['pupil']
+                if self.params['Readout']['filter'] in pupil_slots:
+                    self.params['Readout']['filter'] = str2
+                    self.params['Readout']['pupil'] = str1
+                    if self.params['Readout']['filter'] == 'CLEARP':
+                        self.params['Readout']['filter'] = 'CLEAR'
+                if self.params['Readout']['filter'] in filter_slots:
+                    if str2 == 'CLEAR':
+                        self.params['Readout']['pupil'] = 'CLEARP'
+
+                
         except FileNotFoundError as e:
             print("WARNING: unable to open {}".format(self.paramfile))
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3676,7 +3676,10 @@ class Catalog_seed():
         if self.params["Inst"]["instrument"].lower() in ["nircam", "niriss"]:
             self.zps = self.add_detector_to_zeropoints(detector)
             
-        utils.check_niriss_filter()
+        if self.params['Inst']['instrument'].lower() == 'niriss':
+            newfilter,newpupil = utils.check_niriss_filter(self.params['Readout']['filter'],self.params['Readout']['pupil'])
+            self.params['Readout']['filter'] = newfilter
+            self.params['Readout']['pupil'] = newpupil
             
         # Make sure the requested filter is allowed. For imaging, all filters
         # are allowed. In the future, other modes will be more restrictive

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3675,37 +3675,8 @@ class Catalog_seed():
         # manually add a Detector key to the dictionary as a placeholder.
         if self.params["Inst"]["instrument"].lower() in ["nircam", "niriss"]:
             self.zps = self.add_detector_to_zeropoints(detector)
-
-        # When the instrument is NIRISS, look at the FILTER/PUPIL combinations
-        # and make these work properly, the idea being that the user can put
-        # any of the 12 allowed filter names in the FILTER keyword and the code
-        # will take care of tracking which are actually in the FILTER wheel and
-        # which are in the PUPIL wheel.  Similarly, the PUPIL item can be
-        # CLEAR or CLEARP and the code will keep track of whether it 
-        # needs to be CLEAR or CLEARP for regular imaging.  One should be able
-        # to put NRM or GR150C or GR150R in the PUPIL parameter and the filter
-        # name in the FILTER parameter and get the right values out.
-        #
-        # There is a check on CLEARP plus pupil wheel filters because that would
-        # be an easy mistake to make when making files by hand as opposed to
-        # from an APT file.
-        #
-        # Note that this block of code is also found in obs_generater.py as
-        # the .yaml file is read in again there.
-
-        if self.params['Inst']['instrument'].lower() == 'niriss':
-            pupil_slots = ['F090W','F115W','F140M','F150W','F158M','F200W']
-            filter_slots = ['F277W','F356W','F380M','F430M','F444W','F480M']
-            str1 = self.params['Readout']['filter']
-            str2 = self.params['Readout']['pupil']
-            if self.params['Readout']['filter'] in pupil_slots:
-                self.params['Readout']['filter'] = str2
-                self.params['Readout']['pupil'] = str1
-                if self.params['Readout']['filter'] == 'CLEARP':
-                    self.params['Readout']['filter'] = 'CLEAR'
-            if self.params['Readout']['filter'] in filter_slots:
-                if str2 == 'CLEAR':
-                    self.params['Readout']['pupil'] = 'CLEARP'
+            
+        utils.check_niriss_filter()
             
         # Make sure the requested filter is allowed. For imaging, all filters
         # are allowed. In the future, other modes will be more restrictive
@@ -3714,7 +3685,7 @@ class Catalog_seed():
             usefilt = 'pupil'
         else:
             usefilt = 'filter'
-
+        
         # If instrument is FGS, then force filter to be 'NA' for the purposes
         # of constructing the correct PSF input path name. Then change to be
         # the DMS-required "N/A" when outputs are saved

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3676,6 +3676,37 @@ class Catalog_seed():
         if self.params["Inst"]["instrument"].lower() in ["nircam", "niriss"]:
             self.zps = self.add_detector_to_zeropoints(detector)
 
+        # When the instrument is NIRISS, look at the FILTER/PUPIL combinations
+        # and make these work properly, the idea being that the user can put
+        # any of the 12 allowed filter names in the FILTER keyword and the code
+        # will take care of tracking which are actually in the FILTER wheel and
+        # which are in the PUPIL wheel.  Similarly, the PUPIL item can be
+        # CLEAR or CLEARP and the code will keep track of whether it 
+        # needs to be CLEAR or CLEARP for regular imaging.  One should be able
+        # to put NRM or GR150C or GR150R in the PUPIL parameter and the filter
+        # name in the FILTER parameter and get the right values out.
+        #
+        # There is a check on CLEARP plus pupil wheel filters because that would
+        # be an easy mistake to make when making files by hand as opposed to
+        # from an APT file.
+        #
+        # Note that this block of code is also found in obs_generater.py as
+        # the .yaml file is read in again there.
+
+        if self.params['Inst']['instrument'].lower() == 'niriss':
+            pupil_slots = ['F090W','F115W','F140M','F150W','F158M','F200W']
+            filter_slots = ['F277W','F356W','F380M','F430M','F444W','F480M']
+            str1 = self.params['Readout']['filter']
+            str2 = self.params['Readout']['pupil']
+            if self.params['Readout']['filter'] in pupil_slots:
+                self.params['Readout']['filter'] = str2
+                self.params['Readout']['pupil'] = str1
+                if self.params['Readout']['filter'] == 'CLEARP':
+                    self.params['Readout']['filter'] = 'CLEAR'
+            if self.params['Readout']['filter'] in filter_slots:
+                if str2 == 'CLEAR':
+                    self.params['Readout']['pupil'] = 'CLEARP'
+            
         # Make sure the requested filter is allowed. For imaging, all filters
         # are allowed. In the future, other modes will be more restrictive
 

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -153,7 +153,7 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
     return ((1.0 * xs / amps + colpad) * (ys + rowpad) + fullpad) * 1.e-5
 
 
-def check_niriss_filter(filter,pupil):
+def check_niriss_filter(oldfilter,oldpupil):
     """
     This is a utility function that checks the FILTER and PUPIL parameters read in from the .yaml file and makes sure
     that for NIRISS the filter and pupil names are correct, releaving the user of the need to remember which of the 12 
@@ -167,9 +167,9 @@ def check_niriss_filter(filter,pupil):
     
     Parameters:
     
-    filter:   a string variable, assumed to be the self.params['Readout']['filter'] value from the .yaml file
+    oldfilter:   a string variable, assumed to be the self.params['Readout']['filter'] value from the .yaml file
     
-    pupil:    a string varialbe, assumed to be the self.params['Readout']['pupil'] value from the .yaml file
+    oldpupil:    a string varialbe, assumed to be the self.params['Readout']['pupil'] value from the .yaml file
     
     Return values:
     
@@ -179,19 +179,19 @@ def check_niriss_filter(filter,pupil):
     
     Note that this routine should only be called when the instrument is NIRISS.
     """
-    str1 = filter
-    str2 = pupil
-    if filter in NIRISS_PUPIL_WHEEL_FILTERS:
+    str1 = oldfilter
+    str2 = oldpupil
+    if oldfilter in NIRISS_PUPIL_WHEEL_FILTERS:
         newfilter = str2
         newpupil = str1
         if newfilter == 'CLEARP':
             newfilter = 'CLEAR'
-    if filter in NIRISS_FILTER_WHEEL_FILTERS:
-        if pupil == 'CLEAR':
+    if oldfilter in NIRISS_FILTER_WHEEL_FILTERS:
+        if oldpupil == 'CLEAR':
             newpupil = 'CLEARP'
         else:
-            newpupil = pupil
-        newfilter = filter
+            newpupil = oldpupil
+        newfilter = oldfilter
     return newfilter, newpupil
      
 def ensure_dir_exists(fullpath):

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -153,7 +153,7 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
     return ((1.0 * xs / amps + colpad) * (ys + rowpad) + fullpad) * 1.e-5
 
 
-def check_niriss_filter():
+def check_niriss_filter(filter,pupil):
     """
     This is a utility function that checks the FILTER and PUPIL parameters read in from the .yaml file and makes sure
     that for NIRISS the filter and pupil names are correct, releaving the user of the need to remember which of the 12 
@@ -165,20 +165,34 @@ def check_niriss_filter():
     
     The code also corrects CLEARP to CLEAR if needed.
     
-    There are no parameters or return values for this routine.  It works with self.params, so this routine needs to be
-    called after the .yaml parameter file is read.
+    Parameters:
+    
+    filter:   a string variable, assumed to be the self.params['Readout']['filter'] value from the .yaml file
+    
+    pupil:    a string varialbe, assumed to be the self.params['Readout']['pupil'] value from the .yaml file
+    
+    Return values:
+    
+    newfilter:   a string value, the proper FILTER parameter for the requested NIRISS filter name
+    
+    newpupil:    a string value, the proper PUPIL parameter for the requested NIRISS filter name
+    
+    Note that this routine should only be called when the instrument is NIRISS.
     """
-    if self.params['Inst']['instrument'].lower() == 'niriss':
-        str1 = self.params['Readout']['filter']
-        str2 = self.params['Readout']['pupil']
-        if self.params['Readout']['filter'] in NIRISS_PUPIL_WHEEL_FILTERS:
-            self.params['Readout']['filter'] = str2
-            self.params['Readout']['pupil'] = str1
-            if self.params['Readout']['filter'] == 'CLEARP':
-                self.params['Readout']['filter'] = 'CLEAR'
-        if self.params['Readout']['filter'] in NIRISS_FILTER_WHEEL_FILTERS:
-            if str2 == 'CLEAR':
-                self.params['Readout']['pupil'] = 'CLEARP'
+    str1 = filter
+    str2 = pupil
+    if filter in NIRISS_PUPIL_WHEEL_FILTERS:
+        newfilter = str2
+        newpupil = str1
+        if newfilter == 'CLEARP':
+            newfilter = 'CLEAR'
+    if filter in NIRISS_FILTER_WHEEL_FILTERS:
+        if pupil == 'CLEAR':
+            newpupil = 'CLEARP'
+        else:
+            newpupil = pupil
+        newfilter = filter
+    return newfilter, newpupil
      
 def ensure_dir_exists(fullpath):
     """Creates dirs from ``fullpath`` if they do not already exist.


### PR DESCRIPTION
The code changes here are for allowing the user to put any allowed NIRISS filter name in the FILTER parameter of the .yaml file and put CLEAR in the PUPIL parameter in the .yaml file, and the code will track whether the filter of that name is actually in the filter wheel or whether it is in the pupil wheel.  The block of code for this needs to be put in both in catalog_seed_image.py and obs_generator.py as the .yaml file is read in twice rather than just once as I would have expected.  One could make a small function and have the code in one place.  That may be preferable to the current situation, but I would need some suggestion as to where the code should be put in that case.
I tested the code changes on my machine and they worked.  However, as seems to regularly be the case I ran into a git problem trying to push the changes back so I had to copy the blocks of code in the git editor.  Hence while the code changes should work I have not been able to test them from the git repository.