### PR TITLE
Frame time corrections

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -870,7 +870,7 @@ class Observation():
                 f_match = self.params['Readout']['filter'] == fw_positions['Name']
                 p_match = self.params['Readout']['pupil'] == fw_positions['Name']
             elif self.instrument.upper() == 'NIRCAM':
-                if self.detector[-1] == '5':
+                if '5' in self.detector[-1] or 'LONG' in self.detector.upper():
                     channel = 'LW'
                 else:
                     channel = 'SW'

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -149,7 +149,7 @@ class Catalog_seed():
         # calculate the exposure time of a single frame, based on the size of the subarray
         self.frametime = utils.calc_frame_time(self.params['Inst']['instrument'],
                                                self.params['Readout']['array_name'],
-                                               self.nominal_dims[0], self.nominal_dims[1],
+                                               self.nominal_dims[1], self.nominal_dims[0],
                                                self.params['Readout']['namp'])
         print("Frametime is {}".format(self.frametime))
 

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -141,19 +141,23 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
     elif instrument == 'fgs':
         xs = ydim
         ys = xdim
-        colpad = 6
-        if 'acq1' in aperture.lower():
-            colpad = 12
-        rowpad = 1
-        if amps == 4:
+        colpad = 12
+
+        if namps == 4:
+            rowpad = 1
             fullpad = 1
         else:
+            rowpad = 2
             fullpad = 0
+
+        if ((xdim <= 32) & (ydim <= 32)):
+            colpad = 6
+            rowpad = 1
 
     return ((1.0 * xs / amps + colpad) * (ys + rowpad) + fullpad) * 1.e-5
 
 
