### PR TITLE
Overlapping wfss source types

### DIFF
--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -488,7 +488,7 @@ def _load_itm_library(library_file):
         # Convert to HDUList and create library
         phdu = fits.PrimaryHDU(data, hdr)
         hdulist = fits.HDUList(phdu)
-        library = to_griddedpsfmodel(hdulist, ext=0)
+        library = to_griddedpsfmodel(hdulist)
 
         return library
     else:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -468,7 +468,21 @@ class Catalog_seed():
         return padded_seed, padded_seg
 
     def saveSeedImage(self, seed_image, segmentation_map, seed_file_name):
-        # Create the grism direct image or ramp to be saved
+        """Save the seed image and accompanying segmentation map to a
+        fits file.
+
+        Parameters
+        ----------
+        seed_image : numpy.ndarray
+            Array containing the seed image
+
+        segmentation_map : numpy.ndimage
+            Array containing the segmentation map
+
+        seed_file_name : str
+            Name of FITS file to save ``seed_image`` and `segmentation_map``
+            into
+        """
         arrayshape = seed_image.shape
         if len(arrayshape) == 2:
             units = 'ADU/sec'
@@ -1504,15 +1518,6 @@ class Catalog_seed():
 
             ptsrc_segmap = ptsrc_segmap.segmap
 
-            # save the point source image for examination by user
-            #if self.params['Output']['save_intermediates'] is True:
-            #    psf_image_name = self.basename + '_pointSourceRateImage_adu_per_sec.fits'
-            #    h0 = fits.PrimaryHDU(psfimage)
-            #    h1 = fits.ImageHDU(ptsrc_segmap)
-            #    hlist = fits.HDUList([h0, h1])
-            #    hlist.writeto(psf_image_name, overwrite=True)
-            #print("Point source image and segmap saved as {}".format(psf_image_name))
-
             # Add the point source image to the overall image
             signalimage = signalimage + psfimage
             segmentation_map += ptsrc_segmap
@@ -1528,8 +1533,9 @@ class Catalog_seed():
             # tool does not work on subarrays
             aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
             if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
-                (aperture_suffix not in ['FULL', 'CEN'])):
-                self.point_source_seed, self.point_source_seg_map = self.pad_wfss_subarray(self.point_source_seed, self.point_source_seg_map)
+                 (aperture_suffix not in ['FULL', 'CEN'])):
+                self.point_source_seed, self.point_source_seg_map = self.pad_wfss_subarray(self.point_source_seed,
+                                                                                           self.point_source_seg_map)
 
             # Save the point source seed image
             self.ptsrc_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_ptsrc_seed_image.fits')
@@ -1561,8 +1567,9 @@ class Catalog_seed():
             # tool does not work on subarrays
             aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
             if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
-                (aperture_suffix not in ['FULL', 'CEN'])):
-                self.galaxy_source_seed, self.galaxy_source_seg_map = self.pad_wfss_subarray(self.galaxy_source_seed, self.galaxy_source_seg_map)
+                 (aperture_suffix not in ['FULL', 'CEN'])):
+                self.galaxy_source_seed, self.galaxy_source_seg_map = self.pad_wfss_subarray(self.galaxy_source_seed,
+                                                                                             self.galaxy_source_seg_map)
 
             # Save the galaxy source seed image
             self.galaxy_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_galaxy_seed_image.fits')
@@ -1571,15 +1578,6 @@ class Catalog_seed():
 
             # Add galaxy segmentation map to the master copy
             segmentation_map += galaxy_segmap
-
-            # save the galaxy image for examination by the user
-            #if self.params['Output']['save_intermediates'] is True:
-            #    galImageName = self.basename + '_galaxyRateImage_adu_per_sec.fits'
-            #    h0 = fits.PrimaryHDU(galaxyCRImage)
-            #    h1 = fits.ImageHDU(galaxy_segmap)
-            #    hlist = fits.HDUList([h0, h1])
-            #    hlist.writeto(galImageName, overwrite=True)
-            #    # self.saveSingleFits(galaxyCRImage, galImageName)
 
             # add the galaxy image to the signalimage
             signalimage = signalimage + galaxyCRImage
