### PR TITLE
Make background sources optional in grism TSO simulations

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2271,7 +2271,7 @@ class Catalog_seed():
 
         # If no good point sources were found in the requested array, alert the user
         if len(pointSourceList) < 1:
-            print("INFO: no point sources within the requested array.")
+            print("INFO: No point sources within the requested aperture.")
             # print("The point source image option is being turned off")
             # self.runStep['pointsource']=False
             # if self.runStep['extendedsource'] == False and self.runStep['cosmicray'] == False:

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -900,12 +900,6 @@ def read_pattern_check(parameters):
                .format(parameters['Readout']['readpatt'],
                        parameters['Readout']['nframe'],
                        parameters['Readout']['nskip'])))
-
-        print('in read_pattern_check, nframe and nskip are:')
-        print(parameters['Readout']['nframe'], parameters['Readout']['nskip'])
-        print(type(parameters['Readout']['nframe']), type(parameters['Readout']['nskip']))
-        print('maxiter', parameters['nonlin']['maxiter'], type(parameters['nonlin']['maxiter']))
-
     else:
         # If the read pattern is not present in the definition file
         # then quit.


### PR DESCRIPTION
When creating a grism TSO simulation, Mirage currently fails if there is no background source catalog (e.g. point source, galaxy, extended) listed in the input yaml file. It also fails if none of the background sources from those catalogs are within the requested aperture.

This PR makes updates so that the background catalogs are not required, and if no sources within those catalogs happen to be in the FOV, then Mirage will handle that situation.