### PR TITLE
Make segmentation map thresholds a user input

### DIFF
--- a/docs/example_yaml.rst
+++ b/docs/example_yaml.rst
@@ -44,6 +44,7 @@ Below is an example yaml input file for *Mirage*. The yaml file used as the prim
 	  pixelflat_: None
 	  illumflat_: None           #Illumination flat field file
 	  astrometric_: crds         #Astrometric distortion file (asdf)
+	  photom_: crds              #Cal pipeline photom reference file
 	  ipc_: crds                 #File containing IPC kernel to apply
 	  invertIPC_: True           #Invert the IPC kernel before the convolution. True or False. Use True if the kernel is designed for the removal of IPC effects, like the JWST reference files are.
 	  occult_: None              #Occulting spots correction image
@@ -99,6 +100,8 @@ Below is an example yaml input file for *Mirage*. The yaml file used as the prim
 	  pymethod_: True                                 #Use double Poisson simulation for photon yield
 	  expand_catalog_for_segments_: False             # Expand catalog for 18 segments and use distinct PSFs
 	  use_dateobs_for_background_: False              # Use date_obs value to determine background. If False, bkgdrate is used.
+	  signal_low_limit_for_segmap_: 0.031             # Lower signal limit for a pixel to be included in the segmentation map
+	  signal_low_limit_for_segmap_units_: ADU/sec     # Units of signal_low_limit_for_segmap_. Can be: ADU/sec, e/sec, MJy/sr, ergs/cm2/a, ergs/cm2/hz
 
 	Telescope_:
 	  ra_: 53.1                     #RA of simulated pointing
@@ -398,6 +401,19 @@ Name of the astrometric distortion reference file to use for including the effec
 
 .. hint::
 	Setting this entry equal to 'crds' will cause Mirage to query the Calibration Reference Database System (CRDS) for the appropriate file, and download that file if it is not already present in your CRDS cache.
+
+.. _photom:
+
+Photom Reference File
++++++++++++++++++++++
+
+*Reffiles:photom*
+
+Name of the JWST calibration pipeline photom reference file to use. This file is used to translate the minimum flux level for pixel inclusion in the segmentation map to ADU/sec in the case where the user provides that value in MJy/sr.
+
+.. hint::
+	Setting this entry equal to 'crds' will cause Mirage to query the Calibration Reference Database System (CRDS) for the appropriate file, and download that file if it is not already present in your CRDS cache.
+
 
 .. _ipc:
 
@@ -921,6 +937,25 @@ Use date_obs for background
 *simSignals:use_dateobs_for_background*
 
 This entry controls the way the background signal for the observation is calculated. If it is True, then the background value will be created by extracting the background spectrum assoicated with :ref:`date_obs <date_obs>` from the `jwst_backgrounds <https://github.com/spacetelescope/jwst_backgrounds>`_ package. If False, the background will be determined by calculating the background value at a certain percentile of the collection of backgrounds for the given pointing over 365 days. If :ref:`bkgdrate <bkgdrate>` is "low", "medium", "high", then the percentiles used are 10th, 50th, and 90th, respectively. If it is a float, that value (in ADU/sec/pixel) will be added to all pixels.
+
+.. _signal_low_limit_for_segmap:
+
+Lower Signal Limit for the Segmentation Map
++++++++++++++++++++++++++++++++++++++++++++
+
+*simSignals:signal_low_limit_for_segmap*
+
+When adding an astrophysical source to the seed image, this is the lower threshold value used to control which pixels in the source are added to the segmentation map. Pixels with signal rates below this threshold will not be included. Mirage uses the segmentation map for WFSS simulations. Only object pixels that are present in the segmentation map are dispersed. This is done, rather than dispersing all pixels, in order to save compute time. The value can be given in a number of units. See :ref:`signal_low_limit_for_segmap_units <signal_low_limit_for_segmap_units>` below for a list of valid units.
+
+.. _signal_low_limit_for_segmap_units:
+
+Units for the Lower Signal Limit for the Segmentation Map
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+*simSignals:signal_low_limit_for_segmap_units*
+
+This field gives the units associated with the value in the :ref: `signal_low_limit_for_segmap <signal_low_limit_for_segmap>` value above. Supported units include: ADU/sec, ADU/s, e/sec, e/s, MJy/sr, ergs/cm2/a, ergs/cm2/hz. Note that this field is case insensitive. If the signal limit is given in units other than ADU/sec, Mirage will convert the value to ADU/sec before comparing source signal levels and adding pixels to the segmentation map.
+
 
 .. _Telescope:
 

