### PR TITLE
Add flat field to list of reffiles returned by CRDS query

### DIFF
--- a/docs/yaml_generator.rst
+++ b/docs/yaml_generator.rst
@@ -78,7 +78,7 @@ There are currently a number of parameters which can only be set using the ``par
 JWST Calibration Reference Files
 ++++++++++++++++++++++++++++++++
 
-Mirage makes use of a handful of the `reference file types <https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#reference-files>`_ used by the JWST calibration pipeline. This includes the `bad pixel mask <https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/reference_files.html#mask-reffile>`_, `saturation level map <https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html#saturation-reffile>`_, `superbias <https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html#superbias-reffile>`_, `gain <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html#gain-reffile>`_, `interpixel capacitance <https://jwst-pipeline.readthedocs.io/en/stable/jwst/ipc/reference_files.html#ipc-reffile>`_, `linearity correction  <https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html#linearity-reffile>`_, and `distortion correction <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/distortion_reffile.html#distortion-reffile>`_ files.
+Mirage makes use of a handful of the `reference file types <https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#reference-files>`_ used by the JWST calibration pipeline. This includes the `bad pixel mask <https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/reference_files.html#mask-reffile>`_, `saturation level map <https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html#saturation-reffile>`_, `superbias <https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html#superbias-reffile>`_, `gain <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html#gain-reffile>`_, `interpixel capacitance <https://jwst-pipeline.readthedocs.io/en/stable/jwst/ipc/reference_files.html#ipc-reffile>`_, `linearity correction  <https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html#linearity-reffile>`_, `distortion correction <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/distortion_reffile.html#distortion-reffile>`_ and `pixel to pixel flat field <https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/reference_files.html#flat-reference-file>`_ files.
 
 Mirage relies on the `CRDS <https://hst-crds.stsci.edu/static/users_guide/index.html>`_ package from STScI to identify the appropriate reference files for a given exposure. These files are automatically downloaded to the user's machine at one of two times:
 
@@ -121,7 +121,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'distortion': {detector_name: {filter: {exposure_type: 'reffile_name.asdf'}}},
                            'ipc':        {detector_name: 'reffile_name.fits'},
                            'area':       {detector_name: {filter: {pupil: {exposure_type: 'reffile_name.asdf'}}}},
-                           'badpixmask': {detector_name: 'reffile_name.fits'}
+                           'badpixmask': {detector_name: 'reffile_name.fits'},
+                           'pixelflat':  {detector_name: {filter: {pupil: 'reffile_name.fits'}}}
                            },
                 'niriss': {'superbias':  {readpattern: 'reffile_name.fits'},
                            'linearity':  'reffile_name.fits',
@@ -130,7 +131,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'distortion': {pupil: {exposure_type: 'reffile_name.fits'}},
                            'ipc':        'reffile_name.fits',
                            'area':       {filter: {pupil: {exposure_type: 'reffile_name.asdf'}}},
-                           'badpixmask': 'reffile_name.fits'
+                           'badpixmask': 'reffile_name.fits',
+                           'pixelflat':  {filter: {pupil: 'reffile_name.fits'}}
                            },
                 'fgs':    {'superbias':  {detector_name: {readpattern: 'reffile_name.fits'}},
                            'linearity':  {detector_name: 'reffile_name.fits'},
@@ -139,7 +141,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'distortion': {detector_name: {exposure_type: 'reffile_name.fits'}},
                            'ipc':        {detector_name: 'reffile_name.fits'},
                            'area':       {detector_name: 'reffile_name.asdf'},
-                           'badpixmask': {detector_name: {exposure_type: 'reffile_name.fits'}}
+                           'badpixmask': {detector_name: {exposure_type: 'reffile_name.fits'}},
+                           'pixelflat':  {detector_name: {exposure_type: 'reffile_name.fits'}}
                            }
 
 
@@ -167,6 +170,13 @@ Here we show an example dictionary for a particular set of observations.
                                           'nrcb4': {'f444w':  {'clear': {'nrc_image': 'my_reffiles/my_pam_for_b4.asdf'}}}},
                            'badpixmask': {'nrcb5': 'my_reffiles/my_bpm_for_b5.fits',
                                           'nrcb4': 'my_reffiles/my_bpm_for_b4.fits'},
