### PR TITLE
Allow dark_prep to be skipped if dark files exist

### DIFF
--- a/docs/imaging_simulations.rst
+++ b/docs/imaging_simulations.rst
@@ -14,8 +14,26 @@ The imaging simulator has only two possible inputs: the yaml parameter file, and
     sim = ImgSim(paramfile='my_yaml_file.yaml')
     sim.create()
 
+.. _img_provide_segmented_darks:
 
-If you have a fits file containing a dark current exposure that is the proper format (linearized, with the correct readout pattern and array size) for the simulated data you are creating, you can provide this via the ``override_dark`` keyword parameter. This will cause the dark current preparation step to be skipped, which will save some time. In practice, the only way to have a fits file with the properly formatted dark current exposure will be from previous runs of the imaging simulator (or :ref:`dark prep <dark_prep>` step).
+If you have dark current products for your simulation from a previous run of Mirage, it is possible to provide these files to *imaging_simulator.py* as inputs using the **override_dark** parameter. In this case, the call to *dark_prep.py* will be skipped, which will save some computing time. Note that the dark current products must be specific to your exoposure, in that they must contain arrays of the proper shape. So in practice, this detail is useful if you are repeating a previous call to Mirage. In that case, the darks can be provided as shown below. In the case where a single dark file is needed, it can be provided as a string or a 1-element list. In cases where the exposure is broken into segments and there are multiple dark files, these files must be provided as a list.
+
+::
+
+    from mirage.imaging_simulator import ImgSim
+
+    # Single dark file
+    dark = 'jw09996001001_01101_00001_nrcb5_uncal_linear_dark_prep_object.fits'
+    m = ImgSim(override_dark=dark)
+    m.paramfile = 'jw09996001001_01101_00001_nrcb5.yaml'
+    m.create()
+
+    # Exposure broken into multiple segments
+    dark = ['jw09996001001_01101_00001_nrcb5_uncal_seg001_linear_dark_prep_object.fits',
+            'jw09996001001_01101_00001_nrcb5_uncal_seg002_linear_dark_prep_object.fits']
+    m = ImgSim(override_dark=dark)
+    m.paramfile = 'jw09996001001_01101_00001_nrcb5.yaml'
+    m.create()
 
 .. tip::
 

--- a/docs/tso_simulations.rst
+++ b/docs/tso_simulations.rst
@@ -38,3 +38,27 @@ Imaging TSO data
 - **Lightcurve file:** Tabulated list of the parent body's flux versus time
 - **Imaging TSO source catalog:** Mirage-specific source catalog containing all information relevant to the source
 
+Dark_prep files (optional)
+++++++++++++++++++++++++++
+
+If you have a fits file containing a dark current exposure that is the proper format (linearized, with the correct readout pattern and array size) for the simulated data you are creating, you can provide this via the ``override_dark`` keyword parameter. This will cause the dark current preparation step to be skipped, which will save some computing time. In practice, the only way to have a fits file with the properly formatted dark current exposure will be from previous runs of the imaging simulator (or :ref:`dark prep <dark_prep>` step).
+
+In the case where a single dark file is needed, it can be provided as a string or a 1-element list. In cases where the exposure is broken into segments and there are multiple dark files, these files must be provided as a list. For TSO observations, the latter case is much more likely.
+
+For a grism TSO observation, darks can be provided as such:
+
+::
+
+    from mirage.grism_tso_simulator import GrismTSO
+
+    sed_file = 'test_grism_tso_sed_file_wasp79.hdf5'
+    gr_tso_yaml_file = 'jw88888001001_01101_00002_nrca5.yaml'
+    darks_to_use = ['jw88888001001_01101_00002_nrca5_uncal_seg001_linear_dark_prep_object.fits',
+                    'jw88888001001_01101_00002_nrca5_uncal_seg002_linear_dark_prep_object.fits']
+
+    m = GrismTSO(gr_tso_yaml_file, SED_file=sed_file, SED_normalizing_catalog_column=None,
+                 final_SED_file=None, save_dispersed_seed=True, source_stamps_file=None,
+                 extrapolate_SED=True, override_dark=None, disp_seed_filename=None, orders=["+1", "+2"])
+    m.create()
+
+For an imaging TSO observation, the call the call looks the same as for :ref:`regular imaging observations <img_provide_segmented_darks>`.