--- a/docs/yaml_generator.rst
+++ b/docs/yaml_generator.rst
@@ -325,7 +325,7 @@ observation numbers from your APT file. Each entry should then contain a diction
 JWST Calibration Reference Files
 ++++++++++++++++++++++++++++++++
 
-Mirage makes use of a handful of the `reference file types <https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#reference-files>`_ used by the JWST calibration pipeline. This includes the `bad pixel mask <https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/reference_files.html#mask-reffile>`_, `saturation level map <https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html#saturation-reffile>`_, `superbias <https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html#superbias-reffile>`_, `gain <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html#gain-reffile>`_, `interpixel capacitance <https://jwst-pipeline.readthedocs.io/en/stable/jwst/ipc/reference_files.html#ipc-reffile>`_, `linearity correction  <https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html#linearity-reffile>`_, `distortion correction <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/distortion_reffile.html#distortion-reffile>`_ and `pixel to pixel flat field <https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/reference_files.html#flat-reference-file>`_ files.
+Mirage makes use of a handful of the `reference file types <https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#reference-files>`_ used by the JWST calibration pipeline. This includes the `bad pixel mask <https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/reference_files.html#mask-reffile>`_, `saturation level map <https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html#saturation-reffile>`_, `superbias <https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html#superbias-reffile>`_, `gain <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html#gain-reffile>`_, `interpixel capacitance <https://jwst-pipeline.readthedocs.io/en/stable/jwst/ipc/reference_files.html#ipc-reffile>`_, `linearity correction  <https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html#linearity-reffile>`_, `distortion correction <https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/distortion_reffile.html#distortion-reffile>`_ `pixel to pixel flat field <https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/reference_files.html#flat-reference-file>`_ and `photom <https://jwst-pipeline.readthedocs.io/en/stable/jwst/photom/reference_files.html#photom-reference-file>`_ files.
 
 Mirage relies on the `CRDS <https://hst-crds.stsci.edu/static/users_guide/index.html>`_ package from STScI to identify the appropriate reference files for a given exposure. These files are automatically downloaded to the user's machine at one of two times:
 
@@ -369,7 +369,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'ipc':        {detector_name: 'reffile_name.fits'},
                            'area':       {detector_name: {filter: {pupil: {exposure_type: 'reffile_name.asdf'}}}},
                            'badpixmask': {detector_name: 'reffile_name.fits'},
-                           'pixelflat':  {detector_name: {filter: {pupil: 'reffile_name.fits'}}}
+                           'pixelflat':  {detector_name: {filter: {pupil: 'reffile_name.fits'}}},
+                           'photom':     {detector_name: 'reffile_name.fits'}
                            },
                 'niriss': {'superbias':  {readpattern: 'reffile_name.fits'},
                            'linearity':  'reffile_name.fits',
@@ -379,7 +380,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'ipc':        'reffile_name.fits',
                            'area':       {filter: {pupil: {exposure_type: 'reffile_name.asdf'}}},
                            'badpixmask': 'reffile_name.fits',
-                           'pixelflat':  {filter: {pupil: 'reffile_name.fits'}}
+                           'pixelflat':  {filter: {pupil: 'reffile_name.fits'}},
+                           'photom':     {detector_name: 'reffile_name.fits'}
                            },
                 'fgs':    {'superbias':  {detector_name: {readpattern: 'reffile_name.fits'}},
                            'linearity':  {detector_name: 'reffile_name.fits'},
@@ -389,7 +391,8 @@ Here is a view of the dictionary structure required when specifying reference fi
                            'ipc':        {detector_name: 'reffile_name.fits'},
                            'area':       {detector_name: 'reffile_name.asdf'},
                            'badpixmask': {detector_name: {exposure_type: 'reffile_name.fits'}},
-                           'pixelflat':  {detector_name: {exposure_type: 'reffile_name.fits'}}
+                           'pixelflat':  {detector_name: {exposure_type: 'reffile_name.fits'}},
+                           'photom':     {detector_name: 'reffile_name.fits'}
                            }
 
 
