### PR TITLE
Remove dictionary of dummy catalogs in call to yaml_generator

### DIFF
--- a/mirage/catalogs/create_catalog.py
+++ b/mirage/catalogs/create_catalog.py
@@ -49,10 +49,8 @@ def create_basic_exposure_list(xml_file, pointing_file):
     from mirage.yaml import yaml_generator
     from mirage.apt import apt_inputs
 
-    dummy_catalogs = {'nircam': {'sw': 'dummy.cat', 'lw': 'dummy.cat'},
-                      'niriss': 'dummy.cat', 'fgs': 'dummy.cat'}
     info = yaml_generator.SimInput(input_xml=xml_file, pointing_file=pointing_file,
-                                   catalogs=dummy_catalogs, offline=True)
+                                   offline=True)
 
     apt = apt_inputs.AptInput(input_xml=xml_file, pointing_file=pointing_file)
     apt.observation_list_file = info.observation_list_file


### PR DESCRIPTION
This PR updates the `catalogs` input in the call to the `yaml_generator` within `create_catalogs.for_proposal`. The dictionary of dummy values used previously did not agree with the updated format required for the dictionary. I removed the dummy dictionary entirely and fall back to the default value of None.

After making the fix, I ran the Catalog_Generation_Tools notebook and the `create_catalog.for_proposal` call completed successfully.

Resolves #396 