### PR TITLE
Fix typo in JWST version tag in the install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -21,7 +21,7 @@ These are: **jwst**, which is the JWST calibration pipeline software, and two pa
     pip install mirage
     pip install git+https://github.com/npirzkal/GRISMCONF#egg=grismconf
     pip install git+https://github.com/npirzkal/NIRCAM_Gsim#egg=nircam_gsim
-    pip install git+https://github.com/spacetelescope/jwst@0.14.2
+    pip install git+https://github.com/spacetelescope/jwst#0.15.1
 
 .. tip::
     Some of Mirage's dependencies rely on `Healpy <https://healpy.readthedocs.io/en/latest/>`_,. Healpy has released different wheels for different versions of Mac OSX. For example, healpy version 1.12.5


### PR DESCRIPTION
Resolves #465 

This PR fixes a typo in the Mirage installation instructions. When installing the jwst calibration pipeline, the documentation originally said to install using:

pip install git+https://github.com/spacetelescope/jwst@0.14.2

The '@' in here is a typo, which git ignores. Someone using this command would have the current development version of the pipeline installed, rather than version 0.14.2. So this PR changes the @ to a #, which is what it should have been. We also update from version 0.14.2 to 0.15.1.