### PR TITLE
Avoid sources with negative sersic, ellipticity, radius

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1684,7 +1684,7 @@ class Observation():
             signalgain[neg] = 0.
 
         # Add poisson noise
-        newimage = np.random.poisson(signalgain, signalgain.shape).astype(np.float)
+        newimage = np.random.poisson(signalgain, signalgain.shape).astype(np.float64)
 
         if np.nanmin(signalgain) < 0.:
             newimage[neg] = negatives[neg]

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3474,6 +3474,17 @@ class Catalog_seed():
             factor = 0.
         else:
             factor = totalcounts / summedcounts
+
+
+
+
+        print('\n\nin create_galaxy:')
+        print(radius, ellipticity, sersic, posang, totalcounts, summedcounts)
+        print(np.nanmin(img), np.nanmax(img), np.min(img), np.max(img))
+        print('\n\n')
+
+
+
         img = img * factor
 
         # Crop image down such that it contains 99.95% of the total signal

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3475,16 +3475,6 @@ class Catalog_seed():
         else:
             factor = totalcounts / summedcounts
 
-
-
-
-        print('\n\nin create_galaxy:')
-        print(radius, ellipticity, sersic, posang, totalcounts, summedcounts)
-        print(np.nanmin(img), np.nanmax(img), np.min(img), np.max(img))
-        print('\n\n')
-
-
-
         img = img * factor
 
         # Crop image down such that it contains 99.95% of the total signal


### PR DESCRIPTION
This is a small update to galaxy_background(). I was getting errors from signal values higher than the limit of a 64-bit float in my simulation. I think this was due to galaxies with unrealistic parameters. galaxy_background() adds random offsets to radius, ellipticity, and sersic index, but was not checking to ensure positive values for everything.

This update includes some checking to force the radius, ellipticity, and sersic index to be positive and no larger than the largest values in the 3DHST catalog from which the sources are retrieved.