### PR TITLE
Remove extra yaml file from notebook

### DIFF
--- a/examples/Imaging_simulator_use_examples.ipynb
+++ b/examples/Imaging_simulator_use_examples.ipynb
@@ -581,19 +581,7 @@
     "\n",
     "This is generally a 2D noiseless countrate image that contains only simulated astronomical sources.\n",
     "\n",
-    "A seed image is generated based on a `.yaml` file that contains all the necessary parameters for simulating data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define the yaml file that contains the parameters of the\n",
-    "# data to be simulated. Example yaml file shown at the bottom of this\n",
-    "# notebook\n",
-    "yamlfile = 'imaging_example_data/imaging_test_for_notebook.yaml'"
+    "A seed image is generated based on a `.yaml` file that contains all the necessary parameters for simulating data. For this exercise, use the same yaml file that was used in the [Create Simulated Data](#run_steps_together) section as input."
    ]
   },
   {


### PR DESCRIPTION
This PR removes reference to a yaml file from the Imaging_simulator_use_examples notebook. This notebook runs the yaml_generator, and one of the resulting yaml files is used in a call to the imaging_simulator. The next step in the notebook is to run Mirage's steps one at a time. Previously this was done using a separate yaml file made solely for this purpose. This PR changes that so that the call to the three steps uses the same yaml file that is used in the call to the imaging_simulator. Since this yaml file is created when the notebook is run, there is no need for use to keep it up to date. 