### PR TITLE
Allow for yaml files in directories other than the current working directory

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -4079,7 +4079,8 @@ class Catalog_seed():
 
         if adjust_file:
             # Make a copy of the original file and then delete it
-            yaml_copy = 'orig_{}'.format(self.paramfile)
+            param_dir, param_file = os.path.split(self.paramfile)
+            yaml_copy = os.path.join(param_dir, 'orig_{}'.format(param_file))
             shutil.copy2(self.paramfile, yaml_copy)
             os.remove(self.paramfile)
 


### PR DESCRIPTION
This PR makes a small adjustment to the yaml filename in the case where there is a colon in the input yaml. Previously the code assumed that the yaml file was in the current working directory. This PR removes that assumption so that yaml files in other directories can also be used.