@@ -1610,8 +1608,9 @@ class Catalog_seed():
             # tool does not work on subarrays
             aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
             if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
-                (aperture_suffix not in ['FULL', 'CEN'])):
-                self.extended_source_seed, self.extended_source_seg_map = self.pad_wfss_subarray(self.extended_source_seed, self.extended_source_seg_map)
+                 (aperture_suffix not in ['FULL', 'CEN'])):
+                self.extended_source_seed, self.extended_source_seg_map = self.pad_wfss_subarray(self.extended_source_seed,
+                                                                                                 self.extended_source_seg_map)
 
             # Save the extended source seed image
             self.extended_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_extended_seed_image.fits')
@@ -1620,14 +1619,6 @@ class Catalog_seed():
 
             # Add galaxy segmentation map to the master copy
             segmentation_map += ext_segmap
-
-            # Save extended source image and segmap
-            #if self.params['Output']['save_intermediates'] is True:
-            #    extImageName = self.basename + '_extendedObject_adu_per_sec.fits'
-            #    h0 = fits.PrimaryHDU(extimage)
-            #    h1 = fits.ImageHDU(ext_segmap)
-            #    hlist = fits.HDUList([h0, h1])
-            #    hlist.writeto(extImageName, overwrite=True)
 
             # add the extended image to the synthetic signal rate image
             signalimage = signalimage + extimage

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1577,7 +1577,7 @@ class Catalog_seed():
             print("Simulated galaxy image and segmap saved as {}".format(self.galaxy_seed_filename))
 
             # Add galaxy segmentation map to the master copy
-            segmentation_map += galaxy_segmap
+            segmentation_map = self.add_segmentation_maps(segmentation_map, galaxy_segmap)
 
             # add the galaxy image to the signalimage
             signalimage = signalimage + galaxyCRImage
@@ -1618,7 +1618,7 @@ class Catalog_seed():
             print("Extended object image and segmap saved as {}".format(self.extended_seed_filename))
 
             # Add galaxy segmentation map to the master copy
-            segmentation_map += ext_segmap
+            segmentation_map = add_segmentation_maps(segmentation_map, ext_segmap)
 
             # add the extended image to the synthetic signal rate image
             signalimage = signalimage + extimage
@@ -1705,6 +1705,30 @@ class Catalog_seed():
     #    ysciscale = row['YSciScale'].data[0]
 
     #    return x_coeffs, y_coeffs, v2ref, v3ref, parity, yang, xsciscale, ysciscale, v3scixang
+
+    @staticmethod
+    def add_segmentation_maps(map1, map2):
+        """Add two segmentation maps together. In the case of overlapping
+        objects, the object in map1 is kept and the object in map2 is
+        ignored.
+
+        Parameters
+        ----------
+        map1 : numpy.ndarray
+            2D segmentation map
+
+        map2 : numpy.ndarray
+            2D segmentation map
+
+        Returns
+        -------
+        combined : numpy.ndarray
+            Summed segmentation map
+        """
+        map1_zeros = map1 == 0
+        combined = copy.deepcopy(map1)
+        combined[map1_zeros] += map2[map1_zeros]
+        return combined
 
     def get_point_source_list(self, filename, segment_offset=None):
         # read in the list of point sources to add, and adjust the

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -284,7 +284,11 @@ class Catalog_seed():
             self.seed_segmap *= maskimage
 
         # Save the combined static + moving targets ramp
-        self.saveSeedImage()
+        self.seed_file = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_seed_image.fits')
+        self.saveSeedImage(self.seedimage, self.seed_segmap, self.seed_file)
+        print("Final seed image and segmentation map saved as {}".format(self.seed_file))
+        print("Seed image, segmentation map, and metadata available as:")
+        print("self.seedimage, self.seed_segmap, self.seedinfo.")
 
         # Return info in a tuple
         # return (self.seedimage, self.seed_segmap, self.seedinfo)
