### PR TITLE
Add file splitting to imaging mode data

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -391,30 +391,6 @@ class DarkPrep():
         for ref in rlist:
             self.ref_check(ref)
 
-    def file_splits(self):
-        """Check to see whether the final dark file will need to be
-        split into segments due to large file size
-        """
-        # Let's declare the equivalent of a 100 group full frame ramp
-        # as the upper limit for observation file size
-        pixel_limit = 2048 * 2048 * 100
-
-        xd = self.subarray_bounds[3] - self.subarray_bounds[1]
-        yd = self.subarray_bounds[2] - self.subarray_bounds[0]
-        pix_per_int = self.numgroups * yd * xd
-        observation = pix_per_int * self.numints
-
-        split = False
-        int_list = [0, self.numints]
-        if observation > pixel_limit:
-            split = True
-            ints_per_split = np.int(pixel_limit / pix_per_int)
-            #num_splits = self.numints / ints_per_split
-            int_list = np.arange(0, self.numints, ints_per_split)
-            if int_list[-1] != self.numints:
-                int_list = np.append(int_list, self.numints)
-        return split, int_list
-
     def get_base_dark(self, input_file):
         """Read in the dark current ramp that will serve as the
         base for the simulated ramp"""

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1166,8 +1166,12 @@ class Observation():
                 try:
                     print("Creating output file name with segment number.")
                     parts = basename.split('_')
-                    basename = '{}_{}_{}-seg{}_{}_{}'.format(parts[0], parts[1], parts[2], seg_str,
-                                                             parts[3], parts[4])
+
+                    if len(parts) == 5:
+                        basename = '{}_{}_{}-seg{}_{}_{}'.format(parts[0], parts[1], parts[2], seg_str,
+                                                                 parts[3], parts[4])
+                    else:
+                        basename = basename.replace('.fits', '-seg{}.fits'.format(seg_str))
                 except IndexError:
                     # Non-standard filename format
                     basename = basename.replace('.fits', '-seg{}.fits'.format(seg_str))

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -570,7 +570,7 @@ class Catalog_seed():
                         print('\n\n\ntotal_seed_segments-and_parts: ', self.total_seed_segments_and_parts)
                         seg_string = str(self.segment_number).zfill(3)
                         part_string = str(self.segment_part_number).zfill(3)
-                        self.seed_file = '{}_{}_{}_seg{}_part{}_seed_image.fits'.format(self.basename, self.params['Readout'][filter],
+                        self.seed_file = '{}_{}_{}_seg{}_part{}_seed_image.fits'.format(self.basename, self.params['Readout']['filter'],
                                                                                         self.params['Readout']['pupil'], seg_string, part_string)
 
                         self.saveSeedImage(seed, segmap, self.seed_file)

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -348,7 +348,11 @@ class WFSSSim():
             d = dark_prep.DarkPrep(offline=self.offline)
             d.paramfile = self.wfss_yaml
             d.prepare()
-            obslindark = d.prepDark
+
+            if len(d.dark_files) == 1:
+                obslindark = d.prepDark
+            else:
+                obslindark = d.dark_files
         else:
             self.read_dark_product()
             obslindark = self.darkPrep


### PR DESCRIPTION
This PR adds file splitting for imaging mode observations. File splitting was already implemented for imaging TSO and grism TSO observations, but it is also possible for other modes to have observations that are large enough to trigger file splitting. This has been seen in several WFSC commissioning programs. 

These changes allow for file splitting in imaging data with sidereal tracking. 

- [x] Test updates with imaging observations that are both over and under the splitting limit

- [x] Test with WFSS observations both over and under the limit.

- [x] Test TSO imaging mode to make sure these changes haven't caused any errors

- [x] Test TSO grism mode to make sure these changes haven't caused any errors

These changes will not affect non-sidereal observations, nor sidereal observations that contain non-sidereal targets (e.g. background asteroids). Implementing file splitting for those modes will be much more complicated and invasive, and at the moment is lower priority.
