### PR TITLE
Add installation notes for Mac OSX 10.14 Mojave

### DIFF
--- a/docs/example_yaml.rst
+++ b/docs/example_yaml.rst
@@ -54,6 +54,7 @@ Below is an example yaml input file for *Mirage*. The yaml file used as the prim
 	  filtpupilcombo_:  config   #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
 	  filter_wheel_positions_: config  #File that lists the filter wheel element / pupil wheel element combinations. Used only in writing output file
 	  flux_cal_:        config   #File that lists flux conversion factor and pivot wavelength for each filter. Only used when making direct image outputs to be fed into the grism disperser code.
+	  filter_throughput_: /Users/me/mirage/mirage/config/placeholder.txt #File containing filter throughput curve
 
 	nonlin_:
 	  limit_: 60000.0        #Upper singal limit to which nonlinearity is applied (ADU)
@@ -86,6 +87,8 @@ Below is an example yaml input file for *Mirage*. The yaml file used as the prim
 	  movingTargetExtended_: None                     #ascii file containing a list of stamp images to add as moving targets (planets, moons, etc)
 	  movingTargetConvolveExtended_: True             #convolve the extended moving targets with PSF before adding.
 	  movingTargetToTrack_: None                      #File containing a single moving target which JWST will track during observation (e.g. a planet, moon, KBO, asteroid)	This file will only be used if mode is set to "moving_target"
+	  tso_imaging_catalog_: None                      #Catalog listing TSO source to be used for imaging TSO simulations
+	  tso_grism_catalog_: None                        #Catalog listing TSO source to be used for grism TSO observations
 	  zodiacal_:  None                                #Zodiacal light count rate image file
 	  zodiscale_:  1.0                                #Zodi scaling factor
 	  scattered_:  None                               #Scattered light count rate image file
@@ -512,6 +515,15 @@ Ascii file that lists flux conversion factors and the pivot wavelength associate
 .. hint::
 	To use the flux calibration files packaged with Mirage, set this to **config** in the input yaml file. This is the default when creating yaml files from an APT file using the :ref:`yaml generator <yaml_generator>`
 
+.. _filter_throughput:
+
+Filter Throughput
++++++++++++++++++
+
+*Reffiels:filter_throughput*
+
+Ascii files that contains the system throughput when using a particular filter. By default, the yaml generator will set this parameter to have a value of "placeholder.txt" in the input yaml files. Mirage will then locate the appropriate throughput file at runtime.
+
 .. _nonlin:
 
 Nonlin section
@@ -767,6 +779,24 @@ Tracked non-sidereal target catalog file
 *simSignals:movingTargetToTrack*
 
 This ascii catalog file is used for what are traditionally (in HST jargon) called 'moving targets'.  Targets listed in this file are treated as non-sidereal targets that JWST will track during the simulated observation. In this case, the target listed in this file will appear static in the output data, but all other sources (e.g. those listed in :ref:`pointSource <pointsource>`, :ref:`galaxyListFile <galaxyListFile>`, and :ref:`extended <extended>`) will all appear trailed through the data. A description and example of the file are shown in the :ref:`Non-sidereal Source <nonsidereal>` section on the :ref:`Catalogs <catalogs>` page.
+
+.. _tso_imaging_catalog:
+
+TSO Imaging Catalog
++++++++++++++++++++
+
+*simSignals:tso_imaging_catalog*
+
+Ascii catalog file containing information on the source to be used when creating imaging TSO observations. The catalog format is detailed in the :ref:`Imaging TSO Catalog section <imaging_tso_cat>` section of the :ref:`Source Catalog Formats page <catalogs>`.
+
+.. _tso_grism_catalog:
+
+TSO Grism Catalog
++++++++++++++++++
+
+*simSignals:tso_grism_catalog*
+
+Ascii catalog file containing information on the source to be used when creating grism TSO observations. The catalog format is detailed in the :ref:`Grism TSO Catalog section <grism_tso_cat>` section of the :ref:`Source Catalog Formats page <catalogs>`.
 
 .. _zodiacal:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,6 +4,15 @@ There are two aspects to Mirage installation. First, the software itself must be
 must be downloaded. The preferred installation method is via :ref:`Pypi <pypi>`, as this is the latest stable version of the software.
 
 
+.. attention::
+    **For those running Mac OSX 10.14:**
+
+    There are several extra steps that must be taken when installing Mirage on a machine running Mac OSX 10.14 (Mojave). These changes are relalted to the option of running calculations in the `Batman <https://github.com/lkreidberg/batman>`_ package in parallel. There are two options for this modified installation, which are described in this `Batman issue on github <https://github.com/lkreidberg/batman/issues/32https://github.com/lkreidberg/batman/issues/32>`_
+
+    1. (The less invasive method) If you do want to make use of parallel processing, you must install LLVM and OpenMP on your machine prior to installing Mirage as described below. See this `StackOverflow issue <https://stackoverflow.com/questions/43555410/enable-openmp-support-in-clang-in-mac-os-x-sierra-mojave>`_ for details.
+
+    2. If you do not wish to use parallel processing within Batman, then you must clone the `Batman <https://github.com/lkreidberg/batman>`_ package, open its *setup.py* file, and remove "-fopenmp". In this case, it is easiest to then :ref:`install Mirage via the environment file <env_file_install>`. Before creating the environment, remove Batman from the environment file. Then create the environment, and then pip install the local copy of Batman.
+
 .. _pypi:
 
 Install from Pypi