@@ -463,9 +467,9 @@ class Catalog_seed():
             raise ValueError("Seed image is not 2D or 4D. It should be.")
         return padded_seed, padded_seg
 
-    def saveSeedImage(self):
+    def saveSeedImage(self, seed_image, segmentation_map, seed_file_name):
         # Create the grism direct image or ramp to be saved
-        arrayshape = self.seedimage.shape
+        arrayshape = seed_image.shape
         if len(arrayshape) == 2:
             units = 'ADU/sec'
             yd, xd = arrayshape
@@ -490,18 +494,12 @@ class Catalog_seed():
         kw['ycenter'] = ycent_fov
         kw['units'] = units
         kw['TGROUP'] = tgroup
-        if self.params['Readout']['pupil'][0].upper() == 'F':
-            usefilt = 'pupil'
-        else:
-            usefilt = 'filter'
-
-        self.seed_file = os.path.join(self.basename + '_' + self.params['Readout'][usefilt] + '_seed_image.fits')
 
         # Set FGS filter to "N/A" in the output file
         # as this is the value DMS looks for.
-        if self.params['Readout'][usefilt] == "NA":
-            self.params['Readout'][usefilt] = "N/A"
-        kw['filter'] = self.params['Readout'][usefilt]
+        if self.params['Readout'][self.usefilt] == "NA":
+            self.params['Readout'][self.usefilt] = "N/A"
+        kw['filter'] = self.params['Readout'][self.usefilt]
         kw['PHOTFLAM'] = self.photflam
         kw['PHOTFNU'] = self.photfnu
         kw['PHOTPLAM'] = self.pivot * 1.e4  # put into angstroms
@@ -547,10 +545,7 @@ class Catalog_seed():
 
         kw['GRISMPAD'] = self.grism_direct_factor
         self.seedinfo = kw