@@ -423,9 +426,26 @@ Here we show an example dictionary for a particular set of observations.
                                                                }
                                                     },
                                           'nrcb4': {'f070w': {'clear': 'my_SW_favs/sw_flat.fits'}}
-                                          }
+                                          },
+                            'photom':    {'nrca5': 'my_favorites/photom_file.fits'}
                             }
                 }
+
+
+.. _segmap_limits:
+
+Signal Limits for the Segmentation Map
+++++++++++++++++++++++++++++++++++++++
+
+Accompanying the noiseless seed image, Mirage will also produce a segmentation map containing all sources on the detector. Mirage makes use of this segmentation map only when producing spectroscopic data (i.e. WFSS or grism TSO mode). For all other modes, the segmentation map is informational only. In order to save time when making spectroscopic data, only pixels identified in the segmentation map as belonging to a source are run through the disperser code. Mirage uses a simple threshold value to determine which pixels to add to each source in the segmentation map. Pixles with signal values equal to or above the threshold are added. Mirage uses a default value of 0.031 ADU/sec as the floor value. Depending on the brightness and size of your targets, you may want to focus only on the brighter targets, or include everything. Therefore, this is a tunable parameter which users can specify in a variety of units. To specify your own segmentation map signal threshold when creating yaml files, provide your values to the yaml_generator. Note that if you omit these keywords, Mirage will use the default value.
+
+::
+
+    minimum_signal = 0.08
+    minimum_signal_units = 'MJy/sr'
+
+The allowed units for the threshold value are: ADU/sec, e/sec, MJy/sr, erg/cm2/A, erg/cm2/Hz
+Note that these are case insensitive.
 
 
 .. _yaml_generator:
@@ -457,7 +477,9 @@ Set ``parameter_defaults`` equal to the dictionary of parameter values to use.
                                   simdata_output_dir='/location/to/place/simulated_data',
                                   cosmic_rays=crs, background=background, roll_angle=pav3,
                                   dates=dates, datatype='raw', dateobs_for_background=False,
-                                  reffile_defaults='crds', reffile_overrides=reffile_overrides)
+                                  reffile_defaults='crds', reffile_overrides=reffile_overrides,
+                                  segmap_flux_limit=minmum_signal, segmap_flux_limit_units=minimum_signal_units
+                                  )
     yam.use_linearized_darks = True
     yam.create_inputs()
 

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -391,30 +391,6 @@ class DarkPrep():
         for ref in rlist:
             self.ref_check(ref)
 
-    def file_splits(self):
-        """Check to see whether the final dark file will need to be
-        split into segments due to large file size
-        """
-        # Let's declare the equivalent of a 100 group full frame ramp
-        # as the upper limit for observation file size
-        pixel_limit = 2048 * 2048 * 100
-
-        xd = self.subarray_bounds[3] - self.subarray_bounds[1]
-        yd = self.subarray_bounds[2] - self.subarray_bounds[0]
-        pix_per_int = self.numgroups * yd * xd
-        observation = pix_per_int * self.numints
-
-        split = False
-        int_list = [0, self.numints]
-        if observation > pixel_limit:
-            split = True
-            ints_per_split = np.int(pixel_limit / pix_per_int)
-            #num_splits = self.numints / ints_per_split
-            int_list = np.arange(0, self.numints, ints_per_split)
-            if int_list[-1] != self.numints:
-                int_list = np.append(int_list, self.numints)
-        return split, int_list
-
     def get_base_dark(self, input_file):
         """Read in the dark current ramp that will serve as the
         base for the simulated ramp"""

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1166,8 +1166,12 @@ class Observation():
                 try:
                     print("Creating output file name with segment number.")
                     parts = basename.split('_')
