### PR TITLE
NIRISS filter name typos

### DIFF
--- a/mirage/config/niriss_dual_wheel_list.txt
+++ b/mirage/config/niriss_dual_wheel_list.txt
@@ -3,11 +3,11 @@ F090W      CLEAR         F090W
 F115W      CLEAR         F115W
 F140M      CLEAR         F140M
 F150W      CLEAR         F150W
-F159M      CLEAR         F159M
+F158M      CLEAR         F158M
 F200W      CLEAR         F200W
 F277W      F277W         CLEARP
 F356W      F356W         CLEARP
 F380M      F380M         CLEARP
 F430M      F430M         CLEARP
 F444W      F444W         CLEARP
-F580M      F480M         CLEARP
+F480M      F480M         CLEARP


### PR DESCRIPTION
niriss_dual_wheel_list.txt has two typos. This PR fixes those typos.

Resolves #499 