-        self.saveSingleFits(self.seedimage, self.seed_file, key_dict=kw, image2=self.seed_segmap, image2type='SEGMAP')
-        print("Seed image and segmentation map saved as {}".format(self.seed_file))
-        print("Seed image, segmentation map, and metadata available as:")
-        print("self.seedimage, self.seed_segmap, self.seedinfo.")
+        self.saveSingleFits(seed_image, seed_file_name, key_dict=kw, image2=segmentation_map, image2type='SEGMAP')
 
     def combineSimulatedDataSources(self, inputtype, input1, mov_tar_ramp):
         """Combine the exposure containing the trailed sources with the
@@ -1496,7 +1491,7 @@ class Catalog_seed():
                     # Create a point source image, using the specific point
                     # source list and PSF for the given segment
                     seg_psfimage, ptsrc_segmap = self.make_point_source_image(pslist, segment_number=i_segment,
-                                                                           ptsrc_segmap=ptsrc_segmap)
+                                                                              ptsrc_segmap=ptsrc_segmap)
 
                     if self.params['Output']['save_intermediates'] is True:
                         seg_psfImageName = self.basename + '_pointSourceRateImage_seg{:02d}.fits'.format(i_segment)
@@ -1510,17 +1505,41 @@ class Catalog_seed():
             ptsrc_segmap = ptsrc_segmap.segmap
 
             # save the point source image for examination by user
-            if self.params['Output']['save_intermediates'] is True:
-                psf_image_name = self.basename + '_pointSourceRateImage_adu_per_sec.fits'
-                h0 = fits.PrimaryHDU(psfimage)
-                h1 = fits.ImageHDU(ptsrc_segmap)
-                hlist = fits.HDUList([h0, h1])
-                hlist.writeto(psf_image_name, overwrite=True)
-                print("Point source image and segmap saved as {}".format(psf_image_name))
+            #if self.params['Output']['save_intermediates'] is True:
+            #    psf_image_name = self.basename + '_pointSourceRateImage_adu_per_sec.fits'
+            #    h0 = fits.PrimaryHDU(psfimage)
+            #    h1 = fits.ImageHDU(ptsrc_segmap)
+            #    hlist = fits.HDUList([h0, h1])
+            #    hlist.writeto(psf_image_name, overwrite=True)
+            #print("Point source image and segmap saved as {}".format(psf_image_name))
 
             # Add the point source image to the overall image
             signalimage = signalimage + psfimage
             segmentation_map += ptsrc_segmap
+
+            # To avoid problems with overlapping sources between source
+            # types in observations to be dispersed, make the point
+            # source-only segmentation map available as a class variable
+            self.point_source_seed = psfimage
+            self.point_source_seg_map = ptsrc_segmap
+
+            # For seed images to be dispersed in WFSS mode,
+            # embed the seed image in a full frame array. The disperser
+            # tool does not work on subarrays
+            aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
+            if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
+                (aperture_suffix not in ['FULL', 'CEN'])):
+                self.point_source_seed, self.point_source_seg_map = self.pad_wfss_subarray(self.point_source_seed, self.point_source_seg_map)
+
+            # Save the point source seed image
+            self.ptsrc_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_ptsrc_seed_image.fits')
+            self.saveSeedImage(self.point_source_seed, self.point_source_seg_map, self.ptsrc_seed_filename)
+            print("Point source image and segmap saved as {}".format(self.ptsrc_seed_filename))
+
+        else:
+            self.point_source_seed = None
+            self.point_source_seg_map = None
+            self.point_seed_filename = None
 
         # Simulated galaxies
         # Read in the list of galaxy positions/magnitudes to simulate
@@ -1531,21 +1550,44 @@ class Catalog_seed():
             # Multiply by the pixel area map
             galaxyCRImage *= self.pam
 
+            # To avoid problems with overlapping sources between source
+            # types in observations to be dispersed, make the galaxy-
+            # only segmentation map available as a class variable
+            self.galaxy_source_seed = galaxyCRImage
+            self.galaxy_source_seg_map = galaxy_segmap
+
+            # For seed images to be dispersed in WFSS mode,
+            # embed the seed image in a full frame array. The disperser
+            # tool does not work on subarrays
+            aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
+            if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
+                (aperture_suffix not in ['FULL', 'CEN'])):
+                self.galaxy_source_seed, self.galaxy_source_seg_map = self.pad_wfss_subarray(self.galaxy_source_seed, self.galaxy_source_seg_map)
+
+            # Save the galaxy source seed image
+            self.galaxy_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_galaxy_seed_image.fits')
+            self.saveSeedImage(self.galaxy_source_seed, self.galaxy_source_seg_map, self.galaxy_seed_filename)
+            print("Simulated galaxy image and segmap saved as {}".format(self.galaxy_seed_filename))
+
             # Add galaxy segmentation map to the master copy
             segmentation_map += galaxy_segmap
 
             # save the galaxy image for examination by the user
-            if self.params['Output']['save_intermediates'] is True:
-                galImageName = self.basename + '_galaxyRateImage_adu_per_sec.fits'
-                h0 = fits.PrimaryHDU(galaxyCRImage)
-                h1 = fits.ImageHDU(galaxy_segmap)
-                hlist = fits.HDUList([h0, h1])
-                hlist.writeto(galImageName, overwrite=True)
-                # self.saveSingleFits(galaxyCRImage, galImageName)
-                print("Simulated galaxy image and segmap saved as {}".format(galImageName))
+            #if self.params['Output']['save_intermediates'] is True:
+            #    galImageName = self.basename + '_galaxyRateImage_adu_per_sec.fits'
+            #    h0 = fits.PrimaryHDU(galaxyCRImage)
+            #    h1 = fits.ImageHDU(galaxy_segmap)
+            #    hlist = fits.HDUList([h0, h1])
+            #    hlist.writeto(galImageName, overwrite=True)
+            #    # self.saveSingleFits(galaxyCRImage, galImageName)
 
             # add the galaxy image to the signalimage
             signalimage = signalimage + galaxyCRImage
+
+        else:
+            self.galaxy_source_seed = None
+            self.galaxy_source_seg_map = None
+            self.galaxy_seed_filename = None
 
         # read in extended signal image and add the image to the overall image
         if self.runStep['extendedsource'] is True:
@@ -1557,20 +1599,43 @@ class Catalog_seed():
             # Multiply by the pixel area map
             extimage *= self.pam
 
+            # To avoid problems with overlapping sources between source
+            # types in observations to be dispersed, make the point
+            # source-only segmentation map available as a class variable
+            self.extended_source_seed = extimage
+            self.extended_source_seg_map = ext_segmap
+
+            # For seed images to be dispersed in WFSS mode,
+            # embed the seed image in a full frame array. The disperser
+            # tool does not work on subarrays
+            aperture_suffix = self.params['Readout']['array_name'].split('_')[-1]
+            if ((self.params['Inst']['mode'] in ['wfss', 'ts_wfss']) & \
+                (aperture_suffix not in ['FULL', 'CEN'])):
+                self.extended_source_seed, self.extended_source_seg_map = self.pad_wfss_subarray(self.extended_source_seed, self.extended_source_seg_map)
+
+            # Save the extended source seed image
+            self.extended_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_extended_seed_image.fits')
+            self.saveSeedImage(self.extended_source_seed, self.extended_source_seg_map, self.extended_seed_filename)
+            print("Extended object image and segmap saved as {}".format(self.extended_seed_filename))
+
             # Add galaxy segmentation map to the master copy
             segmentation_map += ext_segmap
 
             # Save extended source image and segmap
-            if self.params['Output']['save_intermediates'] is True:
-                extImageName = self.basename + '_extendedObject_adu_per_sec.fits'
-                h0 = fits.PrimaryHDU(extimage)
-                h1 = fits.ImageHDU(ext_segmap)
-                hlist = fits.HDUList([h0, h1])
-                hlist.writeto(extImageName, overwrite=True)
-                print("Extended object image and segmap saved as {}".format(extImageName))
+            #if self.params['Output']['save_intermediates'] is True:
+            #    extImageName = self.basename + '_extendedObject_adu_per_sec.fits'
+            #    h0 = fits.PrimaryHDU(extimage)
+            #    h1 = fits.ImageHDU(ext_segmap)
+            #    hlist = fits.HDUList([h0, h1])
+            #    hlist.writeto(extImageName, overwrite=True)
 
             # add the extended image to the synthetic signal rate image
             signalimage = signalimage + extimage
+
+        else:
+            self.extended_source_seed = None
+            self.extended_source_seg_map = None
+            self.extended_seed_filename = None
 
         # ZODIACAL LIGHT
         if self.runStep['zodiacal'] is True:
@@ -2590,11 +2655,11 @@ class Catalog_seed():
         """
         # Determine the filter name to look for
         if self.params['Inst']['instrument'].lower() in ['nircam', 'niriss']:
