### PR TITLE
Correct schema for X/YOFFSET keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+Unreleased
+==========
+
+Header Keywords
+---------------
+
+Corrected schema to populate the XOFFSET and YOFFSET header keywords
+
+
+Reference Files
+---------------
+
+Fix bug in downloader that was preventing NIRISS darks from being downloaded (#450)
+
+
 1.3.2
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Unreleased
 Header Keywords
 ---------------
 
-Corrected schema to populate the XOFFSET and YOFFSET header keywords
+Corrected schema to populate the XOFFSET and YOFFSET header keywords (#454)
 
 
 Reference Files

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
-Unreleased
-==========
+1.3.3
+=====
 
 Header Keywords
 ---------------

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2874,8 +2874,8 @@ class Observation():
         outModel.meta.dither.subpixel_type = self.params['Output']['subpix_dither_type']
         outModel.meta.dither.subpixel_number = self.params['Output']['subpix_dither_position']
         outModel.meta.dither.subpixel_total_points = self.params['Output']['total_subpix_dither_positions']
-        outModel.meta.dither.xoffset = self.params['Output']['xoffset']
-        outModel.meta.dither.yoffset = self.params['Output']['yoffset']
+        outModel.meta.dither.x_offset = self.params['Output']['xoffset']
+        outModel.meta.dither.y_offset = self.params['Output']['yoffset']
 
         # pixel coordinates in FITS header start from 1 not from 0
         xc = (self.subarray_bounds[2] + self.subarray_bounds[0])/2.+1.


### PR DESCRIPTION
This PR corrects the schema entry used to populate the XOFFSET and YOFFEST header keywords. Prior to this update, the offset values were contained in the asdf entry of the output file, but under the incorrect entry, and the XOFFSET and YOFFSET keywords were not being created.

Resolves #453 