### PR TITLE
Dark entries in yaml_generator if no darks are present

### DIFF
--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -661,9 +661,15 @@ class SimInput:
         if self.use_linearized_darks:
             self.info['dark'] = [None] * len(darks)
             self.info['lindark'] = lindarks
+            if set(lindarks) == set([None]):
+                raise RuntimeError(("ERROR: Linearized darks requested, but no linearized dark files "
+                                    "found. Check: {}").format(os.path.join(os.path.expandvars('$MIRAGE_DATA'), instrument)))
         else:
             self.info['dark'] = darks
             self.info['lindark'] = [None] * len(lindarks)
+            if set(darks) == set([None]):
+                raise RuntimeError(("ERROR: Raw darks requested, but no raw dark files found. "
+                                    "Check: {}").format(os.path.join(os.path.expandvars('$MIRAGE_DATA'), instrument)))
 
         # Add setting describing whether JWST pipeline will be used
         self.info['use_JWST_pipeline'] = [self.use_JWST_pipeline] * len(darks)

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -657,7 +657,6 @@ class SimInput:
             darks.append(self.get_dark(instrument, det))
             lindarks.append(self.get_lindark(instrument, det))
 
-        self.info['dark'] = darks
         # If linearized darks are to be used, set the darks to None
         if self.use_linearized_darks:
             self.info['dark'] = [None] * len(darks)
@@ -900,9 +899,11 @@ class SimInput:
         files = self.dark_list[instrument][detector]
         if len(files) == 1:
             return files[0]
-        else:
+        elif len(files) > 1:
             rand_index = np.random.randint(0, len(files) - 1)
             return files[rand_index]
+        else:
+            return None
 
     def get_lindark(self, instrument, detector):
         """
@@ -922,9 +923,11 @@ class SimInput:
         files = self.lindark_list[instrument][detector]
         if len(files) == 1:
             return files[0]
-        else:
+        elif len(files) > 1:
             rand_index = np.random.randint(0, len(files) - 1)
             return files[rand_index]
+        else:
+            return None
 
     def get_readpattern_defs(self, filename=None):
         """Read in the readpattern definition file and return table.


### PR DESCRIPTION
This PR addresses a bug where the yaml_generator crashed in the case where only the linearized dark current inputs were present. The yaml_generator searches for both raw and linearized input darks regardless of which type the user requests. In the case where someone has downloaded only one kind of darks, this would lead to the yaml_generator crashing when the other type of darks was not present.

With this fix, yaml_generator still searches for both types of darks, but returns None if no dark file is found.

Resolves #477 