-            if self.params['Readout']['pupil'][0].upper() == 'F':
-                usefilt = 'pupil'
-            else:
-                usefilt = 'filter'
-            filter_name = self.params['Readout'][usefilt].lower()
+        #    if self.params['Readout']['pupil'][0].upper() == 'F':
+        #        usefilt = 'pupil'
+        #    else:
+        #        usefilt = 'filter'
+            filter_name = self.params['Readout'][self.usefilt].lower()
             # Construct the column header to look for
             specific_mag_col = "{}_{}_magnitude".format(self.params['Inst']['instrument'].lower(),
                                                         filter_name)
@@ -3715,11 +3780,10 @@ class Catalog_seed():
 
         # Make sure the requested filter is allowed. For imaging, all filters
         # are allowed. In the future, other modes will be more restrictive
-
         if self.params['Readout']['pupil'][0].upper() == 'F':
-            usefilt = 'pupil'
+            self.usefilt = 'pupil'
         else:
-            usefilt = 'filter'
+            self.usefilt = 'filter'
 
         # If instrument is FGS, then force filter to be 'NA' for the purposes
         # of constructing the correct PSF input path name. Then change to be
@@ -3728,14 +3792,14 @@ class Catalog_seed():
             self.params['Readout']['filter'] = 'NA'
             self.params['Readout']['pupil'] = 'NA'
 