-                    basename = '{}_{}_{}-seg{}_{}_{}'.format(parts[0], parts[1], parts[2], seg_str,
-                                                             parts[3], parts[4])
+
+                    if len(parts) == 5:
+                        basename = '{}_{}_{}-seg{}_{}_{}'.format(parts[0], parts[1], parts[2], seg_str,
+                                                                 parts[3], parts[4])
+                    else:
+                        basename = basename.replace('.fits', '-seg{}.fits'.format(seg_str))
                 except IndexError:
                     # Non-standard filename format
                     basename = basename.replace('.fits', '-seg{}.fits'.format(seg_str))

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1145,10 +1145,18 @@ class Observation():
         for i, linDark in enumerate(self.linDark):
             temp_outdir, basename = os.path.split(self.params['Output']['file'])
 
+
+            print('initial basename: ', basename)
+
             # Get the segment number of the file if present
-            seg_location = linDark.find('_seg')
+            linDarkfile = os.path.basename(linDark)
+            seg_location = linDarkfile.find('_seg')
+
+            print(linDark)
+            print('seg_location: ', seg_location)
+
             if seg_location != -1:
-                seg_str = linDark[seg_location+4:seg_location+7]
+                seg_str = linDarkfile[seg_location+4:seg_location+7]
                 #print('first segment string: ', seg_str)
             else:
                 try:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -4209,7 +4209,6 @@ class Catalog_seed():
         # Get the threshold signal value for pixels to be included in the
         # segmentation map. Pixels with signals greater than or equal to
         # this level will be included in the segmap
-        self.get_surface_brightness_fluxcal()
         self.set_segmentation_threshold()
 
         # Convert the input RA and Dec of the pointing position into floats
@@ -4493,6 +4492,7 @@ class Catalog_seed():
         elif segmentation_threshold_units == ['e/s', 'e/sec']:
             self.segmentation_threshold /= self.gain_value
         elif segmentation_threshold_units == ['mjy/sr', 'mjy/sr']:
+            self.get_surface_brightness_fluxcal()
             self.segmentation_threshold /= self.surface_brightness_fluxcal
         elif segmentation_threshold_units in ['erg/cm2/a']:
             self.segmentation_threshold /= self.photflam

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -570,7 +570,7 @@ class Catalog_seed():
                         print('\n\n\ntotal_seed_segments-and_parts: ', self.total_seed_segments_and_parts)
                         seg_string = str(self.segment_number).zfill(3)
                         part_string = str(self.segment_part_number).zfill(3)
