### PR TITLE
Switch versioning from relic to setuptools_scm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,11 +9,4 @@ include mirage/config/refpix.cfg
 include mirage/config/saturation.cfg
 include mirage/config/superbias.cfg
 include mirage/config/xtalk20150303g0.errorcut.txt
-include RELIC-INFO
 exclude mirage/version.py
-
-# Not recommended: Uncomment below to bundle RELIC during `sdist`
-#
-#recursive-include relic *
-#prune relic/.git
-#prune relic/tests

--- a/mirage/__init__.py
+++ b/mirage/__init__.py
@@ -1,0 +1,16 @@
+import re
+import sys
+from pkg_resources import get_distribution, DistributionNotFound
+
+__version_commit__ = ''
+_regex_git_hash = re.compile(r'.*\+g(\w+)')
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    __version__ = 'dev'
+
+if '+' in __version__:
+    commit = _regex_git_hash.match(__version__).groups()
+    if commit:
+        __version_commit__ = commit[0]

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -39,7 +39,6 @@ from mirage.utils import read_fits, utils, siaf_interface
 from mirage.utils.file_splitting import find_file_splits
 from mirage.reference_files import crds_tools
 
-MIRAGE_VERSION = mirage.__version__
 
 # Allowed instruments
 INST_LIST = ['nircam', 'niriss', 'fgs']
@@ -932,7 +931,7 @@ class DarkPrep():
             h0.header['FASTAXIS'] = self.fastaxis
 
             # Add some basic Mirage-centric info
-            h0.header['MRGEVRSN'] = (MIRAGE_VERSION, 'Mirage version used')
+            h0.header['MRGEVRSN'] = (mirage.__version__, 'Mirage version used')
             h0.header['YAMLFILE'] = (self.paramfile, 'Mirage input yaml file')
 
             hl = fits.HDUList([h0, h1, h2, h3, h4])

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -34,14 +34,12 @@ import pkg_resources
 import numpy as np
 from astropy.io import fits, ascii
 
-
+import mirage
 from mirage.utils import read_fits, utils, siaf_interface
 from mirage.utils.file_splitting import find_file_splits
 from mirage.reference_files import crds_tools
 
-from mirage import version
-
-MIRAGE_VERSION = version.__version__
+MIRAGE_VERSION = mirage.__version__
 
 # Allowed instruments
 INST_LIST = ['nircam', 'niriss', 'fgs']

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -52,7 +52,6 @@ from mirage.utils import read_fits, utils, siaf_interface
 from mirage.utils import set_telescope_pointing_separated as stp
 from mirage.utils.constants import EXPTYPES
 
