### PR TITLE
Use correct RA, Dec values when constructing PC matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.1.4
+=====
+
+WCS keywords
+------------
+
+- Correct the input RA and Dec used to calculate the values of the PC matrix. Remove the calculation of CRVAL1,2 from set_telescope_pointing.py since it is already done in observation_generator.py
+
+
 1.1.3
 =====
 

--- a/mirage/utils/set_telescope_pointing_separated.py
+++ b/mirage/utils/set_telescope_pointing_separated.py
@@ -135,8 +135,10 @@ def add_wcs(filename, roll=0.):
     #try:
     #    q, j2fgs_matrix, fsmcorr, obstime = get_pointing(obsstart, obsend)
     #except ValueError as exception:
-    ra = pheader['TARG_RA']
-    dec = pheader['TARG_DEC']
+    #ra = pheader['TARG_RA']
+    #dec = pheader['TARG_DEC']
+    ra = fheader['CRVAL1']
+    dec = fheader['CRVAL2']
     #roll = 0
 
     #logger.warning(
@@ -173,11 +175,11 @@ def add_wcs(filename, roll=0.):
     #        '\n\tRA = {} DEC={} PA_V3={}'.format(crval1, crval2, v3_pa_deg)
     #    )
 
-    fheader['RA_V1'] = v1_ra_deg
-    fheader['DEC_V1'] = v1_dec_deg
-    fheader['PA_V3'] = v3_pa_deg
-    fheader['CRVAL1'] = crval1
-    fheader['CRVAL2'] = crval2
+    #fheader['RA_V1'] = v1_ra_deg
+    #fheader['DEC_V1'] = v1_dec_deg
+    #fheader['PA_V3'] = v3_pa_deg
+    #fheader['CRVAL1'] = crval1
+    #fheader['CRVAL2'] = crval2
     fheader['PC1_1'] = -np.cos(pa_aper_deg * D2R)
     fheader['PC1_2'] = np.sin(pa_aper_deg * D2R)
     fheader['PC2_1'] = np.sin(pa_aper_deg * D2R)


### PR DESCRIPTION
This PR makes a small change to set_telescope_pointing.py. Previously, the values of the PC matrix were being created using an attitude matrix derived from RA_TARG and DEC_TARG. This used to be correct when RA_TARG and DEC_TARG were being populated with the RA and Dec values of the pointing. But now that the correct target RA, Dec are being populated, the PC matrix and CRVAL keyword values are incorrect. This fix corrects those values by basing the PC matrix values on the CRVAL header keyword values, which themselves are the RA, Dec of the pointing.