-                        self.seed_file = '{}_{}_{}_seg{}_part{}_seed_image.fits'.format(self.basename, self.params['Readout'][filter],
+                        self.seed_file = '{}_{}_{}_seg{}_part{}_seed_image.fits'.format(self.basename, self.params['Readout']['filter'],
                                                                                         self.params['Readout']['pupil'], seg_string, part_string)
 
                         self.saveSeedImage(seed, segmap, self.seed_file)

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -4463,7 +4463,8 @@ class Catalog_seed():
         elif len(good) == 0:
             raise ValueError("No matching row in the photom reference file for {} and {}".format(self.params['Readout']['filter'], self.params['Readout']['pupil']))
 
-        self.surface_brightness_fluxcal = photom_values[good[0]]
+        surf_bright_fluxcal = photom_values[good[0]]
+        return surf_bright_fluxcal
 
     def set_segmentation_threshold(self):
         """Determine the threshold value to use when determining which pixels
@@ -4491,9 +4492,9 @@ class Catalog_seed():
             pass
         elif segmentation_threshold_units == ['e/s', 'e/sec']:
             self.segmentation_threshold /= self.gain_value
-        elif segmentation_threshold_units == ['mjy/sr', 'mjy/sr']:
-            self.get_surface_brightness_fluxcal()
-            self.segmentation_threshold /= self.surface_brightness_fluxcal
+        elif segmentation_threshold_units == ['mjy/sr', 'mjy/str']:
+            surface_brightness_fluxcal = self.get_surface_brightness_fluxcal()
+            self.segmentation_threshold /= surface_brightness_fluxcal
         elif segmentation_threshold_units in ['erg/cm2/a']:
             self.segmentation_threshold /= self.photflam
         elif segmentation_threshold_units in ['erg/cm2/hz']:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -43,7 +43,8 @@ from ..utils import backgrounds
 from ..utils import rotations, polynomial, read_siaf_table, utils
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 from ..utils import siaf_interface, file_io
-from ..utils.constants import CRDS_FILE_TYPES, MEAN_GAIN_VALUES
+from ..utils.constants import CRDS_FILE_TYPES, MEAN_GAIN_VALUES, SEGMENTATION_MIN_SIGNAL_RATE, \
+                              SUPPORTED_SEGMENTATION_THRESHOLD_UNITS
 from ..utils.flux_cal import fluxcal_info
 from ..psf.psf_selection import get_gridded_psf_library, get_psf_wings
 from ..utils.constants import grism_factor, TSO_MODES
@@ -1549,15 +1550,8 @@ class Catalog_seed():
                                       self.frametime, newdimsx, newdimsy)
                 mt_integration[integ, :, :, :] += mt_source
 
-                noiseval = self.single_ron / 100. + self.params['simSignals']['bkgdrate']
-                if self.params['Inst']['mode'].lower() in ['wfss', 'ts_grism']:
-                    noiseval += self.grism_background
-
-                if input_type in ['pointSource', 'galaxies']:
-                    moving_segmap.add_object_noise(mt_source[-1, :, :], 0, 0, index, noiseval)
-                else:
-                    indseg = self.seg_from_photutils(mt_source[-1, :, :], np.int(index), noiseval)
-                    moving_segmap.segmap += indseg
+                # Add object to segmentation map
+                moving_segmap.add_object_threshold(mt_source[-1, :, :], 0, 0, index, self.segmentation_threshold)
 
             # Check the elapsed time for creating each object
             elapsed_time = time.time() - start_time
@@ -2530,11 +2524,8 @@ class Catalog_seed():
             try:
                 psfimage[j1:j2, i1:i2] += scaled_psf[l1:l2, k1:k2]
 
-                # Divide readnoise by 100 sec, which is a 10 group RAPID ramp?
-                noiseval = self.single_ron / 100. + self.params['simSignals']['bkgdrate']
-                if self.params['Inst']['mode'].lower() in ['wfss', 'ts_grism']:
-                    noiseval += self.grism_background
-                ptsrc_segmap.add_object_noise(scaled_psf[l1:l2, k1:k2], j1, i1, entry['index'], noiseval)
+                # Add source to segmentation map
+                ptsrc_segmap.add_object_threshold(scaled_psf[l1:l2, k1:k2], j1, i1, entry['index'], self.segmentation_threshold)
             except IndexError:
                 # In here we catch sources that are off the edge
                 # of the detector. These may not necessarily be caught in
@@ -3658,11 +3649,8 @@ class Catalog_seed():
                 # Now add the stamp to the main image
                 if ((j2 > j1) and (i2 > i1) and (l2 > l1) and (k2 > k1) and (j1 < yd) and (i1 < xd)):
                     galimage[j1:j2, i1:i2] += stamp[l1:l2, k1:k2]
-                    # Divide readnoise by 100 sec, which is a 10 group RAPID ramp
-                    noiseval = self.single_ron / 100. + self.params['simSignals']['bkgdrate']
-                    if self.params['Inst']['mode'].lower() in ['wfss', 'ts_grism']:
-                        noiseval += self.grism_background
-                    segmentation.add_object_noise(stamp[l1:l2, k1:k2], j1, i1, entry['index'], noiseval)
+                    # Add source to segmentation map
+                    segmentation.add_object_threshold(stamp[l1:l2, k1:k2], j1, i1, entry['index'], self.segmentation_threshold)
 
                 else:
                     pass
@@ -3986,15 +3974,9 @@ class Catalog_seed():
                 if ((j2 > j1) and (i2 > i1) and (l2 > l1) and (k2 > k1) and (j1 < yd) and (i1 < xd)):
                     extimage[j1:j2, i1:i2] += stamp[l1:l2, k1:k2]
 
-                # Divide readnoise by 100 sec, which is a 10 group RAPID ramp?
-                noiseval = self.single_ron / 100. + self.params['simSignals']['bkgdrate']
-                if self.params['Inst']['mode'].lower() in ['wfss', 'ts_grism']:
-                    noiseval += self.grism_background
-
-                # Make segmentation map
-                indseg = self.seg_from_photutils(stamp[l1:l2, k1:k2] * entry['countrate_e/s'],
-                                                 entry['index'], noiseval)
-                segmentation.segmap[j1:j2, i1:i2] += indseg
+                # Add source to segmentation map
+                segmentation.add_object_threshold(stamp[l1:l2, k1:k2], j1, i1, entry['index'],
+                                                  self.segmentation_threshold)
                 self.n_extend += 1
 
         if self.n_extend == 0:
@@ -4224,6 +4206,12 @@ class Catalog_seed():
             fluxcal_info(self.params['Reffiles']['flux_cal'], self.instrument, self.params['Readout']['filter'],
                          self.params['Readout']['pupil'], detector, module)
 
+        # Get the threshold signal value for pixels to be included in the
+        # segmentation map. Pixels with signals greater than or equal to
+        # this level will be included in the segmap
+        self.get_surface_brightness_fluxcal()
+        self.set_segmentation_threshold()
+
         # Convert the input RA and Dec of the pointing position into floats
         # Check to see if the inputs are in decimal units or hh:mm:ss strings
         try:
@@ -4295,11 +4283,11 @@ class Catalog_seed():
                         shorthand = 'lw{}'.format(module.lower())
                     else:
                         shorthand = 'sw{}'.format(module.lower())
-                    gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()][shorthand]
+                    self.gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()][shorthand]
                 elif self.params['Inst']['instrument'].lower() == 'niriss':
-                    gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()]
+                    self.gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()]
                 elif self.params['Inst']['instrument'].lower() == 'fgs':
-                    gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()][detector.lower()]
+                    self.gain_value = MEAN_GAIN_VALUES[self.params['Inst']['instrument'].lower()][detector.lower()]
 
                 if self.params['simSignals']['use_dateobs_for_background']:
                     bkgd_wave, bkgd_spec = backgrounds.day_of_year_background_spectrum(self.params['Telescope']['ra'],
@@ -4307,7 +4295,7 @@ class Catalog_seed():
                                                                                        self.params['Output']['date_obs'])
                     self.params['simSignals']['bkgdrate'] = backgrounds.calculate_background(self.ra, self.dec,
                                                                                              filter_file, True,
-                                                                                             gain_value, self.siaf,
+                                                                                             self.gain_value, self.siaf,
                                                                                              back_wave=bkgd_wave,
                                                                                              back_sig=bkgd_spec)
                     print("Background rate determined using date_obs: {}".format(self.params['Output']['date_obs']))
@@ -4316,7 +4304,7 @@ class Catalog_seed():
                     orig_level = copy.deepcopy(self.params['simSignals']['bkgdrate'])
                     self.params['simSignals']['bkgdrate'] = backgrounds.calculate_background(self.ra, self.dec,
                                                                                              filter_file, False,
-                                                                                             gain_value, self.siaf,
+                                                                                             self.gain_value, self.siaf,
                                                                                              level=self.params['simSignals']['bkgdrate'].lower())
                     print("Background rate determined using {} level: {}".format(orig_level, self.params['simSignals']['bkgdrate']))
             else:
@@ -4459,6 +4447,57 @@ class Catalog_seed():
                                       "{}. Not present in directory tree specified by "
                                       "the {} environment variable."
                                       .format(pth, self.env_var)))
+
+    def get_surface_brightness_fluxcal(self):
+        """Get the conversion value for MJy/sr to ADU/sec from the jwst
+        calibration pipeline photom reference file. The value is based
+        on the filter and pupil value of the observation.
+        """
+        photom_data = fits.getdata(self.params['Reffiles']['photom'])
+        photom_filters = np.array([elem['filter'] for elem in photom_data])
+        photom_pupils = np.array([elem['pupil'] for elem in photom_data])
+        photom_values = np.array([elem['photmjsr'] for elem in photom_data])
+
+        good = np.where((photom_filters == self.params['Readout']['filter'].upper()) & (photom_pupils == self.params['Readout']['pupil'].upper()))[0]
+        if len(good) > 1:
+            raise ValueError("More than one matching row in the photom reference file for {} and {}".format(self.params['Readout']['filter'], self.params['Readout']['pupil']))
+        elif len(good) == 0:
+            raise ValueError("No matching row in the photom reference file for {} and {}".format(self.params['Readout']['filter'], self.params['Readout']['pupil']))
+
+        self.surface_brightness_fluxcal = photom_values[good[0]]
+
+    def set_segmentation_threshold(self):
+        """Determine the threshold value to use when determining which pixels
+        to include in the segmentation map. Final units for the threshold
+        should be ADU/sec, but inputs (in the input yaml file) can be:
+        ADU/sec, electrons/sec, or MJy/str
+        """
+        # First, set the default, in case the input yaml does not have the
+        # threshold entry
+        self.segmentation_threshold = SEGMENTATION_MIN_SIGNAL_RATE
+        segmentation_threshold_units = 'adu/s'
+
+        #Now see if there is an entry in the yaml file
+        try:
+            self.segmentation_threshold = self.params['simSignals']['signal_low_limit_for_segmap']
+            segmentation_threshold_units = self.params['simSignals']['signal_low_limit_for_segmap_units'].lower()
+        except KeyError:
+            print(('simSignals:signal_low_limit_for_segmap and/or simSignals:signal_low_limit_for_segmap_units '
+                   'not present in input yaml file. Using the default value of: {} ADU/sec'.format(self.segmentation_threshold)))
+
+        if segmentation_threshold_units not in SUPPORTED_SEGMENTATION_THRESHOLD_UNITS:
+            raise ValueError(('Unsupported unit for the segmentation map lower signal limit: {}.\n'
+                              'Supported units are: {}'.format(segmentation_threshold_units, SUPPORTED_SEGMENTATION_THRESHOLD_UNITS)))
+        if segmentation_threshold_units in ['adu/s', 'adu/sec']:
+            pass
+        elif segmentation_threshold_units == ['e/s', 'e/sec']:
+            self.segmentation_threshold /= self.gain_value
+        elif segmentation_threshold_units == ['mjy/sr', 'mjy/sr']:
+            self.segmentation_threshold /= self.surface_brightness_fluxcal
+        elif segmentation_threshold_units in ['erg/cm2/a']:
+            self.segmentation_threshold /= self.photflam
+        elif segmentation_threshold_units in ['erg/cm2/hz']:
+            self.segmentation_threshold /= self.photfnu
 
     def input_check(self, inparam):
         # Check for the existence of the input file. In

--- a/mirage/seed_image/segmentation_map.py
+++ b/mirage/seed_image/segmentation_map.py
@@ -39,13 +39,32 @@ class SegMap():
         flag = image >= cutoff
         stamp[flag] = number
 
-    def add_object_noise(self, image, ystart, xstart, number, noise):
-        # Add an object to the segmentation map
-        # In this case, only flag pixels whose
-        # signal is higher than a calculated cutoff
-        # that is based on average noise/background
-        # values for NIRCam
+    def add_object_threshold(self, image, ystart, xstart, number, threshold):
+        """Add an object to the segmentation map
+        In this case, only flag pixels whose
+        signal is higher than the given threshold value
+
+        Paramters
+        ---------
+        image : numpy.ndarray
+            Image containing the source to be added to the segmentation map
+
+        ystart : int
+            Y coordinate, in the coordinate system of the full seed image
+            of the lower left corner of '''image'''
+
+        xstart : imt
+            X coordinate, in the coordinate system of the full seed image
+            of the lower left corner of '''image'''
+
+        number : int
+            Value to be placed into the segmentation map for this object
+
+        threshold : float
+            Pixels with signal values higher than this will be added to
+            the segmentation map as part of this object
+        """
         yd, xd = image.shape
         stamp = self.segmap[ystart:ystart+yd, xstart:xstart+xd]
-        flag = image >= noise
+        flag = image >= threshold
         stamp[flag] = number

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -82,7 +82,8 @@ CRDS_FILE_TYPES = {'badpixmask': 'mask',
                    'pixelAreaMap': 'area',
                    'saturation': 'saturation',
                    'superbias': 'superbias',
-                   'pixelflat': 'flat'}
+                   'pixelflat': 'flat',
+                   'photom': 'photom'}
 
 MEAN_GAIN_VALUES = {'nircam': {'swa': 2.443376, 'swb': 2.4908085, 'lwa': 2.1923525, 'lwb': 2.1811192,
                                'nrca1': 2.4926066, 'nrca2': 2.5222762, 'nrca3': 2.4837794, 'nrca4': 2.2748423,
@@ -95,6 +96,10 @@ MEAN_GAIN_VALUES = {'nircam': {'swa': 2.443376, 'swb': 2.4908085, 'lwa': 2.19235
 # Factor by which throughput is decreased when the Grism is used compared
 # to when it is not in the beam
 NIRISS_GRISM_THROUGHPUT_FACTOR = 0.8
+
+# Minimum signal rate for a pixel to be included in the segmentation map.
+SEGMENTATION_MIN_SIGNAL_RATE = 0.031  # ADU/sec
+SUPPORTED_SEGMENTATION_THRESHOLD_UNITS = ['adu/s', 'adu/sec', 'e/s', 'e/sec', 'mjy/str', 'mjy/sr', 'erg/cm2/a', 'erg/cm2/hz']
 
 # For use in converting background MJy/sr to e-/sec
 PRIMARY_MIRROR_AREA = 25.326 * u.meter * u.meter

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -366,7 +366,7 @@ def full_paths(params, module_path, crds_dictionary, offline=False):
                              'crosstalk', 'occult', 'pixelAreaMap',
                              'subarray_defs', 'filtpupilcombo',
                              'flux_cal', 'readpattdefs', 'filter_throughput',
-                             'filter_wheel_positions'],
+                             'filter_wheel_positions', 'photom'],
                 'simSignals': ['pointsource', 'psfpath', 'galaxyListFile',
                                'extended', 'movingTargetList', 'movingTargetSersic',
                                'movingTargetExtended', 'movingTargetToTrack',

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -348,7 +348,11 @@ class WFSSSim():
             d = dark_prep.DarkPrep(offline=self.offline)
             d.paramfile = self.wfss_yaml
             d.prepare()
-            obslindark = d.prepDark
+
+            if len(d.dark_files) == 1:
+                obslindark = d.prepDark
+            else:
+                obslindark = d.dark_files
         else:
             self.read_dark_product()
             obslindark = self.darkPrep

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -384,6 +384,7 @@ class SimInput:
         saturation_arr = deepcopy(empty_col)
         gain_arr = deepcopy(empty_col)
         distortion_arr = deepcopy(empty_col)
+        photom_arr = deepcopy(empty_col)
         ipc_arr = deepcopy(empty_col)
         ipc_invert = np.array([True] * len(self.info['Instrument']))
         pixelAreaMap_arr = deepcopy(empty_col)


### PR DESCRIPTION
This PR updates the threshold value that is used when adding sources to the segmentation map. Previously the threshold value was based on a guess of some fraction of the noise in the observation. However, this didn't take into account observation programs with the ultimate goal of combining N exposures in the level 3 data. Instead of the one-size-fits-all approach, this update allows the threshold value as a user input in the yaml files.

The default value is 0.031 ADU/sec, as determined by some experimentation by Nor with a very deep observation program example. If the new threshold keywords are not present in the yaml file, Mirage will use this default value. Otherwise, users can provide their own value, along with the units that value is in. Allowed units are: ADU/sec, e/sec, MJy/sr, FLAM, and FNU. All are converted to ADU/sec upon entry.