@@ -63,7 +72,9 @@ Create and activate a new environment. In this example we call the environment "
 .. tip::
     This method installs `webbpsf <https://webbpsf.readthedocs.io/en/latest/>`_ via pip. In this case, you must also `manually download the collection of webbpsf data files <https://webbpsf.readthedocs.io/en/latest/installation.html#installing-the-required-data-files>`_ If you install webbpsf via conda, the data files are downloaded and installed for you.
 
-Or, to install using the environment file, again creating an environment called "mirage"::
+.. _env_file_install:
+
+**Or, to install using the environment file, again creating an environment called "mirage"**::
 
     cd mirage
     conda env create -f environment.yml --name mirage python=3.6

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,11 +7,8 @@ must be downloaded. The preferred installation method is via :ref:`Pypi <pypi>`,
 .. attention::
     **For those running Mac OSX 10.14:**
 
-    There are several extra steps that must be taken when installing Mirage on a machine running Mac OSX 10.14 (Mojave). These changes are relalted to the option of running calculations in the `Batman <https://github.com/lkreidberg/batman>`_ package in parallel. There are two options for this modified installation, which are described in this `Batman issue on github <https://github.com/lkreidberg/batman/issues/32https://github.com/lkreidberg/batman/issues/32>`_
+    Some users have reported errors when installing Mirage on their machines running Mac OSX 10.14. If you see installation failures for the synphot or batman packages, they are most likely related to the OpenMP library. See the section below on :ref:`Troubleshooting for Mac OSX 10.14 installtion <osx1014>`.
 
-    1. (The less invasive method) If you do want to make use of parallel processing, you must install LLVM and OpenMP on your machine prior to installing Mirage as described below. See this `StackOverflow issue <https://stackoverflow.com/questions/43555410/enable-openmp-support-in-clang-in-mac-os-x-sierra-mojave>`_ for details.
-
-    2. If you do not wish to use parallel processing within Batman, then you must clone the `Batman <https://github.com/lkreidberg/batman>`_ package, open its *setup.py* file, and remove "-fopenmp". In this case, it is easiest to then :ref:`install Mirage via the environment file <env_file_install>`. Before creating the environment, remove Batman from the environment file. Then create the environment, and then pip install the local copy of Batman.
 
 .. _pypi:
 
@@ -83,6 +80,45 @@ Create and activate a new environment. In this example we call the environment "
 
 .. tip::
     For this latter case, packages are installed via conda. For `webbpsf <https://webbpsf.readthedocs.io/en/latest/installation.html#requirements-installation>`_, this means the data files will be downloaded and installed with the software itself. No manual installation of the data files is necessary.
+
+
+.. _osx1014:
+
+Troubleshooting for Mac OSX 10.14 installtion
+---------------------------------------------
+
+If you have installation errors on your machine running 10.14 (Mojave), try these solutions.
+
+Synphot
++++++++
+
+If the synphot package fails to build, try installing via conda using the conda-forge channel. Do this before installing Mirage, using the command:
+
+    - conda install synphot -c conda-forge
+
+Batman
+++++++
+
+If the `Batman <https://github.com/lkreidberg/batman>`_ package fails to build, the work-around is more complex. Mirage uses the Batman package when simulating imaging and grism Time Series Observations (TSO).
+
+The installation errors are related to supporting Batman's ability to run calculations in parallel. There are two options for modifying the installation, which are described in this `Batman issue on github <https://github.com/lkreidberg/batman/issues/32https://github.com/lkreidberg/batman/issues/32>`_
+
+    1. If you do want to make use of parallel processing (or simply want to try the less invasive installation fix), you must install LLVM and OpenMP on your machine prior to installing Mirage. See this `StackOverflow issue <https://stackoverflow.com/questions/43555410/enable-openmp-support-in-clang-in-mac-os-x-sierra-mojave>`_ for details. If you successfully install these, then you should be able to install Mirage following the instructions in the sections above.
+
+
+    2. If you do not wish to use parallel processing within Batman, or the option above fails, then you can modify Batman such that it does not use parallel processing. This involves modifying the Batman and Mirage *setup.py* files and install using those. Clone the `Batman <https://github.com/lkreidberg/batman>`_ package, open its *setup.py* file, and remove "-fopenmp". Then you must clone Mirage and remove Batman from Mirage's *environment.yml* and *setup.py* files. Then create the environment using *environment.yml*, pip install the local copy of Batman, and pip install the local copy of Mirage.
+
+    ::
+
+        cd mirage
+        conda env create -f environment.yml --name mirage python=3.6
+        conda activate mirage
+        pip install .
+        cd ../batman
+        pip install .
+
+    3. If you are having installtion problems and will not be creating TSO simulations, you could skip Batman installation altogether. In this case you will still need to clone Mirage and remove Batman from the *environment.yml* and *setup.py* files. Then :ref:`install Mirage via the environment file <env_file_install>`.
+
 
 .. _ref_file_collection:
 


### PR DESCRIPTION
This PR adds a note in the documentation to help with Mirage installation for users running Mac OSX 10.14. This is needed because installation of the Batman dependency will fail unless the user has first installed LLVM and OpenMP. The other option involves cloning Batman and modifying its setup.py file before installing.

Resolves #451 