### PR TITLE
Fix switched channel values in CRDS dictionary

### DIFF
--- a/mirage/reference_files/crds_tools.py
+++ b/mirage/reference_files/crds_tools.py
@@ -121,9 +121,9 @@ def dict_from_yaml(yaml_dict):
 
     if instrument == 'NIRCAM':
         if crds_dict['DETECTOR'] in ['NRCALONG', 'NRCBLONG']:
-            crds_dict['CHANNEL'] = 'SHORT'
-        else:
             crds_dict['CHANNEL'] = 'LONG'
+        else:
+            crds_dict['CHANNEL'] = 'SHORT'
 
     # For the purposes of choosing reference files, the exposure type should
     # always be set to imaging, since it is used to locate sources in the


### PR DESCRIPTION
This PR fixes a bug in the generation of the dictionary sent to CRDS when searching for the best reference files. Previously the SHORT and LONG channels were switched from what they should have been. This only affected searches for the distortion reference file.