### PR TITLE
Add reference pixel masking

### DIFF
--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -182,8 +182,14 @@ class WFSSSim():
         gainfile = cat.params['Reffiles']['gain']
         gain, gainheader = self.read_gain_file(gainfile)
 
-        # Disperser output is always full frame. Crop to the
-        # requested subarray if necessary
+        # Disperser output is always full frame. Remove the signal from
+        # the refrence pixels now since we know exactly where they are
+        disp_seed.final[0:4, :] = 0.
+        disp_seed.final[2044:, :] = 0.
+        disp_seed.final[:, 0:4] = 0.
+        disp_seed.final[:, 2044:] = 0.
+
+        # Crop to the requested subarray if necessary
         if cat.params['Readout']['array_name'] not in self.fullframe_apertures:
             print("Subarray bounds: {}".format(cat.subarray_bounds))
             print("Dispersed seed image size: {}".format(disp_seed.final.shape))


### PR DESCRIPTION
This PR fixes an issue where reference pixels in the seed images contained signal from astronomical sources. A mask has been created that zeros out the reference pixels in the seed image when in modes other than WFSS. A similar mask is applied to dispersed seed images coming out of the disperser.  Direct seed images going into the disperser are not masked because the disperser needs to know about the astronomical signal in areas outside the science pixels.

I've tested this on direct seed images in full frame and subarray mode, and the seed images now look correct. I still need to test WFSS observations.

Closes #385 