-        if self.params['Readout'][usefilt] not in self.zps['Filter']:
+        if self.params['Readout'][self.usefilt] not in self.zps['Filter']:
             raise ValueError(("WARNING: requested filter {} is not in the list of "
-                              "possible filters.".format(self.params['Readout'][usefilt])))
+                              "possible filters.".format(self.params['Readout'][self.usefilt])))
 
         # Get the photflambda and photfnu values that go with
         # the filter
         mtch = ((self.zps['Detector'] == detector) &
-                (self.zps['Filter'] == self.params['Readout'][usefilt]) &
+                (self.zps['Filter'] == self.params['Readout'][self.usefilt]) &
                 (self.zps['Module'] == module))
         self.vegazeropoint = self.zps['VEGAMAG'][mtch][0]
         self.photflam = self.zps['PHOTFLAM'][mtch][0]
@@ -3793,10 +3857,10 @@ class Catalog_seed():
                     instrm = self.params['Inst']['instrument'].lower()
                     if instrm == 'nircam':
                         filter_file = ("{}_nircam_plus_ote_throughput_mod{}_sorted.txt"
-                                       .format(self.params['Readout'][usefilt].upper(), module.lower()))
+                                       .format(self.params['Readout'][self.usefilt].upper(), module.lower()))
                     elif instrm == 'niriss':
                         filter_file = ("{}_niriss_throughput1.txt"
-                                       .format(self.params['Readout'][usefilt].lower()))
+                                       .format(self.params['Readout'][self.usefilt].lower()))
                     elif instrm == 'fgs':
                         # det = self.params['Readout']['array_name'].split('_')[0]
                         filter_file = "{}_throughput_py.txt".format(detector.lower())

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -132,12 +132,18 @@ class WFSSSim():
         # Loop over the yaml files and create
         # a direct seed image for each
         imseeds = []
+        ptsrc_seeds = []
+        galaxy_seeds = []
+        extended_seeds = []
         for pfile in self.paramfiles:
             print('Running catalog_seed_image for {}'.format(pfile))
             cat = catalog_seed_image.Catalog_seed(offline=self.offline)
             cat.paramfile = pfile
             cat.make_seed()
             imseeds.append(cat.seed_file)
+            ptsrc_seeds.append(cat.ptsrc_seed_filename)
+            galaxy_seeds.append(cat.galaxy_seed_filename)
+            extended_seeds.append(cat.extended_seed_filename)
             # If Mirage is going to produce an hdf5 file of spectra,
             # then we only need a single direct seed image.
             if self.create_continuum_seds:
@@ -169,14 +175,25 @@ class WFSSSim():
         # Default to extracting all orders
         orders = None
 
