### PR TITLE
Fix installation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,4 +25,4 @@ dependencies:
 - pip:
     - jwst-backgrounds>=1.1.1
     - pysiaf==0.3.0
-    - git+https://github.com/spacetelescope/jwst@9d5eb8c#egg=jwst
+    - git+https://github.com/spacetelescope/jwst@0.13.8

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,15 @@
 channels:
 - http://ssb.stsci.edu/astroconda
-- http://ssb.stsci.edu/astroconda-dev
 - conda-forge
 - defaults
 dependencies:
 - asdf>=2.1.0.dev1+ga161518
 - astropy==3.2.1
 - astroquery>=0.3.8
+- crds>=7.4.1
 - gwcs>=0.10a.dev21+g75e92da
 - healpy>=1.10
 - h5py>=2.8.0
-- jwst>=0.12.0a.dev115+g9d5eb8c
 - jwxml>=0.3.0
 - matplotlib>=3.0.0
 - numpy>=1.16
@@ -26,3 +25,4 @@ dependencies:
 - pip:
     - jwst-backgrounds>=1.1.1
     - pysiaf==0.3.0
+    - git+https://github.com/spacetelescope/jwst@9d5eb8c#egg=jwst


### PR DESCRIPTION
The current `environment.yaml` no longer works now that STScI does not support the astroconda-dev channel. I removed that channel and subsequently moved the `jwst` installation from via conda to via pip, matching the version that was previously in the env file. I also added an explicit `crds` import since it isn't done by default with pip's installation of `jwst`.