-def check_niriss_filter(oldfilter,oldpupil):
+def check_niriss_filter(oldfilter, oldpupil):
     """
     This is a utility function that checks the FILTER and PUPIL parameters read in from the .yaml file and makes sure
     that for NIRISS the filter and pupil names are correct, releaving the user of the need to remember which of the 12
@@ -204,6 +208,7 @@ def check_niriss_filter(oldfilter,oldpupil):
         newfilter = oldfilter
         newpupil = oldpupil
     return newfilter, newpupil
+
 
 def ensure_dir_exists(fullpath):
     """Creates dirs from ``fullpath`` if they do not already exist.

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -109,8 +109,6 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
     """
     instrument = instrument.lower()
     if instrument == "nircam":
-        xs = xdim
-        ys = ydim
         colpad = 12
 
         # Fullframe
@@ -121,13 +119,12 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
             # All subarrays
             rowpad = 2
             fullpad = 0
+
             if ((xdim <= 8) & (ydim <= 8)):
                 # The smallest subarray
                 rowpad = 3
 
     elif instrument == "niriss":
-        xs = ydim
-        ys = xdim
         colpad = 12
 
         # Fullframe
@@ -139,22 +136,18 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
             fullpad = 0
 
     elif instrument == 'fgs':
-        xs = ydim
-        ys = xdim
-        colpad = 12
+        rowpad = 1
+        fullpad = 0
 
-        if namps == 4:
-            rowpad = 1
-            fullpad = 1
+        if ((xdim == 2048) & (ydim == 2048)):
+            colpad = 6
         else:
-            rowpad = 2
-            fullpad = 0
+            colpad = 12
 
         if ((xdim <= 32) & (ydim <= 32)):
             colpad = 6
-            rowpad = 1
 
-    return ((1.0 * xs / amps + colpad) * (ys + rowpad) + fullpad) * 1.e-5
+    return ((1.0 * xdim / amps + colpad) * (ydim + rowpad) + fullpad) * 1.e-5
 
 
 def check_niriss_filter(oldfilter, oldpupil):

--- a/tests/test_frametime.py
+++ b/tests/test_frametime.py
@@ -1,0 +1,89 @@
+'''Define unit tests for calculation of single frame exposure times
+
+Authors
+-------
+    - Bryan Hilbert
+
+Use
+---
+    Ensure you have pytest installed. Then, simply run pytest in any
+    parent directory of mirage/tests/:
+    >>> pytest
+'''
+
+import numpy as np
+
+from mirage.utils.utils import calc_frame_time
+
+
+def test_fgs_cal_frametime():
+    """These tests apply to the FGS CAL apertures only. ACQ1, ACQ2, ID,
+    TRK, and FG are not yet supported
+    """
+    fgs_full = calc_frame_time('fgs', 'FGS_', 2048, 2048, 4)
+    assert np.isclose(fgs_full, 10.61382, rtol=0., atol=1e-5)
+
+    fgs_128 = calc_frame_time('fgs', 'FGS_', 128, 128, 1)
+    assert np.isclose(fgs_128, 0.1806, rtol=0., atol=1e-5)
+
+    fgs_32 = calc_frame_time('fgs', 'FGS_', 32, 32, 1)
+    assert np.isclose(fgs_32, 0.01254, rtol=0., atol=1e-5)
+
+    fgs_8 = calc_frame_time('fgs', 'FGS_', 8, 8, 1)
+    assert np.isclose(fgs_8, 0.00126, rtol=0., atol=1e-5)
+
+
+def test_nircam_frametime():
+    """Test NIRCam exposure times
+    """
+    nrc_full = calc_frame_time('nircam', 'NRCA1_FULL', 2048, 2048, 4)
+    assert np.isclose(nrc_full, 10.73677, rtol=0., atol=1e-5)
+
+    nrc_640 = calc_frame_time('nircam', 'NRCA1_SUB640', 640, 640, 1)
+    assert np.isclose(nrc_640, 4.18584, rtol=0., atol=1e-5)
+
+    nrc_320 = calc_frame_time('nircam', 'NRCA1_SUB320', 320, 320, 1)
+    assert np.isclose(nrc_320, 1.06904, rtol=0., atol=1e-5)
+
+    nrc_160 = calc_frame_time('nircam', 'NRCA1_SUB160', 160, 160, 1)
+    assert np.isclose(nrc_160, 0.27864, rtol=0., atol=1e-5)
+
+    nrc_64 = calc_frame_time('nircam', 'NRCB4_SUB64P', 64, 64, 1)
+    assert np.isclose(nrc_64, 0.05016, rtol=0., atol=1e-5)
+
+    nrc_32 = calc_frame_time('nircam', 'NRC_SUB32TATS', 32, 32, 1)
+    assert np.isclose(nrc_32, 0.01496, rtol=0., atol=1e-5)
+
+    nrc_subgrism256_1 = calc_frame_time('nircam', 'NRC_SUBGRISM256', 2048, 256, 1)
+    print(nrc_subgrism256_1, 5.31480)
+    #assert np.isclose(nrc_subgrism256_1, 5.29420, rtol=0., atol=1e-5)
+
+    nrc_subgrism256_4 = calc_frame_time('nircam', 'NRC_SUBGRISM256', 2048, 256, 4)
+    print(nrc_subgrism256_4, 1.34669)
+    #assert np.isclose(nrc_subgrism256_4, 1.34669, rtol=0., atol=1e-5)
+
+    nrc_subgrism128_1 = calc_frame_time('nircam', 'NRC_SUBGRISM128', 2048, 128, 1)
+    print(nrc_subgrism128_1, 2.67800)
+    #assert np.isclose(nrc_subgrism128_1, 2.6574, rtol=0., atol=1e-5)
+
+    nrc_subgrism128_4 = calc_frame_time('nircam', 'NRC_SUBGRISM128', 2048, 128, 4)
+    assert np.isclose(nrc_subgrism128_4, 0.67597, rtol=0., atol=1e-5)
+
+    nrc_subgrism64_1 = calc_frame_time('nircam', 'NRC_SUBGRISM64', 2048, 64, 1)
+    assert np.isclose(nrc_subgrism64_1, 1.35960, rtol=0., atol=1e-5)
+
+    nrc_subgrism64_4 = calc_frame_time('nircam', 'NRC_SUBGRISM64', 2048, 64, 4)
+    assert np.isclose(nrc_subgrism64_4, 0.34061, rtol=0., atol=1e-5)
+
+
+def test_niriss_frametime():
+    """Test NIRISS exposure times
+    """
+    nis_full = calc_frame_time('niriss', 'NIS_CEN', 2048, 2048, 4)
+    assert np.isclose(nis_full, 10.73677, rtol=0., atol=1e-5)
+
+    nis_80 = calc_frame_time('niriss', 'NIS_SUB80', 80, 80, 1)
+    assert np.isclose(nis_80, 0.07544, rtol=0., atol=1e-5)
+
+    nis_64 = calc_frame_time('niriss', 'NIS_SUBTAAMI', 64, 64, 1)
+    assert np.isclose(nis_64, 0.05016, rtol=0., atol=1e-5)


### PR DESCRIPTION
This PR makes two small adjustments to the calculation of the frame time.

1. Correct the order of x,y inputs to calc_frame_time() in catalog_seed_image(). Previously x and y were in the wrong order. This switch was only noticed when creating data using the grism stripe 256 aperture, which is 2048 x 256. For square apertures, this correction does not change the calculated frame time.

2. Update FGS timing model. FGS frame times were updated according to the model provided by Stansberry. This includes changing the padding for subarrays 32x32 and smaller.