### PR TITLE
Remove testing directories from notebook

### DIFF
--- a/examples/NIRISS_WFSS_data_creation_example.ipynb
+++ b/examples/NIRISS_WFSS_data_creation_example.ipynb
@@ -272,10 +272,8 @@
    "source": [
     "# Create a series of Mirage input yaml files\n",
     "# using the APT files\n",
-    "#yaml_output_dir = '/where/to/put/yaml/files'\n",
-    "#simulations_output_dir = '/where/to/put/simulated/data'\n",
-    "yaml_output_dir = '/Users/hilbert/python_repos/test'\n",
-    "simulations_output_dir = '/Users/hilbert/python_repos/test'\n",
+    "yaml_output_dir = '/where/to/put/yaml/files'\n",
+    "simulations_output_dir = '/where/to/put/simulated/data'\n",
     "# Run the yaml generator\n",
     "yam = yaml_generator.SimInput(input_xml=xml_file, pointing_file=pointing_file,\n",
     "                              catalogs=catalogs, cosmic_rays=cosmic_rays,\n",


### PR DESCRIPTION
This PR removes some testing directories from the WFSS notebook, and replaces them with placeholder values. Trivial change.