### PR TITLE
Allow strings for jitter input to webbpsf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ UNRELEASED:
 Commissioning
 -------------
 
-Lajoie implemented an optional telescope boresight offset and fixed the tilt scaling issue seen between SW and LW data when using segment_psfs.
+Allow use of strings for jitter input in the webbpsf call when generating PSF libraries for WFSC. A recent update (beyond 0.9.0) to webbpsf allows
+for this input. (#464)
+
+Updated the unstacked mirror and nonnominal PSF notebooks with bug fixes and improvements to support upcoming rehearsal. New notebook dealing with
+unstacked mirrors added to the repo. Updates made to get_catalog.py, psf_selection.py, yaml_generator.py and catalog_seed_image.py to support the
+unique PSF libraries used by WFSC simulations. (#463)
+
+Lajoie implemented an optional telescope boresight offset and fixed the tilt scaling issue seen between SW and LW data when using segment_psfs. (#462)
 
 
 1.3.3

--- a/mirage/psf/segment_psfs.py
+++ b/mirage/psf/segment_psfs.py
@@ -112,6 +112,13 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
             nc.options['jitter'] = 'gaussian'
             nc.options['jitter_sigma'] = jitter
             print('Adding jitter', jitter)
+        elif isinstance(jitter, str):
+            allowed_strings = ['PCS=Coarse_Like_ITM', 'PCS=Coarse']
+            if jitter in allowed_strings:
+                nc.options['jitter'] = jitter
+                print('Adding {} jitter'.format(jitter))
+            else:
+                print("Invalid jitter string. Must be one of: {}. Ignoring and using defaults.".format(allowed_strings))
         else:
             print("Wrong input to jitter, assuming defaults")
 


### PR DESCRIPTION
This PR allows the user to input a string for the jitter value in the call to webbpsf when creating a gridded PSF library for WFSC libraries only. This change does not affect science observations or PSF libraries at all.

@Skyhawk172 does this look good to you?