-        # Create dispersed seed image from the direct images
-        disp_seed = Grism_seed(imseeds, self.crossing_filter,
-                               dmode, config_path=loc, instrument=self.instrument.upper(),
-                               extrapolate_SED=self.extrapolate_SED, SED_file=self.SED_file,
-                               SBE_save=self.source_stamps_file)
-        disp_seed.observation(orders=orders)
-        disp_seed.disperse(orders=orders)
-        disp_seed.finalize(Back=background_file)
+        # Call the disperser separately for each type of object: point sources
+        # galaxies, extended objects
+        disp_seed = np.zeros((cat.ffsize, cat.ffsize))
+        background_done = False
+        for seed_files in [ptsrc_seeds, galaxy_seeds, extended_seeds]:
+            if seed_files[0] is not None:
+                dispersed_objtype_seed = Grism_seed(seed_files, self.crossing_filter,
+                                                    dmode, config_path=loc, instrument=self.instrument.upper(),
+                                                    extrapolate_SED=self.extrapolate_SED, SED_file=self.SED_file,
+                                                    SBE_save=self.source_stamps_file)
+                dispersed_objtype_seed.observation(orders=orders)
+                dispersed_objtype_seed.disperse(orders=orders)
+                # Only include the background in one of the object type seed images
+                if not background_done:
+                    dispersed_objtype_seed.finalize(Back=background_file)
+                    background_done = True
+                else:
+                    dispersed_objtype_seed.finalize()
+                disp_seed += dispersed_objtype_seed.final
 
         # Get gain map
         gainfile = cat.params['Reffiles']['gain']
@@ -184,16 +201,16 @@ class WFSSSim():
 
         # Disperser output is always full frame. Remove the signal from
         # the refrence pixels now since we know exactly where they are
-        disp_seed.final[0:4, :] = 0.
-        disp_seed.final[2044:, :] = 0.
-        disp_seed.final[:, 0:4] = 0.
-        disp_seed.final[:, 2044:] = 0.
+        disp_seed[0:4, :] = 0.
+        disp_seed[2044:, :] = 0.
+        disp_seed[:, 0:4] = 0.
+        disp_seed[:, 2044:] = 0.
 
         # Crop to the requested subarray if necessary
         if cat.params['Readout']['array_name'] not in self.fullframe_apertures:
             print("Subarray bounds: {}".format(cat.subarray_bounds))
-            print("Dispersed seed image size: {}".format(disp_seed.final.shape))
-            disp_seed.final = self.crop_to_subarray(disp_seed.final, cat.subarray_bounds)
+            print("Dispersed seed image size: {}".format(disp_seed.shape))
+            disp_seed = self.crop_to_subarray(disp_seed, cat.subarray_bounds)
             gain = self.crop_to_subarray(gain, cat.subarray_bounds)
 
             # Segmentation map will be centered in a frame that is larger
@@ -212,11 +229,11 @@ class WFSSSim():
         # "perfect" noiseless view of the scene that does not depend on
         # detector effects, such as gain.
         if self.save_dispersed_seed:
-            self.save_dispersed_seed_image(disp_seed.final)
+            self.save_dispersed_seed_image(disp_seed)
 
         # Convert seed image to ADU/sec to be consistent
         # with other simulator outputs
-        disp_seed.final /= gain
+        disp_seed /= gain
 
         # Update seed image header to reflect the
         # division by the gain
@@ -255,7 +272,7 @@ class WFSSSim():
         # Combine into final observation
         obs = obs_generator.Observation(offline=self.offline)
         obs.linDark = obslindark
-        obs.seed = disp_seed.final
+        obs.seed = disp_seed
         obs.segmap = cat.seed_segmap
         obs.seedheader = cat.seedinfo
         #obs.paramfile = y.outname


### PR DESCRIPTION
This PR tweaks the way that the WFSS simulator code works, in order to calculate the correct dispersed signal in areas of the detector where sources **with different source types (e.g. a star and a galaxy)** overlap.  Previously the direct seed image and segmentation map were fed into the disperser. However, in cases where objects of different types overlapped, the segmentation map was being improperly calculated. In that case the object numbers from the two objects were summed. This was later interpreted as a new object number by the disperser. 

With this fix, we now save the seed image and segmentation map from each type of object separately. Each of these is then sent to the disperser, and the resulting dispersed seed images are then combined. In this way, the signal from a star and a galaxy that fall on the same pixel will be accurately computed.

This fix does *NOT* address the problem of overlapping sources of the same type (e.g. two overlapping galaxies). In that case, the segmentation map keeps the value from only one of the two objects, meaning that only one object's signal will fall on those pixels. A fix for this will come later, as it requires modifications to the disperser software.

Resolves #401 