### PR TITLE
Correct bug in psf library selection for NIRCam PW filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,19 @@
+1.1.5
+=====
+
+PSF Selection
+-------------
+
+- Fix bug in PSF library selection code for observations using one of NIRCam's filters present in the pupil wheel. The bug was preventing the correct library file from being found. (#420)
+
+
 1.1.4
 =====
 
 WCS keywords
 ------------
 
-- Correct the input RA and Dec used to calculate the values of the PC matrix. Remove the calculation of CRVAL1,2 from set_telescope_pointing.py since it is already done in observation_generator.py
+- Correct the input RA and Dec used to calculate the values of the PC matrix. Remove the calculation of CRVAL1,2 from set_telescope_pointing.py since it is already done in observation_generator.py (#419)
 
 
 1.1.3

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -37,7 +37,7 @@ from astropy.io import fits
 import numpy as np
 from webbpsf.utils import to_griddedpsfmodel
 
-from mirage.utils.constants import NIRISS_PUPIL_WHEEL_FILTERS
+from mirage.utils.constants import NIRISS_PUPIL_WHEEL_FILTERS, NIRCAM_PUPIL_WHEEL_FILTERS
 from mirage.utils.utils import expand_environment_variable
 
 
@@ -108,6 +108,35 @@ def confirm_gridded_properties(filename, instrument, detector, filtername, pupil
             pupil = 'CLEAR'
         elif instrument.upper() == 'NIRISS':
             pupil = 'CLEARP'
+
+    # NIRISS has many filters in the pupil wheel. WebbPSF does
+    # not make a distinction, but Mirage does. Adjust the info
+    # to match Mirage's expectations
+    if inst.upper() == 'NIRISS' and filt in NIRISS_PUPIL_WHEEL_FILTERS:
+        save_filt = copy(filt)
+        if pupil == 'CLEARP':
+            filt = 'CLEAR'
+        else:
+            raise ValueError(('Pupil value is something other than '
+                              'CLEARP, but the filter being used is '
+                              'in the pupil wheel.'))
+        pupil = save_filt
+
+    # Same for NIRCam
+    if inst.upper() == 'NIRCAM' and filt in NIRCAM_PUPIL_WHEEL_FILTERS:
+        save_filt = copy(filt)
+        if pupil == 'CLEAR':
+            if save_filt[0:2] == 'F4':
+                filt = 'F444W'
+            elif save_filt[0:2] == 'F3':
+                filt = 'F322W2'
+            elif save_filt[0:2] == 'F1':
+               filt = 'F150W2'
+        else:
+            raise ValueError(('Pupil value is something other than '
+                              'CLEAR, but the filter being used is '
+                              'in the pupil wheel.'))
+        pupil = save_filt
 
     opd_file = header['OPD_FILE']
     if default_psf:
@@ -322,6 +351,22 @@ def get_library_file(instrument, detector, filt, pupil, wfe, wfe_group,
                 else:
                     raise ValueError(('Pupil value is something other than '
                                       'CLEARP, but the filter being used is '
+                                      'in the pupil wheel.'))
+                file_pupil = save_filt
+
+            # Same for NIRCam
+            if file_inst.upper() == 'NIRCAM' and file_filt in NIRCAM_PUPIL_WHEEL_FILTERS:
+                save_filt = copy(file_filt)
+                if file_pupil == 'CLEAR':
+                    if save_filt[0:2] == 'F4':
+                        file_filt = 'F444W'
+                    elif save_filt[0:2] == 'F3':
+                        file_filt = 'F322W2'
+                    elif save_filt[0:2] == 'F1':
+                        file_filt = 'F150W2'
+                else:
+                    raise ValueError(('Pupil value is something other than '
+                                      'CLEAR, but the filter being used is '
                                       'in the pupil wheel.'))
                 file_pupil = save_filt
 

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -23,6 +23,7 @@ EXPTYPES = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
 
 NIRISS_FILTER_WHEEL_FILTERS = ['F277W', 'F356W', 'F380M', 'F430M', 'F444W', 'F480M']
 NIRISS_PUPIL_WHEEL_FILTERS = ['F090W', 'F115W', 'F158M', 'F140M', 'F150W', 'F200W']
+NIRCAM_PUPIL_WHEEL_FILTERS = ['F162M', 'F164N', 'F323N', 'F405N', 'F466N', 'F470N']
 
 FLAMBDA_CGS_UNITS = u.erg / u.second / u.cm / u.cm / u.AA
 FLAMBDA_MKS_UNITS = u.watt / u.meter**2 / u.micron


### PR DESCRIPTION
This PR contains a fix in the logic for selecting a PSF library file in the case of an observation that uses a NIRCam pupil wheel filter. Previously the pupil value was set to that of the filter (as intended), but the filter value was never set to the appropriate blocking filter. This fix corrects that.