+                           'pixelflat':  {'nrcb5': {'f322w2': {'clear': 'my_favorites/lw_flat.fits',
+                                                               'grismr': 'my_favorites/lwR_flat.fits',
+                                                               'grismc': 'my_favorites/lwC_flat.fits'
+                                                               }
+                                                    },
+                                          'nrcb4': {'f070w': {'clear': 'my_SW_favs/sw_flat.fits'}}
+                                          }
                             }
                 }
 

--- a/mirage/reference_files/crds_tools.py
+++ b/mirage/reference_files/crds_tools.py
@@ -163,15 +163,22 @@ def get_reffiles(parameter_dict, reffile_types, download=True):
     # IMPORTANT: Import of crds package must be done AFTER the environment
     # variables are set in the functions above
     import crds
+    from crds import CrdsLookupError
 
     if download:
-        reffile_mapping = crds.getreferences(parameter_dict, reftypes=reffile_types)
+        try:
+            reffile_mapping = crds.getreferences(parameter_dict, reftypes=reffile_types)
+        except CrdsLookupError as e:
+            raise ValueError("ERROR: CRDSLookupError when trying to find reference files for parameters: {}".format(parameter_dict))
     else:
         # If the files will not be downloaded, still return the same local
         # paths that are returned when the files are downloaded. Note that
         # this follows the directory structure currently assumed by CRDS.
         crds_path = os.environ.get('CRDS_PATH')
-        reffile_mapping = crds.getrecommendations(parameter_dict, reftypes=reffile_types)
+        try:
+            reffile_mapping = crds.getrecommendations(parameter_dict, reftypes=reffile_types)
+        except CrdsLookupError as e:
+            raise ValueError("ERROR: CRDSLookupError when trying to find reference files for parameters: {}".format(parameter_dict))
         for key, value in reffile_mapping.items():
             instrument = value.split('_')[1]
             reffile_mapping[key] = os.path.join(crds_path, 'references/jwst', instrument, value)

--- a/mirage/reference_files/crds_tools.py
+++ b/mirage/reference_files/crds_tools.py
@@ -180,6 +180,8 @@ def get_reffiles(parameter_dict, reffile_types, download=True):
         except CrdsLookupError as e:
             raise ValueError("ERROR: CRDSLookupError when trying to find reference files for parameters: {}".format(parameter_dict))
         for key, value in reffile_mapping.items():
+            if "NOT FOUND" in value:
+                raise ValueError("ERROR: No {} reference file found when using parameter dictionary: {}".format(key, parameter_dict))
             instrument = value.split('_')[1]
             reffile_mapping[key] = os.path.join(crds_path, 'references/jwst', instrument, value)
 

--- a/mirage/reference_files/crds_tools.py
+++ b/mirage/reference_files/crds_tools.py
@@ -170,6 +170,11 @@ def get_reffiles(parameter_dict, reffile_types, download=True):
             reffile_mapping = crds.getreferences(parameter_dict, reftypes=reffile_types)
         except CrdsLookupError as e:
             raise ValueError("ERROR: CRDSLookupError when trying to find reference files for parameters: {}".format(parameter_dict))
+
+        # Check for missing files
+        for key, value in reffile_mapping.items():
+            if "NOT FOUND" in value:
+                raise ValueError("ERROR: No {} reference file found when using parameter dictionary: {}".format(key, parameter_dict))
     else:
         # If the files will not be downloaded, still return the same local
         # paths that are returned when the files are downloaded. Note that
@@ -180,13 +185,12 @@ def get_reffiles(parameter_dict, reffile_types, download=True):
         except CrdsLookupError as e:
             raise ValueError("ERROR: CRDSLookupError when trying to find reference files for parameters: {}".format(parameter_dict))
         for key, value in reffile_mapping.items():
+
+            # Check for NOT FOUND must be done here because the following
+            # line will raise an exception if NOT FOUND is present
             if "NOT FOUND" in value:
                 raise ValueError("ERROR: No {} reference file found when using parameter dictionary: {}".format(key, parameter_dict))
             instrument = value.split('_')[1]
             reffile_mapping[key] = os.path.join(crds_path, 'references/jwst', instrument, value)
 
