### PR TITLE
Channel selection

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -870,7 +870,7 @@ class Observation():
                 f_match = self.params['Readout']['filter'] == fw_positions['Name']
                 p_match = self.params['Readout']['pupil'] == fw_positions['Name']
             elif self.instrument.upper() == 'NIRCAM':
-                if self.detector[-1] == '5':
+                if '5' in self.detector or 'LONG' in self.detector:
                     channel = 'LW'
                 else:
                     channel = 'SW'


### PR DESCRIPTION
This PR makes a simple change to a line in obs_generator where the NIRCam channel value is set based on the detector. Previously the code was only looking for a '5' in the detector name in order to set the channel as 'LW'. With this change, it looks for '5' or 'LONG', so that both versions of the longwave detector names are supported.