### PR TITLE
Update countrate scaling for NIRISS AMI and filter wheel filters

### DIFF
--- a/mirage/catalogs/spectra_from_catalog.py
+++ b/mirage/catalogs/spectra_from_catalog.py
@@ -100,18 +100,30 @@ def add_flam_columns(cat, mag_sys):
     for key in parameters:
         tmp_adjusted_key = key.split('_mod')[0]
         magnitude_values = cat[tmp_adjusted_key].data
-        flam_values = convert_to_flam(magnitude_values, parameters[key], mag_sys)
+        parts = key.split('_')
+        instrument = parts[0]
+        filter_value = parts[1]
+        flam_values = convert_to_flam(instrument, filter_value, magnitude_values,
+                                      parameters[key], mag_sys)
         new_column_name = key.replace('magnitude', 'flam')
         cat[new_column_name] = flam_values
     return cat, parameters
 
 
-def convert_to_flam(magnitudes, param_tuple, magnitude_system):
+def convert_to_flam(instrument, filter_name, magnitudes, param_tuple, magnitude_system):
     """Convert the magnitude values for a given magnitude column into
     units of f_lambda.
 
     Parameters
     ----------
+    instrument : str
+        e.g. 'nircam'
+
+    filter_name : str
+        Name of filter associated with observation. Only passed to
+        ``magnitude_to_countrate`` where it is only used for scaling
+        in the case of NIRISS filter wheel filters
+
     magnitudes : list
         List of magnitude values to be converted
 
@@ -130,7 +142,8 @@ def convert_to_flam(magnitudes, param_tuple, magnitude_system):
     photflam, photfnu, zeropoint, pivot = param_tuple
 
     if magnitude_system in ['stmag', 'vegamag']:
-        countrate = magnitude_to_countrate('wfss', magnitude_system, magnitudes, photfnu=photfnu,
+        countrate = magnitude_to_countrate(instrument, filter_name, magnitude_system,
+                                           magnitudes, photfnu=photfnu,
                                            photflam=photflam, vegamag_zeropoint=zeropoint)
         flam = countrate * photflam
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -1425,7 +1425,7 @@ class Catalog_seed():
 
             # Get countrate and PSF size info
             if entry[mag_column] is not None:
-                rate = utils.magnitude_to_countrate(self.params['Inst']['mode'],
+                rate = utils.magnitude_to_countrate(self.instrument, self.params['Readout']['filter'],
                                                     magsys, entry[mag_column],
                                                     photfnu=self.photfnu,
                                                     photflam=self.photflam)
@@ -2214,8 +2214,8 @@ class Catalog_seed():
 
             # Get the input magnitude and countrate of the point source
             mag = float(values[mag_column])
-            countrate = utils.magnitude_to_countrate(self.params['Inst']['mode'], magsys, mag,
-                                                     photfnu=self.photfnu, photflam=self.photflam,
+            countrate = utils.magnitude_to_countrate(self.instrument, self.params['Readout']['filter'],
+                                                     magsys, mag, photfnu=self.photfnu, photflam=self.photflam,
                                                      vegamag_zeropoint=self.vegazeropoint)
 
             psf_len = self.find_psf_size(countrate)
@@ -2287,8 +2287,8 @@ class Catalog_seed():
         magnitudes = self.psf_wing_sizes[magnitude_system].data
 
         # Calculate corresponding countrates
-        countrates = utils.magnitude_to_countrate(self.params['Inst']['mode'], magnitude_system,
-                                                  magnitudes, photfnu=self.photfnu,
+        countrates = utils.magnitude_to_countrate(self.instrument, self.params['Readout']['filter'],
+                                                  magnitude_system, magnitudes, photfnu=self.photfnu,
                                                   photflam=self.photflam,
                                                   vegamag_zeropoint=self.vegazeropoint)
         self.psf_wing_sizes['countrate'] = countrates
@@ -3383,8 +3383,8 @@ class Catalog_seed():
                 entry.append(mag)
 
                 # Convert magnitudes to countrate (ADU/sec) and counts per frame
-                rate = utils.magnitude_to_countrate(self.params['Inst']['mode'], magsystem, mag,
-                                                    photfnu=self.photfnu, photflam=self.photflam,
+                rate = utils.magnitude_to_countrate(self.instrument, self.params['Readout']['filter'],
+                                                    magsystem, mag, photfnu=self.photfnu, photflam=self.photflam,
                                                     vegamag_zeropoint=self.vegazeropoint)
                 framecounts = rate * self.frametime
 
@@ -3812,8 +3812,8 @@ class Catalog_seed():
                 # If a magnitude is given then adjust the countrate to match it
                 if mag is not None:
                     # Convert magnitudes to countrate (ADU/sec) and counts per frame
-                    countrate = utils.magnitude_to_countrate(self.params['Inst']['mode'], magsys, mag,
-                                                             photfnu=self.photfnu, photflam=self.photflam,
+                    countrate = utils.magnitude_to_countrate(self.instrument, self.params['Readout']['filter'],
+                                                             magsys, mag, photfnu=self.photfnu, photflam=self.photflam,
                                                              vegamag_zeropoint=self.vegazeropoint)
                     framecounts = countrate * self.frametime
                     magwrite = mag

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -683,14 +683,19 @@ def normalize_filters(instrument, filter_name, pupil_name):
     return newfilter, newpupil
 
 
-def magnitude_to_countrate(observation_mode, magsys, mag, photfnu=None, photflam=None,
+def magnitude_to_countrate(instrument, filter_name, magsys, mag, photfnu=None, photflam=None,
                            vegamag_zeropoint=None):
     """Convert a given source magnitude into count rate
 
     Parameters
     ----------
