### PR TITLE
Remove pysiaf pre delivery dir

### DIFF
--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -23,7 +23,6 @@ import numpy as np
 
 import pysiaf
 from pysiaf import iando
-#from pysiaf.constants import JWST_DELIVERY_DATA_ROOT
 from ..utils import rotations
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 
@@ -41,14 +40,6 @@ def get_instance(instrument):
     siaf : pysiaf.Siaf
         Siaf object for the requested instrument
     """
-    #if instrument.lower() == 'nircam':
-    #    print("NOTE: Using pre-delivery SIAF data for {}".format(instrument))
-    #    siaf_instrument = 'NIRCam'
-    #    pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, 'NIRCam')
-    #    siaf = pysiaf.Siaf(siaf_instrument, basepath=pre_delivery_dir)
-    #else:
-    #    siaf_instrument = instrument
-    #    siaf = pysiaf.Siaf(siaf_instrument)
     siaf = pysiaf.Siaf(instrument)
     return siaf
 

--- a/mirage/utils/siaf_interface.py
+++ b/mirage/utils/siaf_interface.py
@@ -23,7 +23,7 @@ import numpy as np
 
 import pysiaf
 from pysiaf import iando
-from pysiaf.constants import JWST_DELIVERY_DATA_ROOT
+#from pysiaf.constants import JWST_DELIVERY_DATA_ROOT
 from ..utils import rotations
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 
@@ -41,14 +41,15 @@ def get_instance(instrument):
     siaf : pysiaf.Siaf
         Siaf object for the requested instrument
     """
-    if instrument.lower() == 'nircam':
-        print("NOTE: Using pre-delivery SIAF data for {}".format(instrument))
-        siaf_instrument = 'NIRCam'
-        pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, 'NIRCam')
-        siaf = pysiaf.Siaf(siaf_instrument, basepath=pre_delivery_dir)
-    else:
-        siaf_instrument = instrument
-        siaf = pysiaf.Siaf(siaf_instrument)
+    #if instrument.lower() == 'nircam':
+    #    print("NOTE: Using pre-delivery SIAF data for {}".format(instrument))
+    #    siaf_instrument = 'NIRCam'
+    #    pre_delivery_dir = os.path.join(JWST_DELIVERY_DATA_ROOT, 'NIRCam')
+    #    siaf = pysiaf.Siaf(siaf_instrument, basepath=pre_delivery_dir)
+    #else:
+    #    siaf_instrument = instrument
+    #    siaf = pysiaf.Siaf(siaf_instrument)
+    siaf = pysiaf.Siaf(instrument)
     return siaf
 
 
@@ -152,7 +153,7 @@ def sci_subarray_corners(instrument, aperture_name, siaf=None, verbose=False):
     """
     # get SIAF
     if siaf is None:
-        siaf = pysiaf.Siaf(instrument)
+        siaf = get_instance(instrument)
 
     # get master aperture names
     siaf_detector_layout = iando.read.read_siaf_detector_layout()

--- a/tests/test_ra_dec_to_x_y.py
+++ b/tests/test_ra_dec_to_x_y.py
@@ -309,7 +309,7 @@ def test_locations():
         dec_list.append(dec_entry)
 
     xy_vals = {}
-    instrument_list = ['nircam', 'niriss', 'fgs']
+    instrument_list = ['niriss', 'fgs']
 
     for instrument in instrument_list:
         siaf = siaf_interface.get_instance(instrument)


### PR DESCRIPTION
This PR changes instances of pysiaf.Siaf for NIRCam to be the same as those for the other instruments. Previously Siaf instances for NIRCam were created by looking in pysiaf's pre-delivery directory, as updated coefficients were stored there. However, in order to be consistent with the current set of distortion reference files (which use the old coefficients), which removes the possibility of creating the data with one set of distortion coefficients and then running the pipeline with another set, we move NIRCam back to the old coefficients in pysiaf. Also, in the latest version of pysiaf, the pre-delivery directory is empty.

This has implications for level 3 pipeline processing of Mirage data. NIRCam mosaics will not look right because the old distortion coefficients have large round trip (x, y -> RA, Dec -> x, y) errors around the edges of the detectors.