### PR TITLE
Add timer to estimate time remaining

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -26,6 +26,7 @@ Use:
 import sys
 import os
 import argparse
+import datetime
 from math import floor
 from glob import glob
 
@@ -33,6 +34,7 @@ import yaml
 import pkg_resources
 import numpy as np
 from astropy.io import fits, ascii
+import astropy.units as u
 
 import mirage
 from mirage.utils import read_fits, utils, siaf_interface
@@ -970,12 +972,13 @@ class DarkPrep():
             self.timer.stop(name='seg_{}'.format(str(seg_index+1).zfill(4)))
 
             # If there is more than one segment, provide an estimate of processing time
+            print('\n\nSegment {} out of {} complete.'.format(seg_index+1, len(integration_segment_indexes[:-1])))
             if len(integration_segment_indexes[:-1]) > 1:
-                time_per_segment = self.timer.sum(key_str='seg_') / (file_index+1)
-                estimated_remaining_time = time_per_segment * (len(integration_segment_indexes[:-1]) - (file_index+1)) * u.second
+                time_per_segment = self.timer.sum(key_str='seg_') / (seg_index+1)
+                estimated_remaining_time = time_per_segment * (len(integration_segment_indexes[:-1]) - (seg_index+1)) * u.second
                 time_remaining = np.around(estimated_remaining_time.to(u.minute).value, decimals=2)
                 finish_time = datetime.datetime.now() + datetime.timedelta(minutes=time_remaining)
-                print(('Estimated time remaining to in dark_prep: {} minutes. '
+                print(('Estimated time remaining in dark_prep: {} minutes. '
                        'Projected finish time: {}'.format(time_remaining, finish_time)))
 
         # If only one dark current file is needed, return just the file

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -971,13 +971,12 @@ class DarkPrep():
 
             # If there is more than one segment, provide an estimate of processing time
             if len(integration_segment_indexes[:-1]) > 1:
-                time_per_segment = 0.
-                for key in self.timer.timers:
-                    if 'seg_' in key:
-                        time_per_segment += self.timer.timers[key]
-                time_per_segment /= (i+1)
-                estimated_remaining_time = time_per_segment * (len(integration_segment_indexes[:-1]) - (i+1)) * u.second
-                print('Estimated time remaining in dark_prep: {} minutes.\n\n'.format(estimated_remaining_time.to(u.minute).value))
+                time_per_segment = self.timer.sum(key_str='seg_') / (file_index+1)
+                estimated_remaining_time = time_per_segment * (len(integration_segment_indexes[:-1]) - (file_index+1)) * u.second
+                time_remaining = np.around(estimated_remaining_time.to(u.minute).value, decimals=2)
+                finish_time = datetime.datetime.now() + datetime.timedelta(minutes=time_remaining)
+                print(('Estimated time remaining to in dark_prep: {} minutes. '
+                       'Projected finish time: {}'.format(time_remaining, finish_time)))
 
         # If only one dark current file is needed, return just the file
         # name rather than a list.

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1383,12 +1383,13 @@ class Observation():
             self.timer.stop(name='seg_{}'.format(str(i+1).zfill(4)))
 
             # If there is more than one segment, provide an estimate of processing time
+            print('\n\nSegment {} out of {} complete.'.format(i+1, len(self.linDark)))
             if len(self.linDark) > 1:
                 time_per_segment = self.timer.sum(key_str='seg_') / (i+1)
                 estimated_remaining_time = time_per_segment * (len(self.linDark) - (i+1)) * u.second
                 time_remaining = np.around(estimated_remaining_time.to(u.minute).value, decimals=2)
                 finish_time = datetime.datetime.now() + datetime.timedelta(minutes=time_remaining)
-                print(('Estimated time remaining to in obs_generator: {} minutes. '
+                print(('Estimated time remaining in obs_generator: {} minutes. '
                        'Projected finish time: {}'.format(time_remaining, finish_time)))
 
         print("Observation generation complete.")

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1384,13 +1384,12 @@ class Observation():
 
             # If there is more than one segment, provide an estimate of processing time
             if len(self.linDark) > 1:
-                time_per_segment = 0.
-                for key in self.timer.timers:
-                    if 'seg_' in key:
-                        time_per_segment += self.timer.timers[key]
-                time_per_segment /= (i+1)
+                time_per_segment = self.timer.sum(key_str='seg_') / (i+1)
                 estimated_remaining_time = time_per_segment * (len(self.linDark) - (i+1)) * u.second
-                print('Estimated time remaining in obs_generator: {} minutes.\n\n'.format(estimated_remaining_time.to(u.minute).value))
+                time_remaining = np.around(estimated_remaining_time.to(u.minute).value, decimals=2)
+                finish_time = datetime.datetime.now() + datetime.timedelta(minutes=time_remaining)
+                print(('Estimated time remaining to in obs_generator: {} minutes. '
+                       'Projected finish time: {}'.format(time_remaining, finish_time)))
 
         print("Observation generation complete.")
 

--- a/mirage/utils/timer.py
+++ b/mirage/utils/timer.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python
+
+"""This module creates a Timer class that can be used for timing pieces of code.
+Inspired by a tutorial on RealPython: https://realpython.com/python-timer/
+"""
+import time
+
+
+class Timer:
+    timers = dict()
+
+    def __init__(self):
+        self._start_time = None
+
+    def start(self):
+        """Start a new timer"""
+        if self._start_time is not None:
+            raise TimerError(f"Timer is running. Use .stop() to stop it")
+
+        self._start_time = time.perf_counter()
+
+    def stop(self, name=None):
+        """Stop the timer, and save the elapsed time"""
+        if self._start_time is None:
+            raise TimerError(f"Timer is not running. Use .start() to start it")
+
+        elapsed_time = time.perf_counter() - self._start_time
+        self._start_time = None
+
+        # Add new named timers to dictionary of timers
+        if name:
+            self.timers[name] = elapsed_time
+
+        return elapsed_time

--- a/mirage/utils/timer.py
+++ b/mirage/utils/timer.py
@@ -32,3 +32,13 @@ class Timer:
             self.timers[name] = elapsed_time
 
         return elapsed_time
+
+    def sum(self, key_str=''):
+        """Sum the times for all dictionary entries where the key
+        contains key_str"""
+        total_time = 0.
+
+        for key in self.timers:
+            if key_str in key:
+                total_time += self.timers[key]
+        return total_time


### PR DESCRIPTION
This PR adds a timing module, and uses it to help estimate the amount of time remaining when creating a simulation. Initially, I have applied it to dark_prep and obs_generator only in the cases where the data will be split into multiple segments. Currently, the timer is run during the loop over segments. It uses the elapsed time for prior segments to estimate the time remaining to process remaining segments.

- [x] Switch out the current timing lines for the various types of sources in catalog_seed_image with this new class.

Resolves #515 