### PR TITLE
TA lines in NIRISS AMI proposal: pointing file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+1.3.3
+=====
+
+APT Pointing File
+-----------------
+
+Bug fix such that the only Target Acquisition observations that are read in are those for NIRCam TSO observations.
+
+
 1.3.2
 =====
 

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -775,11 +775,7 @@ class AptInput:
                                                          or 'FGS' in elements[4]
                                                          or 'NRS' in elements[4]
                                                          or 'MIR' in elements[4])
-                            ) or (('TA' in elements[4]) & ('NRC' in elements[4]
-                                                         or 'NIS' in elements[4]
-                                                         or 'FGS' in elements[4]
-                                                         or 'NRS' in elements[4]
-                                                         or 'MIR' in elements[4])):
+                            ) or (('TA' in elements[4]) & ('NRC' in elements[4])):
                             if (elements[18] == 'PARALLEL') and ('MIRI' in elements[4]):
                                 skip = True
 


### PR DESCRIPTION
This PR fixes a bug in apt_inputs.py where Mirage was reading in target acquisition lines from the APT pointing file. But, since the only TA observations that Mirage currently supports are those for NIRCam TSO observations, this was resulting in Mirage crashing when it came across a TA observation for a mode other than TSO. (The bug was discovered when running a NIRISS AMI observation.) 

I believe this bug only affects NIRISS AMI (and possibly NIRISS External Calibration) at the moment, since Mirage does not support NIRISS SOSS, and those are the only NIRISS observing templates with a TA observation.

Resolves #459 