-    # Will we ever come across a case where no reference file is found?
-    for key, value in reffile_mapping.items():
-        if value == 'N/A':
-            reffile_mapping[key] = None
     return reffile_mapping

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3663,12 +3663,12 @@ class Catalog_seed():
         # manually add a Detector key to the dictionary as a placeholder.
         if self.params["Inst"]["instrument"].lower() in ["nircam", "niriss"]:
             self.zps = self.add_detector_to_zeropoints(detector)
-            
+
         if self.params['Inst']['instrument'].lower() == 'niriss':
             newfilter,newpupil = utils.check_niriss_filter(self.params['Readout']['filter'],self.params['Readout']['pupil'])
             self.params['Readout']['filter'] = newfilter
             self.params['Readout']['pupil'] = newpupil
-            
+
         # Make sure the requested filter is allowed. For imaging, all filters
         # are allowed. In the future, other modes will be more restrictive
 
@@ -3676,7 +3676,7 @@ class Catalog_seed():
             usefilt = 'pupil'
         else:
             usefilt = 'filter'
-        
+
         # If instrument is FGS, then force filter to be 'NA' for the purposes
         # of constructing the correct PSF input path name. Then change to be
         # the DMS-required "N/A" when outputs are saved

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -39,7 +39,8 @@ CRDS_FILE_TYPES = {'badpixmask': 'mask',
                    'linearity': 'linearity',
                    'pixelAreaMap': 'area',
                    'saturation': 'saturation',
-                   'superbias': 'superbias'}
+                   'superbias': 'superbias',
+                   'pixelflat': 'flat'}
 
 def grism_factor(instrument_name):
     """Return the factor by which the field of view is expanded when

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -156,31 +156,38 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
 def check_niriss_filter(oldfilter,oldpupil):
     """
     This is a utility function that checks the FILTER and PUPIL parameters read in from the .yaml file and makes sure
-    that for NIRISS the filter and pupil names are correct, releaving the user of the need to remember which of the 12 
-    filters are in the filter wheel and which are in the pupil wheel.  If the user puts the correct values for filter and 
-    pupil nothing is done, but the user can just put the filter name in the filter parameter and CLEAR in the pupil 
-    parameter, in which case this routine sorts out which value actually goes where.  Hence for example one can have a 
-    parameter file with FILTER = F277W and PUPIL = CLEAR or FILTER = F090W and PUPIL = CLEAR for imaging and either will 
+    that for NIRISS the filter and pupil names are correct, releaving the user of the need to remember which of the 12
+    filters are in the filter wheel and which are in the pupil wheel.  If the user puts the correct values for filter and
+    pupil nothing is done, but the user can just put the filter name in the filter parameter and CLEAR in the pupil
+    parameter, in which case this routine sorts out which value actually goes where.  Hence for example one can have a
+    parameter file with FILTER = F277W and PUPIL = CLEAR or FILTER = F090W and PUPIL = CLEAR for imaging and either will
     produce the desired result although the actual pairings would be F277W/CLEARP and CLEAR/F090W respectively.
-    
+
     The code also corrects CLEARP to CLEAR if needed.
