### PR TITLE
2MASS catalog to vegamag. FGS seed image filenames exclude filter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+Not Yet Tagged
+==============
+
+Catalogs
+--------
+
+- Change photometric system in catalog output from 2MASS query from ABmag to Vegamag (#415)
+
+Seed Image
+----------
+
+- Remove filter substring from seed image output file name in the case of FGS simulations (#415)
+
+
 1.1.1
 =====
 

--- a/mirage/catalogs/get_catalog.py
+++ b/mirage/catalogs/get_catalog.py
@@ -134,7 +134,7 @@ def get_sw_catalog(target_coords, search_radius=15 * u.arcmin):
         # Save shortwave catalog and header comments to file
         comments = [
             '',
-            'abmag',
+            'vegamag',
             'Catalog for ramp_simulator.py. created from 2MASS catalog',
             'Matching NIRCam SW F212N filter',
             'Magnitudes are Kmag (2-3 microns).'

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -286,7 +286,10 @@ class Catalog_seed():
             self.seed_segmap *= maskimage
 
         # Save the combined static + moving targets ramp
-        self.seed_file = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_seed_image.fits')
+        if self.params['Inst']['instrument'].lower() != 'fgs':
+            self.seed_file = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_seed_image.fits')
+        else:
+            self.seed_file = '{}_seed_image.fits'.format(self.basename)
         self.saveSeedImage(self.seedimage, self.seed_segmap, self.seed_file)
         print("Final seed image and segmentation map saved as {}".format(self.seed_file))
         print("Seed image, segmentation map, and metadata available as:")
@@ -1464,6 +1467,7 @@ class Catalog_seed():
             signalimage = np.zeros((yd, xd), dtype=np.float)
             segmentation_map = np.zeros((yd, xd))
 
+        instrument_name = self.params['Inst']['instrument'].lower()
         # yd, xd = signalimage.shape
         arrayshape = signalimage.shape
 
@@ -1539,7 +1543,10 @@ class Catalog_seed():
                                                                                            self.point_source_seg_map)
 
             # Save the point source seed image
-            self.ptsrc_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_ptsrc_seed_image.fits')
+            if instrument_name != 'fgs':
+                self.ptsrc_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_ptsrc_seed_image.fits')
+            else:
+                self.ptsrc_seed_filename = '{}_ptsrc_seed_image.fits'.format(self.basename)
             self.saveSeedImage(self.point_source_seed, self.point_source_seg_map, self.ptsrc_seed_filename)
             print("Point source image and segmap saved as {}".format(self.ptsrc_seed_filename))
 
@@ -1573,7 +1580,10 @@ class Catalog_seed():
                                                                                              self.galaxy_source_seg_map)
 
             # Save the galaxy source seed image
-            self.galaxy_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_galaxy_seed_image.fits')
+            if instrument_name != 'fgs':
+                self.galaxy_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_galaxy_seed_image.fits')
+            else:
+                self.galaxy_seed_filename = '{}_galaxy_seed_image.fits'.format(self.basename)
             self.saveSeedImage(self.galaxy_source_seed, self.galaxy_source_seg_map, self.galaxy_seed_filename)
             print("Simulated galaxy image and segmap saved as {}".format(self.galaxy_seed_filename))
 
@@ -1614,7 +1624,10 @@ class Catalog_seed():
                                                                                                  self.extended_source_seg_map)
 
             # Save the extended source seed image
-            self.extended_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_extended_seed_image.fits')
+            if instrument_name != 'fgs':
+                self.extended_seed_filename = os.path.join(self.basename + '_' + self.params['Readout'][self.usefilt] + '_extended_seed_image.fits')
+            else:
+                self.extended_seed_filename = '{}_extended_seed_image.fits'.format(self.basename)
             self.saveSeedImage(self.extended_source_seed, self.extended_source_seg_map, self.extended_seed_filename)
             print("Extended object image and segmap saved as {}".format(self.extended_seed_filename))
 

--- a/mirage/utils/flux_cal.py
+++ b/mirage/utils/flux_cal.py
@@ -59,6 +59,8 @@ def fluxcal_info(params, usefilt, detector, module):
     # manually add a Detector key to the dictionary as a placeholder.
     if params["Inst"]["instrument"].lower() in ["nircam", "niriss"]:
         zps = add_detector_to_zeropoints(detector, zpts)
+    else:
+        zps = copy.deepcopy(zpts)
 
     # Make sure the requested filter is allowed
     if params['Readout'][usefilt] not in zps['Filter']:


### PR DESCRIPTION
This PR fixes two small bugs:

- In get_sw_catalog(), which is the 2MASS catalog search in get_catalog.py, the photometric system in the output source catalog is changed from abmag to vegamag.

- In catalog_seed_image, when saving seed images for FGS simulations, the filter name is excluded from the seed image file name. Since FGS has no filters, it doesn't make sense to have "NA" in every filename. In addition, Mirage changes the filter value to be "N/A", to agree with what CRDS expects, but this was then causing Mirage to look for a filename with "N/A" in it, which was a problem. With this change, the filter substring is removed completely.

Resolves #413 
Resolves #414 