### PR TITLE
Fix non-Travis tests

### DIFF
--- a/tests/test_data/NIRISS/niriss_imaging_test.yaml
+++ b/tests/test_data/NIRISS/niriss_imaging_test.yaml
@@ -15,19 +15,18 @@ Readout:
 Reffiles:                                 #Set to None or leave blank if you wish to skip that step
   dark: $MIRAGE_DATA/niriss/darks/raw/NISNIRISSDARK-172500017_15_496_SE_2017-09-07T05h28m22_dms_uncal.fits   #Dark current integration used as the base
   linearized_darkfile: None # Linearized dark ramp to use as input. Supercedes dark above
-  badpixmask: $MIRAGE_DATA/niriss/reference_files/badpix/jwst_niriss_mask_0008.fits # If linearized dark is used, populate output DQ extensions using this file
-  superbias: $MIRAGE_DATA/niriss/reference_files/superbias/jwst_niriss_superbias_0080.fits #Superbias file. Set to None or leave blank if not using
-  linearity: $MIRAGE_DATA/niriss/reference_files/linearity/jwst_niriss_linearity_0010.fits #linearity correction coefficients
-  saturation: $MIRAGE_DATA/niriss/reference_files/saturation/jwst_niriss_saturation_0010.fits #well depth reference files
-  gain: $MIRAGE_DATA/niriss/reference_files/gain/jwst_niriss_gain_0005.fits
+  badpixmask: crds # If linearized dark is used, populate output DQ extensions using this file
+  superbias: crds #Superbias file. Set to None or leave blank if not using
+  linearity: crds #linearity correction coefficients
+  saturation: crds #well depth reference files
+  gain: crds
   pixelflat: None
   illumflat: None                               #Illumination flat field file
-  astrometric: $MIRAGE_DATA/niriss/reference_files/distortion/jwst_niriss_distortion_0008.asdf #Astrometric distortion file (asdf)
-  distortion_coeffs: $MIRAGE_DATA/niriss/reference_files/SIAF/NIRISS_SIAF_09-28-2017.csv        #CSV file containing distortion coefficients
-  ipc: $MIRAGE_DATA/niriss/reference_files/ipc/Kernel_to_add_IPC_effects_from_jwst_niriss_ipc_0007.fits  #File containing IPC kernel to apply
-  invertIPC: False      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
+  astrometric: crds #Astrometric distortion file (asdf)
+  ipc: crds  #File containing IPC kernel to apply
+  invertIPC: True      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
   occult: None                                    #Occulting spots correction image
-  pixelAreaMap: $MIRAGE_DATA/niriss/reference_files/pam/jwst_niriss_area_0011.fits  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
+  pixelAreaMap: crds  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
   subarray_defs:   config   #File that contains a list of all possible subarray names and coordinates
   readpattdefs:    config   #File that contains a list of all possible readout pattern names and associated NFRAME/NSKIP values
   crosstalk:       config   #File containing crosstalk coefficients
@@ -77,6 +76,7 @@ simSignals:
   poissonseed: 2012872553                  #Random number generator seed for Poisson simulation)
   photonyield: True                         #Apply photon yield in simulation
   pymethod: True                            #Use double Poisson simulation for photon yield
+  expand_catalog_for_segments: False                     # Expand catalog for 18 segments and use distinct PSFs
 
 Telescope:
   ra: 53.1                     #RA of simulated pointing

--- a/tests/test_data/NIRISS/niriss_nrm_test.yaml
+++ b/tests/test_data/NIRISS/niriss_nrm_test.yaml
@@ -15,19 +15,18 @@ Readout:
 Reffiles:                                 #Set to None or leave blank if you wish to skip that step
   dark: $MIRAGE_DATA/niriss/darks/raw/NISNIRISSDARK-172500017_15_496_SE_2017-09-07T05h28m22_dms_uncal.fits   #Dark current integration used as the base
   linearized_darkfile: None # Linearized dark ramp to use as input. Supercedes dark above