-    
-    Parameters:
-    
-    oldfilter:   a string variable, assumed to be the self.params['Readout']['filter'] value from the .yaml file
-    
-    oldpupil:    a string varialbe, assumed to be the self.params['Readout']['pupil'] value from the .yaml file
-    
-    Return values:
-    
-    newfilter:   a string value, the proper FILTER parameter for the requested NIRISS filter name
-    
-    newpupil:    a string value, the proper PUPIL parameter for the requested NIRISS filter name
-    
+
+    Parameters
+    ----------
+
+    oldfilter :  str
+        Assumed to be the self.params['Readout']['filter'] value from the .yaml file
+
+    oldpupil :  str
+        Assumed to be the self.params['Readout']['pupil'] value from the .yaml file
+
+    Returns
+    -------
+
+    newfilter : str
+        The proper FILTER parameter for the requested NIRISS filter name
+
+    newpupil : str
+        The proper PUPIL parameter for the requested NIRISS filter name
+
     Note that this routine should only be called when the instrument is NIRISS.
     """
     str1 = oldfilter
     str2 = oldpupil
+
     if oldfilter in NIRISS_PUPIL_WHEEL_FILTERS:
         newfilter = str2
         newpupil = str1
@@ -193,7 +200,7 @@ def check_niriss_filter(oldfilter,oldpupil):
             newpupil = oldpupil
         newfilter = oldfilter
     return newfilter, newpupil
-     
+
 def ensure_dir_exists(fullpath):
     """Creates dirs from ``fullpath`` if they do not already exist.
     """

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -193,7 +193,7 @@ def check_niriss_filter(oldfilter,oldpupil):
         newpupil = str1
         if newfilter == 'CLEARP':
             newfilter = 'CLEAR'
-    if oldfilter in NIRISS_FILTER_WHEEL_FILTERS:
+    elif oldfilter in NIRISS_FILTER_WHEEL_FILTERS:
         if oldpupil == 'CLEAR':
             newpupil = 'CLEARP'
         else:

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -319,6 +319,7 @@ class SimInput:
 
         # Loop over combinations, create metadata dict, and get reffiles
         for status in unique_obs_info:
+            updated_status = deepcopy(status)
             (instrument, detector, filtername, pupilname, readpattern, exptype) = status
 
             # Make sure NIRISS filter and pupil values are in the correct wheels
@@ -339,6 +340,11 @@ class SimInput:
                     status_dict['CHANNEL'] = 'LONG'
                 else:
                     status_dict['CHANNEL'] = 'SHORT'
+            if instrument == 'FGS':
+                if detector in ['G1', 'G2']:
+                    detector = detector.replace('G', 'GUIDER')
+                    status_dict['DETECTOR'] = detector
+                    updated_status = (instrument, detector, filtername, pupilname, readpattern, exptype)
 
             # Query CRDS
             reffiles = crds_tools.get_reffiles(status_dict, list(CRDS_FILE_TYPES.values()),
@@ -347,7 +353,7 @@ class SimInput:
             # If the user entered reference files in self.reffile_defaults
             # use those over what comes from the CRDS query
             if self.reffile_overrides is not None:
-                manual_reffiles = self.reffiles_from_dict(status)
+                manual_reffiles = self.reffiles_from_dict(updated_status)
 
                 for key in manual_reffiles:
                     if manual_reffiles[key] != 'none':
@@ -421,12 +427,18 @@ class SimInput:
 
         # Loop over combinations, create metadata dict, and get reffiles
         for status in unique_obs_info:
+            updated_status = deepcopy(status)
             (instrument, detector, filtername, pupilname, readpattern, exptype) = status
+
+            if instrument == 'FGS':
+                if detector in ['G1', 'G2']:
+                    detector = detector.replace('G', 'GUIDER')
+                    updated_status = (instrument, detector, filtername, pupilname, readpattern, exptype)
 
             # If the user entered reference files in self.reffile_defaults
             # use those over what comes from the CRDS query
             #sbias, lin, sat, gainfile, dist, ipcfile, pam = self.reffiles_from_dict(status)
-            manual_reffiles = self.reffiles_from_dict(status)
+            manual_reffiles = self.reffiles_from_dict(updated_status)
             for key in manual_reffiles:
                 if manual_reffiles[key] == 'none':
                     manual_reffiles[key] = 'crds'

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1691,7 +1691,7 @@ class SimInput:
             if instrument == 'nircam':
                 files['pixelflat'] = self.reffile_overrides[instrument]['pixelflat'][detector][filtername][pupilname]
             elif instrument == 'niriss':
-                files['pixelflat'] = self.reffile_overrides[instrument]['pixelflat'][detector][filtername][pupilname]
+                files['pixelflat'] = self.reffile_overrides[instrument]['pixelflat'][filtername][pupilname]
             elif instrument == 'fgs':
                 files['pixelflat'] = self.reffile_overrides[instrument]['pixelflat'][detector][exptype]
         except KeyError:

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -417,7 +417,7 @@ class SimInput:
         ipc_arr = deepcopy(empty_col)
         pixelAreaMap_arr = deepcopy(empty_col)
         badpixmask_arr = deepcopy(empty_col)
-        pixelflat_arr = deepcopy(emnpty_col)
+        pixelflat_arr = deepcopy(empty_col)
 
         # Loop over combinations, create metadata dict, and get reffiles
         for status in unique_obs_info:
@@ -453,7 +453,7 @@ class SimInput:
         self.info['ipc'] = list(ipc_arr)
         self.info['pixelAreaMap'] = list(pixelAreaMap_arr)
         self.info['badpixmask'] = list(badpixmask_arr)
-        self.info['pixelflat'] = list(pielflat_arr)
+        self.info['pixelflat'] = list(pixelflat_arr)
 
     def catalog_match(self, filter, pupil, catalog_list, cattype):
         """

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -134,6 +134,7 @@ def test_reffile_crds_full_name():
                                              'nrcb4': {'f150w': {'clear': {'nrc_image': 'my_reffiles/my_pam_for_b4.fits'}}}},
                                     'badpixmask': {'nrcb5': 'my_reffiles/my_bpm_for_b5.fits',
                                                    'nrcb4': 'my_reffiles/my_bpm_for_b4.fits'},
