### PR TITLE
Add extension-helpers to doc build to fix doc failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ DOCS_REQUIRE = [
     'sphinx-automodapi',
     'sphinx-rtd-theme',
     'stsci-rtd-theme',
+    'extension-helpers',
 ]
 TESTS_REQUIRE = [
     'pytest',


### PR DESCRIPTION
Readthedocs builds are failing. Adding extension-helpers to doc dependencies, at @pllim suggestion.