-    observation_mode : str
-        e.g. 'imaging', 'wfss'
+    instrument : str
+        e.g. 'nircam'
+
+    filter_name : str
+        Filter used in the observation. Only used in the case of
+        NIRISS, where filters in the filter wheel have their
+        throughput modified.
 
     magsys : str
         Magnitude system of the input magnitudes. Allowed values are:
@@ -718,15 +723,17 @@ def magnitude_to_countrate(observation_mode, magsys, mag, photfnu=None, photflam
         Count rate (e/s) corresponding to the input magnutude(s)
 
     """
-    # For NIRISS AMI mode, the count rate values calculated need to be
-    # scaled by a factor 0.15/0.84 = 0.17857.  The 0.15 value is the
-    # throughput of the NRM, while the 0.84 value is the throughput of the
-    # imaging CLEARP element that is in place in the pupil wheel for the
-    # normal imaging observations.
-    if observation_mode in ['ami', 'AMI']:
-        count_scale = 0.15 / 0.84
+    # For NIRISS filters in the filter wheel, we increase the count rate by a
+    # factor of 1/0.84. This is because the throughput of the CLEARP element
+    # in the pupil wheel (which will be used in combination with the filter)
+    # is 0.84, and is included in the PSFs produced by WebbPSF, but also in
+    # the throughput curves used by Mirage. So we need to remove one of these
+    # two factors of 0.84
+    if ((instrument.lower() == 'niriss') and (filter_name.upper() in NIRISS_FILTER_WHEEL_FILTERS)):
+        count_scale = 1. / 0.84
     else:
-        count_scale = 1.
+        count_scale = 1.0
+
     if magsys.lower() == 'abmag':
         try:
             return count_scale * (10**((mag + 48.599934378) / -2.5) / photfnu)


### PR DESCRIPTION
This PR updates scaling applied when converting magnitudes to count rates for NIRISS simulations. The previous scaling values were applicable when the PSF from the PSF library was normalized to 1.0, which is no longer the case. With the gridded PSF libraries in place, the throughput factor of 0.15 for the NRM is incorporated into the webbpsf output, so we remove that from the scaling. Also, the PSFs from webbpsf include the throughput factor of 0.84 for the CLEARP optical element. This 0.84 factor is also baked into the photflam/photfnu values used to convert magnitudes to count rates. To avoid applying the 0.84 factor twice, we now scale up the countrate by 1./0.84 for NIRISS filters in the filter wheel (which are paired with CLEARP in the pupil wheel).


Resolves #526 