-  badpixmask: $MIRAGE_DATA/niriss/reference_files/badpix/jwst_niriss_mask_0008.fits # If linearized dark is used, populate output DQ extensions using this file
-  superbias: $MIRAGE_DATA/niriss/reference_files/superbias/jwst_niriss_superbias_0080.fits #Superbias file. Set to None or leave blank if not using
-  linearity: $MIRAGE_DATA/niriss/reference_files/linearity/jwst_niriss_linearity_0010.fits #linearity correction coefficients
-  saturation: $MIRAGE_DATA/niriss/reference_files/saturation/jwst_niriss_saturation_0010.fits #well depth reference files
-  gain: $MIRAGE_DATA/niriss/reference_files/gain/jwst_niriss_gain_0005.fits
+  badpixmask: crds # If linearized dark is used, populate output DQ extensions using this file
+  superbias: crds #Superbias file. Set to None or leave blank if not using
+  linearity: crds #linearity correction coefficients
+  saturation: crds #well depth reference files
+  gain: crds
   pixelflat: None
   illumflat: None                               #Illumination flat field file
-  astrometric: $MIRAGE_DATA/niriss/reference_files/distortion/jwst_niriss_distortion_0008.asdf #Astrometric distortion file (asdf)
-  distortion_coeffs: $MIRAGE_DATA/niriss/reference_files/SIAF/NIRISS_SIAF_09-28-2017.csv        #CSV file containing distortion coefficients
-  ipc: $MIRAGE_DATA/niriss/reference_files/ipc/Kernel_to_add_IPC_effects_from_jwst_niriss_ipc_0007.fits  #File containing IPC kernel to apply
-  invertIPC: False      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
+  astrometric: crds #Astrometric distortion file (asdf)
+  ipc: crds  #File containing IPC kernel to apply
+  invertIPC: True      #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
   occult: None                                    #Occulting spots correction image
-  pixelAreaMap: $MIRAGE_DATA/niriss/reference_files/pam/jwst_niriss_area_0011.fits  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
+  pixelAreaMap: crds  #Pixel area map for the detector. Used to introduce distortion into the output ramp.
   subarray_defs:   config   #File that contains a list of all possible subarray names and coordinates
   readpattdefs:    config   #File that contains a list of all possible readout pattern names and associated NFRAME/NSKIP values
   crosstalk:       config   #File containing crosstalk coefficients
@@ -77,6 +76,7 @@ simSignals:
   poissonseed: 2012872553                  #Random number generator seed for Poisson simulation)
   photonyield: True                         #Apply photon yield in simulation
   pymethod: True                            #Use double Poisson simulation for photon yield
+  expand_catalog_for_segments: False                     # Expand catalog for 18 segments and use distinct PSFs
 
 Telescope:
   ra: 53.1                     #RA of simulated pointing

--- a/tests/test_filename_generation.py
+++ b/tests/test_filename_generation.py
@@ -60,7 +60,7 @@ def test_filenames(temporary_directory):
             print('Processing program {}'.format(apt_file_xml))
 
             yam = yaml_generator.SimInput(input_xml=apt_file_xml, pointing_file=apt_file_pointing,
-                                          catalogs=catalogs, observation_list_file=observation_list_file,
+                                          observation_list_file=observation_list_file,
                                           verbose=True, output_dir=temporary_directory, simdata_output_dir=temporary_directory,
                                           offline=True)
             try:

--- a/tests/test_yaml_generator.py
+++ b/tests/test_yaml_generator.py
@@ -20,6 +20,11 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 # Reset the MIRAGE_DATA env variable to be a real location so yaml_generator
 # doesn't croak
+# Determine if tests are being run on Travis
+ON_TRAVIS = 'travis' in os.path.expanduser('~')
+if not ON_TRAVIS:
+    orig_mirage_data = os.environ['MIRAGE_DATA']
+
 os.environ["MIRAGE_DATA"] = __location__
 os.environ["CRDS_PATH"] = os.path.join(__location__, "temp")
 
@@ -499,3 +504,9 @@ def test_reffile_crds_full_name():
 
     # Clean up
     os.system('rm -r {}'.format(temp_output_dir))
+
+
+# Return environment variable to original value. This is helpful when
+# calling many tests at once, some of which need the real value.
+if not ON_TRAVIS:
+    os.environ['MIRAGE_DATA'] = orig_mirage_data


### PR DESCRIPTION
Several tests that are not run on Travis were failing. This PR fixes those tests. 

- The reference files in the NIRISS example yaml files were set to 'crds' so that there is no need to update the reference file names each time a new reference file is delivered.

- The unnecessary catalog input was removed from test_filename_generation.

- In test_yaml_generator, the Mirage environment variable is set back to its original value if the test is not being run on Travis.