### PR TITLE
Allow input raw dark to have no zeroframe. Create approximation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 UNRELEASED:
 ===========
 
+Dark Current
+------------
+
+Update dark_prep.py to allow the input of non-RAPID dark current exposures with no zeroframe extension. In this case, Mirage will construct
+an approximate zeroframe extension and add it in to the exposure. This situation should only occur in the case where older ground-testing
+darks that have been converted from FITS Writer format are used. (#470)
+
 Metadata
 --------
 

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,6 @@ dependencies:
     - batman-package
     - jwst-backgrounds>=1.1.1
     - pysiaf>=0.6.1
-    - git+https://github.com/spacetelescope/jwst@0.14.2
+    - git+https://github.com/spacetelescope/jwst#0.15.1
     - git+https://github.com/npirzkal/GRISMCONF
     - git+https://github.com/npirzkal/NIRCAM_Gsim

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - defaults
 dependencies:
 - asdf>=2.1.0
-- astropy==3.2.1
+- astropy>=4.0
 - astroquery>=0.3.8
 - crds>=7.4.1
 - gwcs>=0.11

--- a/mirage/utils/read_fits.py
+++ b/mirage/utils/read_fits.py
@@ -35,6 +35,8 @@ class Read_fits():
         self.translate['NFRAMES'] = 'exposure.nframes'
         self.translate['NSKIP'] = 'exposure.nskip'
         self.translate['GROUPGAP'] = 'exposure.groupgap'
+        self.translate['TFRAME'] = 'exposure.frame_time'
+        self.translate['TGROUP'] = 'exposure.group_time'
         self.translate['EXP_TYPE'] = 'exposure.type'
         self.translate['DETECTOR'] = 'instrument.detector'
         self.translate['INSTRUME'] = 'instrument.name'

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     setup_requires=['setuptools_scm'],
     install_requires=[
         'asdf>=2.1.0',
-        'astropy>=3.2.1',
+        'astropy>=4.0',
         'astroquery>=0.3.8',
         'batman-package',
         'crds>=7.4.1',


### PR DESCRIPTION
This PR makes a small adjustment to ```dark_prep.py```  that allows a user to input a non-RAPID dark current ramp that has no ```zeroframe``` extension. This allows for older ground testing darks to be used as inputs. 

In the case where a non-RAPID dark with no zeroframe extension is provided, ```dark_prep.py``` will construct an approximation of the zeroframe extension by normalizing the signal in the initial group by the exposure time of a single frame. This zeroframe will be used in ```obs_generator.py``` when it is added to the zeroframe containing the signal of the simulated astronomical sources. This summed zeroframe is placed in the zeroframe extension of the uncal file output by Mirage. At the moment, the jwst calibration pipeline does not do anything with this extension. In the future, it will be used to calculate the signal rate for pixels that are saturated in all groups of an exposure.