### PR TITLE
APT files with obs numbers out of order

### DIFF
--- a/mirage/yaml/generate_observationlist.py
+++ b/mirage/yaml/generate_observationlist.py
@@ -442,7 +442,7 @@ def expand_for_dithers(indict, verbose=True):
         print('Number of entries after expanding dithers:  {}'.format(len(expanded_table)))
 
     if verbose:
-        for obs_id in np.unique(expanded_table['ObservationID']):
+        for obs_id in list(dict.fromkeys(expanded_table['ObservationID'])):
             print('Expanded table for Observation {} has {} entries'.format(obs_id, len(np.where(expanded_table['ObservationID']==obs_id)[0])))
     return expanded
 
@@ -494,9 +494,7 @@ def get_observation_dict(xml_file, yaml_file, catalogs,
     return_dict = None
 
     # array of unique instrument names
-    used_instruments = np.unique(xml_dict['Instrument'])
     all_observation_ids = xml_dict['ObservationID']
-    unique_observation_ids = np.unique(all_observation_ids).tolist()
 
     # List of target names from the proposal
     all_targets = xml_dict['TargetID']
@@ -651,13 +649,13 @@ def get_observation_dict(xml_file, yaml_file, catalogs,
     entry_number = 0  # running number for every entry in the observation list
 
     # Create an instrument-specific counter to be used with input catalogs
-    all_instruments = np.unique(xml_dict['Instrument'])
     counter = {}
-    for inst in all_instruments:
+    for inst in np.unique(xml_dict['Instrument']):
         counter[inst] = 0
 
     entry_numbers = []
-    observation_numbers = np.unique(xml_dict['ObservationID'])
+    observation_numbers = list(dict.fromkeys(xml_dict['ObservationID']))
+
     for observation_index, observation_number in enumerate(observation_numbers):
         first_index = xml_dict['ObservationID'].index(observation_number)
         text += [
@@ -665,7 +663,6 @@ def get_observation_dict(xml_file, yaml_file, catalogs,
             "  Name: '{}'\n".format(xml_dict['ObservationName'][first_index])
             ]
         observation_rows = np.where(np.array(xml_dict['ObservationID']) == observation_number)[0]
-        instruments_in_observation = np.unique(np.array(xml_dict['Instrument'])[observation_rows])
         for index in observation_rows:
             number_of_dithers = np.int(xml_dict['number_of_dithers'][index])
             instrument = xml_dict['Instrument'][index]


### PR DESCRIPTION
This PR corrects a bug in generate_observationlist.py that was causing incorrect yaml files to be created in the case where the APT program contains observation numbers that are not monotonically increasing. The use of numpy.unique on the list of observation numbers was returning a list of unique observation numbers, but was also reordering the values from lowest to highest. This was then causing the table of exposures to be modified out of order, when the assumption was that it was being done in the order the observations appear.

By replacing the calls to numpy.unique with list(dict.fromkeys(observation_list)), a list of unique observation numbers is now returned in the order that they appear in the APT file. The resulting yaml files are now correct regardless of the relative order and value of observation number.
