### PR TITLE
Add APERNAME value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 UNRELEASED:
 ===========
 
+Metadata
+--------
+
+Populate APERNAME keyword in headers of output files. This keyword is not used by the jwst calibration pipeline later, but was requested by
+people working on WFSC simulations for their data analyses. (#467)
+
 Commissioning
 -------------
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2773,6 +2773,8 @@ class Observation():
         outModel.meta.program.science_category = self.params['Output']['Science_category']
         outModel.meta.program.continuation_id = 0
 
+        outModel.meta.aperture.name = self.params['Readout']['array_name']
+
         outModel.meta.target.catalog_name = 'UNKNOWN'
         outModel.meta.target.ra = self.params['Output']['target_ra']
         outModel.meta.target.dec = self.params['Output']['target_dec']
@@ -3086,6 +3088,8 @@ class Observation():
         outModel[0].header['SUBCAT'] = 'UNKNOWN'
         outModel[0].header['SCICAT'] = self.params['Output']['Science_category']
         outModel[0].header['CONT_ID'] = 0
+
+        outModel[0].header['APERNAME'] = self.params['Readout']['array_name']
 
         outModel[0].header['TARGNAME'] = 'UNKNOWN'
         outModel[0].header['TARGPROP'] = self.params['Output']['target_name']


### PR DESCRIPTION
This PR adds code to populate the APERNAME header keyword in the simulation files output by Mirage.  The aperture name has always been used by Mirage. This update just adds that name to the APERNAME keyword. This keyword is not used by the ``jwst`` calibration pipeline, even though it is in the datamodel schema. Folks working on WFSC simulations requested this keyword in order to help with their data analysis. 