### PR TITLE
Select appropriate NRM psf library

### DIFF
--- a/examples/niriss_ami_example/niriss_ami_example.py
+++ b/examples/niriss_ami_example/niriss_ami_example.py
@@ -21,16 +21,15 @@ output_directory = os.path.join(home_dir, 'ami_mirage_simulation_example')
 simdata_output_directory = output_directory
 
 # AB Dor is in field 19 and HD37093 is in field 20 in Kevin's targets.xlsx file
-catalogues = {'AB-DOR': {'point_source': os.path.join(ami_example_dir,'stars_field19_20_combined_allfilters.list')
-                        },
-              'HD-37093': {'point_source': os.path.join(ami_example_dir,'stars_field19_20_combined_allfilters.list')
-                        }
-             }
+catalogues = {'AB-DOR': {'point_source': os.path.join(ami_example_dir, 'stars_field19_20_combined_allfilters.list')
+                         },
+              'HD-37093': {'point_source': os.path.join(ami_example_dir, 'stars_field19_20_combined_allfilters.list')
+                           }
+              }
 pav3 = 275
 dates = '2020-09-20'
 reffile_defaults = 'crds'
 datatype = 'linear, raw'
-
 
 yam = yaml_generator.SimInput(input_xml=xml_name, pointing_file=pointing_name,
                               catalogs=catalogues, roll_angle=pav3,
@@ -41,18 +40,15 @@ yam = yaml_generator.SimInput(input_xml=xml_name, pointing_file=pointing_name,
 
 yam.create_inputs()
 
-
-#Create all files
+# Create all files
 yaml_files = glob.glob(os.path.join(output_directory, 'jw*.yaml'))
-#create one file for testing
-#yaml_files = glob.glob(os.path.join(output_directory, 'jw00793001001_01101_00001_nis.yaml'))
 print(yaml_files)
 
 for file in yaml_files:
 
     # set astrometric reference file to None to use pysiaf
     with open(file, 'r') as infile:
-        yaml_content = yaml.load(infile)
+        yaml_content = yaml.safe_load(infile)
     yaml_content['Reffiles']['astrometric'] = 'None'
     yaml_content['psf_wing_threshold_file'] = 'config'
     modified_file = file.replace('.yaml', '_mod.yaml')
@@ -62,4 +58,3 @@ for file in yaml_files:
     t1 = imaging_simulator.ImgSim()
     t1.paramfile = str(modified_file)
     t1.create()
-

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -207,9 +207,9 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
     # saves at least a handful of seconds.
     if instrument.lower() == 'fgs':
         default_file_pattern = '{}_{}_fovp*_samp*_npsf*_{}_realization{}.fits'.format(instrument.lower(),
-                                                                                        detector.lower(),
-                                                                                        wavefront_error.lower(),
-                                                                                        wavefront_error_group)
+                                                                                      detector.lower(),
+                                                                                      wavefront_error.lower(),
+                                                                                      wavefront_error_group)
     else:
         # NIRISS gridded library names don't follow standard filter/pupil rules.
         # The filenames are all <filter>_<clear>, where <clear> is clear if it
@@ -221,16 +221,20 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
             elif pupilname.lower() == 'clearp':
                 filename_filter = filtername
                 filename_pupil = pupilname
+            # filter=clear, pupil=nrm is currently not allowed
+            if pupilname.lower() == 'nrm':
+                filename_filter = filtername
+                filename_pupil = 'mask_nrm'
         elif instrument.lower() == 'nircam':
             filename_filter = filtername
             filename_pupil = pupilname
 
         default_file_pattern = '{}_{}_{}_{}_fovp*_samp*_npsf*_{}_realization{}.fits'.format(instrument.lower(),
-                                                                                        detector.lower(),
-                                                                                        filename_filter.lower(),
-                                                                                        filename_pupil.lower(),
-                                                                                        wavefront_error.lower(),
-                                                                                        wavefront_error_group)
+                                                                                            detector.lower(),
+                                                                                            filename_filter.lower(),
+                                                                                            filename_pupil.lower(),
+                                                                                            wavefront_error.lower(),
+                                                                                            wavefront_error_group)
     default_matches = glob(os.path.join(library_path, default_file_pattern))
     library_file = None
     if len(default_matches) == 1:


### PR DESCRIPTION
This PR fixes a small bug where Mirage crashed when trying to select a gridded PSF library for NIRISS NRM simulations. 

Resolves #528 