--- a/docs/wfss_simulations.rst
+++ b/docs/wfss_simulations.rst
@@ -50,5 +50,27 @@ In order to create simulated data with more realistic spectra, users can provide
 
     The `NIRISS WFSS example notebook <https://github.com/spacetelescope/mirage/blob/master/examples/NIRISS_WFSS_data_creation_example.ipynb>`_ shows examples of how to create your own hdf5 catalog file, and how to create WFSS data using the methods described above.
 
+Skip the dark current prep step
++++++++++++++++++++++++++++++++
+
+Similar to the case for imaging mode simulations, if you have dark current products for your simulation from a previous run of Mirage, it is possible to provide these files to *wfss_simulator.py* as inputs using the **override_dark** parameter. In this case, the call to *dark_prep.py* will be skipped, which will save some computing time. Note that the dark current products must be specific to your exoposure, in that they must contain arrays of the proper shape. So in practice, this detail is useful if you are repeating a previous call to Mirage. In that case, the darks can be provided as shown below. In the case where a single dark file is needed, it can be provided as a string or a 1-element list. In cases where the exposure is broken into segments and there are multiple dark files, these files must be provided as a list.
+
+::
+
+    from mirage.wfss_simulator import WFSSSim
+
+    # Single file
+    darks = ['jw01345007001_01101_00010_nrca5_uncal_linear_dark_prep_object.fits']
+    yfile = 'jw01345007001_01101_00010_nrca5.yaml'
+    c = WFSSSim(yfile, override_dark=darks)
+    c.create()
+
+    # File broken into multiple segments
+    darks = ['jw01345007001_01101_00010_nrca5_uncal_seg001_linear_dark_prep_object.fits',
+             'jw01345007001_01101_00010_nrca5_uncal_seg002_linear_dark_prep_object.fits']
+    yfile = 'jw01345007001_01101_00010_nrca5.yaml'
+    c = WFSSSim(yfile, override_dark=darks)
+    c.create()
+
 
 

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -354,8 +354,12 @@ class WFSSSim():
             else:
                 obslindark = d.dark_files
         else:
-            self.read_dark_product()
-            obslindark = self.darkPrep
+            print('\n\noverride_dark has been set. Skipping dark_prep.')
+            if isinstance(self.override_dark, str):
+                self.read_dark_product()
+                obslindark = self.prepDark
+            elif isinstance(self.override_dark, list):
+                obslindark = self.override_dark
 
         # Combine into final observation
         obs = obs_generator.Observation(offline=self.offline)
@@ -411,10 +415,14 @@ class WFSSSim():
 
         # ###################Dark File to Use##################
         if self.override_dark is not None:
-            avail = os.path.isfile(self.override_dark)
-            if not avail:
-                raise FileNotFoundError(("WARNING: {} does not exist."
-                                         .format(self.override_dark)))
+            dark_list = self.override_dark
+            if isinstance(self.override_dark, str):
+                dark_list = [self.override_dark]
+            for darkfile in dark_list:
+                avail = os.path.isfile(darkfile)
+                if not avail:
+                    raise FileNotFoundError(("WARNING: {} does not exist."
+                                             .format(darkfile)))
 
     def find_param_info(self):
         """Extract dispersion direction and crossing filter from the input


### PR DESCRIPTION
This PR modifies the simulator wrappers (imaging, wfss, grism_tso) such that, if the outputs from a call to dark_prep.py already exist, the user can provide these outputs to Mirage, and Mirage will then skip the call to dark_prep.py. This should help save time when testing the code, and also when repeating the creation of simulations.

These changes work both for segmented and non-segmented exposures.

Resolves #518 