### PR TITLE
Re-tweaked FGS timing params after more discussion

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,8 @@ dependencies:
 - scipy>=1.1.0
 - sphinx>=2.1
 - webbpsf>=0.8.0
-- yaml>=0.1.7
+- yaml==0.1.7
 - pip:
     - jwst-backgrounds>=1.1.1
-    - pysiaf==0.3.0
+    - pysiaf>=0.6.1
     - git+https://github.com/spacetelescope/jwst@0.13.8

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -125,6 +125,12 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
                 rowpad = 3
 
     elif instrument == "niriss":
+        # Reverse x and y since NIRISS's fast readout direction is
+        # opposite of NIRCam's
+        tmpx = copy.deepcopy(xdim)
+        xdim = copy.deepcopy(ydim)
+        ydim = tmpx
+
         colpad = 12
 
         # Fullframe
@@ -136,13 +142,15 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
             fullpad = 0
 
     elif instrument == 'fgs':
+        # Reverse x and y since FGS's fast readout direction is
+        # opposite of NIRCam's
+        tmpx = copy.deepcopy(xdim)
+        xdim = copy.deepcopy(ydim)
+        ydim = tmpx
+
         rowpad = 1
         fullpad = 0
-
-        if ((xdim == 2048) & (ydim == 2048)):
-            colpad = 6
-        else:
-            colpad = 12
+        colpad = 12
 
         if ((xdim <= 32) & (ydim <= 32)):
             colpad = 6

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -148,12 +148,18 @@ def calc_frame_time(instrument, aperture, xdim, ydim, amps):
         xdim = copy.deepcopy(ydim)
         ydim = tmpx
 
-        rowpad = 1
-        fullpad = 0
         colpad = 12
+        fullpad = 0
+
+        if ((xdim == 2048) & (ydim == 2048)):
+            rowpad = 1
+            fullpad = 1
+        else:
+            rowpad = 2
 
         if ((xdim <= 32) & (ydim <= 32)):
             colpad = 6
+            rowpad = 1
 
     return ((1.0 * xdim / amps + colpad) * (ydim + rowpad) + fullpad) * 1.e-5
 

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
         'matplotlib>=1.4.3',
         'numpy',
         'photutils>=0.4.0',
-        'pysiaf>=0.1.11'
+        'pysiaf>=0.6.1'
         'scipy>=0.17',
     ],
     include_package_data=True,

--- a/tests/test_frametime.py
+++ b/tests/test_frametime.py
@@ -21,16 +21,16 @@ def test_fgs_cal_frametime():
     TRK, and FG are not yet supported
     """
     fgs_full = calc_frame_time('fgs', 'FGS_', 2048, 2048, 4)
-    assert np.isclose(fgs_full, 10.73676, rtol=0., atol=1e-5), print(fgs_full)
+    assert np.isclose(fgs_full, 10.73677, rtol=0., atol=1e-5)
 
     fgs_128 = calc_frame_time('fgs', 'FGS_', 128, 128, 1)
-    assert np.isclose(fgs_128, 0.1806, rtol=0., atol=1e-5), print(fgs_128)
+    assert np.isclose(fgs_128, 0.1820, rtol=0., atol=1e-5)
 
     fgs_32 = calc_frame_time('fgs', 'FGS_', 32, 32, 1)
-    assert np.isclose(fgs_32, 0.01254, rtol=0., atol=1e-5), print(fgs_32)
+    assert np.isclose(fgs_32, 0.01254, rtol=0., atol=1e-5)
 
     fgs_8 = calc_frame_time('fgs', 'FGS_', 8, 8, 1)
-    assert np.isclose(fgs_8, 0.00126, rtol=0., atol=1e-5), print(fgs_8)
+    assert np.isclose(fgs_8, 0.00126, rtol=0., atol=1e-5)
 
 
 def test_nircam_frametime():

--- a/tests/test_frametime.py
+++ b/tests/test_frametime.py
@@ -21,16 +21,16 @@ def test_fgs_cal_frametime():
     TRK, and FG are not yet supported
     """
     fgs_full = calc_frame_time('fgs', 'FGS_', 2048, 2048, 4)
-    assert np.isclose(fgs_full, 10.61382, rtol=0., atol=1e-5)
+    assert np.isclose(fgs_full, 10.73676, rtol=0., atol=1e-5), print(fgs_full)
 
     fgs_128 = calc_frame_time('fgs', 'FGS_', 128, 128, 1)
-    assert np.isclose(fgs_128, 0.1806, rtol=0., atol=1e-5)
+    assert np.isclose(fgs_128, 0.1806, rtol=0., atol=1e-5), print(fgs_128)
 
     fgs_32 = calc_frame_time('fgs', 'FGS_', 32, 32, 1)
-    assert np.isclose(fgs_32, 0.01254, rtol=0., atol=1e-5)
+    assert np.isclose(fgs_32, 0.01254, rtol=0., atol=1e-5), print(fgs_32)
 
     fgs_8 = calc_frame_time('fgs', 'FGS_', 8, 8, 1)
-    assert np.isclose(fgs_8, 0.00126, rtol=0., atol=1e-5)
+    assert np.isclose(fgs_8, 0.00126, rtol=0., atol=1e-5), print(fgs_8)
 
 
 def test_nircam_frametime():
@@ -87,3 +87,15 @@ def test_niriss_frametime():
 
     nis_64 = calc_frame_time('niriss', 'NIS_SUBTAAMI', 64, 64, 1)
     assert np.isclose(nis_64, 0.05016, rtol=0., atol=1e-5)
+
+    nis_wfss64r = calc_frame_time('niriss', 'NIS_WFSS64R', 64, 2048, 4)
+    assert np.isclose(nis_wfss64r, 0.34061, rtol=0., atol=1e-5)
+
+    nis_wfss64c = calc_frame_time('niriss', 'NIS_WFSS64C', 2048, 64, 1)
+    assert np.isclose(nis_wfss64c, 1.55800, rtol=0., atol=1e-5)
+
+    nis_wfss128r = calc_frame_time('niriss', 'NIS_WFSS128R', 128, 2048, 4)
+    assert np.isclose(nis_wfss128r, 0.67597, rtol=0., atol=1e-5)
+
+    nis_wfss128c = calc_frame_time('niriss', 'NIS_WFSS128C', 2048, 128, 1)
+    assert np.isclose(nis_wfss128c, 2.87000, rtol=0., atol=1e-5)


### PR DESCRIPTION
This PR makes some additional adjustments to the FGS timing model after further discussions with the FGS team.

- colpad set to 12 for all but the apertures smaller than 64x64

- Added back in the x/y switch for NIRISS and FGS, which I mistakenly removed in #407 

- Added a few more frame time calculation tests, for non-square apertures