### PR TITLE
Fix segmentation map in non-sidereal simulations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Master Branch
+=============
+
+Non-sidereal
+------------
+
+Segmentation map addition bug corrected. Example notebook and input yaml file updated.
+
+
 1.2.2
 =====
 

--- a/examples/MovingTarget_simulator_use_examples.ipynb
+++ b/examples/MovingTarget_simulator_use_examples.ipynb
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,74 +190,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CRDS_PATH environment variable not set. Setting to /Users/hilbert/crds_cache\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_mask_0032.fits as the badpixmask reference file.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_superbias_0021.fits as the superbias reference file.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_linearity_0049.fits as the linearity reference file.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_saturation_0066.fits as the saturation reference file.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_gain_0054.fits as the gain reference file.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_ipc_0023.fits as the ipc reference file.\n",
-      "No inverted IPC kernel file found. Kernel will be inverted prior to use.\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_distortion_0063.asdf as the astrometric reference file.\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/xtalk20150303g0.errorcut.txt for Reffiles:crosstalk input file\n",
-      "From CRDS, found /Users/hilbert/crds_cache/references/jwst/nircam/jwst_nircam_area_0026.fits as the pixelAreaMap reference file.\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/NIRCam_subarray_definitions.list for Reffiles:subarray_defs input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/nircam_filter_pupil_pairings.list for Reffiles:filtpupilcombo input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/NIRCam_zeropoints.list for Reffiles:flux_cal input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/nircam_read_pattern_definitions.list for Reffiles:readpattdefs input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/placeholder.txt for Reffiles:filter_throughput input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/nircam_psf_wing_rate_thresholds.txt for simSignals:psf_wing_threshold_file input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/dq_init.cfg for newRamp:dq_configfile input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/saturation.cfg for newRamp:sat_configfile input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/superbias.cfg for newRamp:superbias_configfile input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/refpix.cfg for newRamp:refpix_configfile input file\n",
-      "'config' specified: Using /Users/hilbert/python_repos/mirage/mirage/config/linearity.cfg for newRamp:linear_configfile input file\n",
-      "/ifs/jwst/wit/mirage_data/nircam/gridded_psf_library\n",
-      "Requested readout pattern RAPID is valid. Using the nframe = 1 and nskip = 0\n",
-      "No galaxy catalog provided in yaml file.\n",
-      "NOTE: Using pre-delivery SIAF data for NIRCam\n",
-      "SIAF: Requested NRCB5_FULL   got NRCB5_FULL\n",
-      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n",
-      "output dimensions are: [2048 2048]\n",
-      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n",
-      "Frametime is 10.736770000000002\n",
-      "PSFs will be generated using: /ifs/jwst/wit/mirage_data/nircam/gridded_psf_library/nircam_nrcb5_f250m_clear_fovp41_samp5_npsf16_predicted_realization0.fits\n",
-      "PSF wings will be from: nircam_nrcb5_f250m_clear_fovp401_samp1_predicted_realization0.fits\n",
-      "Creating signal ramp of synthetic inputs\n",
-      "Point list input positions assumed to be in units of RA and Dec.\n",
-      "WARNING: Catalog temp_non_sidereal_point_sources.list does not have a magnitude column called nircam_f250m_magnitude, but does have a generic 'magnitude' column. Continuing simulation using that.\n",
-      "Filtering point sources to keep only those on the detector\n",
-      "Number of point sources found within the requested aperture: 1\n",
-      "2019-09-16 12:30:05.595672: Working on source 0\n",
-      "Adding moving background point sources to seed image.\n",
-      "Setting velocity of targets equal to the non-sidereal tracking velocity\n",
-      "Using nircam_f250m_magnitude column in sidereal_point_sources.cat for magnitudes\n",
-      "Expected time to process 20 sources: 88.65 seconds (1.48 minutes)\n",
-      "Done with creating moving targets from /Users/hilbert/python_repos/mirage/examples/movingtarget_example_data/sidereal_point_sources.cat\n"
-     ]
-    },
-    {
-     "ename": "TypeError",
-     "evalue": "unsupported operand type(s) for +: 'SegMap' and 'int'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-6-492fdbae58b9>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mm\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mimaging_simulator\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mImgSim\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparamfile\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0myamlfile\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0mm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcreate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/python_repos/mirage/mirage/imaging_simulator.py\u001b[0m in \u001b[0;36mcreate\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     49\u001b[0m         \u001b[0mcat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcatalog_seed_image\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCatalog_seed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0moffline\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moffline\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     50\u001b[0m         \u001b[0mcat\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparamfile\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparamfile\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 51\u001b[0;31m         \u001b[0mcat\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmake_seed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     52\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     53\u001b[0m         \u001b[0;31m# Create observation generator object\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/python_repos/mirage/mirage/seed_image/catalog_seed_image.py\u001b[0m in \u001b[0;36mmake_seed\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    228\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparams\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'Telescope'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'tracking'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlower\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'non-sidereal'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Creating signal ramp of synthetic inputs'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 230\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mseedimage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mseed_segmap\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnon_sidereal_seed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    231\u001b[0m             \u001b[0moutapp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'_nonsidereal_target'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    232\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/python_repos/mirage/mirage/seed_image/catalog_seed_image.py\u001b[0m in \u001b[0;36mnon_sidereal_seed\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    750\u001b[0m                 \u001b[0;31m# non_sidereal_zero += mtt_zero_list[i]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    751\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mmtt_data_segmap\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 752\u001b[0;31m             \u001b[0mnonsidereal_segmap\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mmtt_data_segmap\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    753\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mnon_sidereal_ramp\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnonsidereal_segmap\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: unsupported operand type(s) for +: 'SegMap' and 'int'"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "# Run all steps of the imaging simulator for yaml file #1\n",
     "m = imaging_simulator.ImgSim()\n",
@@ -332,7 +269,7 @@
     "# as a normal PSF (although hard to see in this view). All of the \n",
     "# background stars and galaxies are\n",
     "# smeared, since the telescope was not tracking at the sidereal rate.\n",
-    "show(m.seedimage[0,-1,:,:],'Seed Image',max=250)"
+    "show(m.seedimage[0,-1,:,:], 'Seed Image', max=250)"
    ]
   },
   {

--- a/examples/movingtarget_example_data/moving_target_test.yaml
+++ b/examples/movingtarget_example_data/moving_target_test.yaml
@@ -1,7 +1,7 @@
 Inst:
   instrument: NIRCam          #Instrument name
   mode: imaging               #Observation mode (e.g. imaging, WFSS, moving_target)
-  use_JWST_pipeline: False   #Use pipeline in data transformations
+  use_JWST_pipeline: True   #Use pipeline in data transformations
 
 Readout:
   readpatt: RAPID        #Readout pattern (RAPID, BRIGHT2, etc)
@@ -32,6 +32,7 @@ Reffiles:                                 #Set to None or leave blank if you wis
   readpattdefs:    config   #File that contains a list of all possible readout pattern names and associated NFRAME/NSKIP values
   crosstalk:       config   #File containing crosstalk coefficients
   filtpupilcombo:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
+  filter_wheel_positions: config  # File containing resolver wheel positions for each filter/pupil
   flux_cal:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
   filter_throughput: config #File containing filter throughput curve
 
@@ -59,7 +60,7 @@ simSignals:
   psfwfe: predicted                               #PSF WFE value (0,115,123,132,136,150,155)
   psfwfegroup: 0                             #WFE realization group (0 to 9)
   galaxyListFile: None
-  extended: None          #Extended emission count rate image file name
+  extended: None         #Extended emission count rate image file name
   extendedscale: 1.0         #Scaling factor for extended emission image
   extendedCenter: 1024,1024  #x,y pixel location at which to place the extended image if it is smaller than the output array size
   PSFConvolveExtended: True #Convolve the extended image with the PSF before adding to the output image (True or False)
@@ -105,6 +106,9 @@ Output:
   PI_Name: D. Adams  #Proposal PI Name
   Proposal_category: GO  #Proposal category
   Science_category: Cosmology  #Science category
+  target_name: 'My_Target'
+  target_ra: 53.101
+  target_dec: -27.801
   observation_number: '002'    #Observation Number
   observation_label: Obs1    #User-generated observation Label
   visit_number: '024'    #Visit Number

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -3003,7 +3003,8 @@ class Observation():
             ex4 = fits.ImageHDU(err_ext.astype(np.float32), name='ERR')
             ex5 = fits.ImageHDU(zeroframe.astype(np.float32), name='ZEROFRAME')
             ex6 = fits.BinTableHDU(name='GROUP')
-            outModel = fits.HDUList([ex0, ex1, ex2, ex3, ex4, ex5, ex6])
+            ex7 = fits.BinTableHDU(name='INT_TIMES')
+            outModel = fits.HDUList([ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7])
             groupextnum = 6
 
         elif mod == '1b':
@@ -3011,7 +3012,8 @@ class Observation():
             ex1 = fits.ImageHDU(ramp.astype(np.uint16), name='SCI')
             ex2 = fits.ImageHDU(zeroframe.astype(np.uint16), name='ZEROFRAME')
             ex3 = fits.BinTableHDU(name='GROUP')
-            outModel = fits.HDUList([ex0, ex1, ex2, ex3])
+            ex4 = fits.BinTableHDU(name='INT_TIMES')
+            outModel = fits.HDUList([ex0, ex1, ex2, ex3, ex4])
             groupextnum = 3
 
         try:
@@ -3115,8 +3117,8 @@ class Observation():
 
         # Create INT_TIMES table, to be saved in INT_TIMES extension
         int_times = self.int_times_table(ramptime, self.params['Output']['date_obs'], self.params['Output']['time_obs'],
-                                         outModel.data.shape[0])
-        outModel['INT_TIMES'] = int_times
+                                         outModel['SCI'].data.shape[0])
+        outModel['INT_TIMES'].data = int_times
 
         if self.runStep['fwpw']:
             fwpw = ascii.read(self.params['Reffiles']['filtpupilcombo'])

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1117,8 +1117,8 @@ class Catalog_seed():
                 non_sidereal_ramp += mtt_data_list[i]
                 # non_sidereal_zero += mtt_zero_list[i]
         if mtt_data_segmap is not None:
-            nonsidereal_segmap += mtt_data_segmap
-        return non_sidereal_ramp, nonsidereal_segmap
+            nonsidereal_segmap.segmap += mtt_data_segmap
+        return non_sidereal_ramp, nonsidereal_segmap.segmap
 
     def readMTFile(self, filename):
         """
@@ -1721,6 +1721,7 @@ class Catalog_seed():
 
             ptsrc = self.get_point_source_list(temp_ptsrc_filename)
             ptsrcCRImage, ptsrcCRSegmap = self.make_point_source_image(ptsrc)
+
             totalCRList.append(ptsrcCRImage)
             totalSegList.append(ptsrcCRSegmap)
 
@@ -1743,6 +1744,7 @@ class Catalog_seed():
             galaxies.write(os.path.join(self.params['Output']['directory'], 'temp_non_sidereal_sersic_sources.list'), format='ascii', overwrite=True)
 
             galaxyCRImage, galaxySegmap = self.make_galaxy_image('temp_non_sidereal_sersic_sources.list')
+
             galaxyCRImage *= self.pam
             totalCRList.append(galaxyCRImage)
             totalSegList.append(galaxySegmap)


### PR DESCRIPTION
This PR fixes the segmentation map error that was affecting the non-sidereal object simulations.

- Bug affecting the addition of segmentation maps corrected

- Non-sidereal example notebook updated

- Input yaml file used in example notebook brought up-to-date with new input fields

