### PR TITLE
Updates to documentation, env, and testing for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ compiler: gcc
 sudo: false
 
 python:
-    - 3.5
-    - 3.6
-    - 3.7
+    - "3.5"
+    - "3.6"
+    - "3.7"
 
 env:
     global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,13 @@ compiler: gcc
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
+python:
+    - 3.5
+    - 3.6
+    - 3.7
+
 env:
     global:
-        - PYTHON_VERSION=3.6
         - EVENT_TYPE='push pull_request'
 
 matrix:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 UNRELEASED:
 ===========
 
+Python version
+--------------
+
+Update environment.yml file and installation documentation to show that Mirage works with python 3.7 (as well as 3.6 and 3.5) (#471)
+
 Dark Current
 ------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ These are: **jwst**, which is the JWST calibration pipeline software, and two pa
 
 ::
 
-    conda create -n mirage python=3.6 -y
+    conda create -n mirage python=3.7 -y
     conda activate mirage
     pip install healpy==1.12.5
     pip install mirage
@@ -47,14 +47,14 @@ Installation can then be done via pip, which uses setup.py, or using the conda e
 To install using pip and setup.py:
 Create and activate a new environment. In this example we call the environment "mirage". Then move into the mirage directory, and install Mirage into the new environment::
 
-    conda create -n mirage python=3.6 -y
+    conda create -n mirage python=3.7 -y
     conda activate mirage
     cd mirage
     pip install healpy==1.12.5
     pip install .
     pip install git+https://github.com/npirzkal/GRISMCONF#egg=grismconf
     pip install git+https://github.com/npirzkal/NIRCAM_Gsim#egg=nircam_gsim
-    pip install git+https://github.com/spacetelescope/jwst@0.14.2
+    pip install git+https://github.com/spacetelescope/jwst#0.15.1
 
 .. tip::
     Some of Mirage's dependencies rely on `Healpy <https://healpy.readthedocs.io/en/latest/>`_,. Healpy has released different wheels for different versions of Mac OSX. For example, healpy version 1.12.5
@@ -66,7 +66,7 @@ Create and activate a new environment. In this example we call the environment "
 Or, to install using the environment file, again creating an environment called "mirage"::
 
     cd mirage
-    conda env create -f environment.yml --name mirage python=3.6
+    conda env create -f environment.yml --name mirage python=3.7
     conda activate mirage
     pip install .
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - numpy>=1.16
 - photutils>=0.6
 - pytest>=3.8.1
-- python>=3.6,<3.7
+- python>=3.7,<3.8
 - scipy>=1.1.0
 - sphinx>=2.1
 - synphot>=0.2.0


### PR DESCRIPTION
This PR updates Mirage to use python 3.7 as the default version. Documentation for environment creation has been updated from python 3.6 to 3.7. Travis testing is now done using python 3.5, 3.6, and 3.7 (previously only 3.6).  The environment file has also been updated to specify python 3.7.

Tests have shown undiagnosed problems when running with 3.8, which is why it's not included here.