-MIRAGE_VERSION = mirage.__version__
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {"nircam": ["imaging", "ts_imaging", "wfss", "ts_grism"],
@@ -391,7 +390,7 @@ class Observation():
             HDU List containing Mirage-related info in the primary header
         """
         hdulist = fits.HDUList([fits.PrimaryHDU(), fits.ImageHDU()])
-        hdulist[0].header['MRGEVRSN'] = (MIRAGE_VERSION, 'Mirage version used')
+        hdulist[0].header['MRGEVRSN'] = (mirage.__version__, 'Mirage version used')
         hdulist[0].header['YAMLFILE'] = (self.paramfile, 'Mirage input yaml file')
         hdulist[0].header['GAINFILE'] = (self.params['Reffiles']['gain'], 'Gain file used by Mirage')
         hdulist[0].header['DISTORTN'] = (self.params['Reffiles']['astrometric'],

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -45,14 +45,14 @@ from astropy.time import Time, TimeDelta
 import astropy.units as u
 import pysiaf
 
+import mirage
 from mirage.ramp_generator import unlinearize
 from mirage.reference_files import crds_tools
 from mirage.utils import read_fits, utils, siaf_interface
 from mirage.utils import set_telescope_pointing_separated as stp
 from mirage.utils.constants import EXPTYPES
-from mirage import version
 
-MIRAGE_VERSION = version.__version__
+MIRAGE_VERSION = mirage.__version__
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {"nircam": ["imaging", "ts_imaging", "wfss", "ts_grism"],

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -51,7 +51,6 @@ from mirage.utils.file_splitting import find_file_splits, SplitFileMetaData
 from ..psf.segment_psfs import (get_gridded_segment_psf_library_list,
                                 get_segment_offset, get_segment_library_list)
 
-MIRAGE_VERSION = mirage.__version__
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {'nircam': ["imaging", "ts_imaging", "wfss", "ts_grism"],
@@ -846,7 +845,7 @@ class Catalog_seed():
         kw['POISSON'] = self.params['simSignals']['poissonseed']
         kw['PSFWFE'] = self.params['simSignals']['psfwfe']
         kw['PSFWFGRP'] = self.params['simSignals']['psfwfegroup']
-        kw['MRGEVRSN'] = MIRAGE_VERSION
+        kw['MRGEVRSN'] = mirage.__version__
 
         # Observations with high data volumes (e.g. moving targets, TSO)
         # can be split into multiple "segments" in order to cap the

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -35,6 +35,7 @@ import pysiaf
 
 from . import moving_targets
 from . import segmentation_map as segmap
+import mirage
 from mirage.catalogs.catalog_generator import TSO_GRISM_INDEX
 from mirage.seed_image import tso
 from ..reference_files import crds_tools
@@ -49,10 +50,8 @@ from ..utils.constants import grism_factor, TSO_MODES
 from mirage.utils.file_splitting import find_file_splits, SplitFileMetaData
 from ..psf.segment_psfs import (get_gridded_segment_psf_library_list,
                                 get_segment_offset, get_segment_library_list)
-from mirage import version
 
-MIRAGE_VERSION = version.__version__
-
+MIRAGE_VERSION = mirage.__version__
 
 INST_LIST = ['nircam', 'niriss', 'fgs']
 MODES = {'nircam': ["imaging", "ts_imaging", "wfss", "ts_grism"],

--- a/mirage/seed_image/save_seed.py
+++ b/mirage/seed_image/save_seed.py
@@ -6,10 +6,9 @@ Utility for saving seed images
 from astropy.io import fits
 import numpy as np
 
-from mirage import version
+import mirage
 
-MIRAGE_VERSION = version.__version__
-
+MIRAGE_VERSION = mirage.__version__
 
 def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength,
          fullframe_size, nominal_dimensions, coord_adjust, grism_direct_factor,

--- a/mirage/seed_image/save_seed.py
+++ b/mirage/seed_image/save_seed.py
@@ -8,7 +8,6 @@ import numpy as np
 
 import mirage
 
-MIRAGE_VERSION = mirage.__version__
 
 def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength,
          fullframe_size, nominal_dimensions, coord_adjust, grism_direct_factor,
@@ -86,7 +85,7 @@ def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength
     kw['POISSON'] = parameters['simSignals']['poissonseed']
     kw['PSFWFE'] = parameters['simSignals']['psfwfe']
     kw['PSFWFGRP'] = parameters['simSignals']['psfwfegroup']
-    kw['MRGEVRSN'] = MIRAGE_VERSION
+    kw['MRGEVRSN'] = mirage.__version__
 
     # Seed images provided to disperser are always embedded in an array
     # with dimensions equal to full frame * self.grism_direct_factor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools>=41.2.0",
+			"wheel",
+			"setuptools_scm>=3.3.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=41.2.0",
+requires = ["setuptools>=38.2.5",
 			"wheel",
-			"setuptools_scm>=3.3.3"]
+			"setuptools_scm"]

--- a/setup.py
+++ b/setup.py
@@ -7,28 +7,6 @@ from setuptools import setup, find_packages, Extension, Command
 from setuptools.command.test import test as TestCommand
 
 
-if not pkgutil.find_loader('relic'):
-    relic_local = os.path.exists('relic')
-    relic_submodule = (relic_local and
-                       os.path.exists('.gitmodules') and
-                       not os.listdir('relic'))
-    try:
-        if relic_submodule:
-            subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-        elif not relic_local:
-            subprocess.check_call(['git', 'clone', 'https://github.com/spacetelescope/relic.git'])
-
-        sys.path.insert(1, 'relic')
-    except subprocess.CalledProcessError as e:
-        print(e)
-        exit(1)
-
-import relic.release
-
-version = relic.release.get_info()
-relic.release.write_template(version, 'mirage')
-
-
 # allows you to build sphinx docs from the package
 # main directory with "python setup.py build_sphinx"
 
@@ -84,7 +62,6 @@ except ImportError:
 
 setup(
     name='mirage',
-    version=version.pep386,
     description='Create simulated JWST data',
     long_description=('A tool to create simulated NIRCam, NIRISS,'
                       'and FGS exposures'
@@ -112,6 +89,8 @@ setup(
                              'tests/test_data/*/*.pointing',
                              'config/*.*']
                   },
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     install_requires=[
         'asdf>=1.2.0',
         'astropy>=3.2.1',


### PR DESCRIPTION
This PR switches over to use setuptools-scm for versioning. Prior to this, mirage was using relic for versioning. 