+                                    'pixelflat': {'nrcb5': {'f322w2': {'clear': 'my_reffiles/my_flatfield_for_b5.fits'}}}
                                     },
                          'niriss': {'superbias': {'nisrapid': 'my_niriss_supebias.fits'},
                                     'linearity': 'my_niriss_linearity,fits',
@@ -141,7 +142,8 @@ def test_reffile_crds_full_name():
                                     'gain': 'my_niriss_gain.fits',
                                     'distortion': {'F115W': {'nis_image': 'my_niriss_disotrtion.asdf'}},
                                     'area': {'clear': {'f115w': {'nis_image': 'my_niriss_area.fits'}}},
-                                    'badpixmask': 'my_niriss_badpixmask.fits'
+                                    'badpixmask': 'my_niriss_badpixmask.fits',
+                                    'pixelflat': {'clear': {'f115w': 'my_niriss_flatfield.fits'}}
                                     }
                          }
 
@@ -178,10 +180,12 @@ def test_reffile_crds_full_name():
     match_nrc_lw_common = np.where(detectors == 'B5')[0]
     match_nrc_sw_distortion_area = np.where((sw_filternames == 'F150W') & (detectors == 'B4') & (sw_pupilnames == 'CLEAR'))[0]
     match_nrc_lw_distortion_area = np.where((lw_filternames == 'F322W2') & (detectors == 'B5') & (lw_pupilnames == 'CLEAR'))[0]
+    match_nrc_lw_flat = np.where((lw_filternames == 'F322W2') & (detectors == 'B5') & (lw_pupilnames == 'CLEAR'))[0]
 
     match_nis_superbias = np.where(read_patterns == 'NISRAPID')[0]
     match_nis_common = np.where(instruments == 'NIRISS')[0]
     match_nis_distortion_area = np.where((pupilnames == 'F115W') & (instruments == 'NIRISS') & (filternames == 'CLEAR'))[0]
+    match_nis_flat = np.where((pupilnames == 'F115W') & (instruments == 'NIRISS') & (filternames == 'CLEAR'))[0]
 
     # Check that reference files that are covered by reffile_overrides
     # are equal to the override values.
@@ -205,6 +209,8 @@ def test_reffile_crds_full_name():
     for index in match_nrc_lw_distortion_area:
         assert yam.info['astrometric'][index] == 'my_reffiles/my_distortion_for_b5.asdf'
         assert yam.info['pixelAreaMap'][index] == 'my_reffiles/my_pam_for_b5.fits'
+    for index in match_nrc_lw_flat:
+        assert yam.info['pixelflat'][index] == 'my_reffiles/my_flatfield_for_b5.fits'
 
     for index in match_nis_superbias:
         assert yam.info['superbias'][index] == 'my_niriss_supebias.fits'
@@ -216,6 +222,8 @@ def test_reffile_crds_full_name():
     for info in match_nis_distortion_area:
         assert yam.info['astrometric'][index] == 'my_niriss_disotrtion.asdf'
         assert yam.info['pixelAreaMap'][index] == 'my_niriss_area.fits'
+    for info in match_nis_flat:
+        assert yam.info['pixelflat'][index] == 'my_niriss_flatfield.fits'
 
     # Check that reference files covered by reffile_overrides contain
     # the CRDS_PATH, which here has been set to the temp directory


### PR DESCRIPTION
Small addition that adds flat field files to the list of reference files that CRDS is queried for. These files are then added to the input yaml file. Previously the flat field file was hardcoded to None in the yaml files.