### PR TITLE
Rename self.pararms --> self.params

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -612,7 +612,7 @@ class DarkPrep():
         self.crds_dict = crds_tools.dict_from_yaml(self.params)
 
         # Expand param entries to full paths where appropriate
-        self.pararms = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
+        self.params = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
         self.filecheck()
 
         # Base name for output files

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -965,7 +965,7 @@ class Observation():
         self.crds_dict = crds_tools.dict_from_yaml(self.params)
 
         # Expand param entries to full paths where appropriate
-        self.pararms = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
+        self.params = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
 
         self.file_check()
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -116,7 +116,7 @@ class Catalog_seed():
         self.crds_dict = crds_tools.dict_from_yaml(self.params)
 
         # Expand param entries to full paths where appropriate
-        self.pararms = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
+        self.params = utils.full_paths(self.params, self.modpath, self.crds_dict, offline=self.offline)
         self.filecheck()
         self.basename = os.path.join(self.params['Output']['directory'],
                                      self.params['Output']['file'][0:-5].split('/')[-1])


### PR DESCRIPTION
This is just a little thing I noticed while I was cruising through the code.  It looks like this was intended to replace self.params with the expanded paths, but because of the typo it is writing to a new attribute.