### PR TITLE
Keep filter and pupil straight in case of non-CLEAR pupil

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -593,11 +593,14 @@ class ReadAPTXML():
                     if key == 'ShortFilter':
                         ShortPupil, ShortFilter = self.separate_pupil_and_filter(value)
                         filter_config_dict['ShortPupil'] = ShortPupil
+                        filter_config_dict['ShortFilter'] = ShortFilter
                     elif key == 'LongFilter':
                         LongPupil, LongFilter = self.separate_pupil_and_filter(value)
                         filter_config_dict['LongPupil'] = LongPupil
+                        filter_config_dict['LongFilter'] = LongFilter
 
-                    filter_config_dict[key] = value
+                    if key not in ['ShortFilter', 'ShortPupil', 'LongFilter', 'LongPupil']:
+                        filter_config_dict[key] = value
 
                 for key in self.APTObservationParams_keys:
                     if key in filter_config_dict.keys():
@@ -772,6 +775,11 @@ class ReadAPTXML():
         for key, item in exposures_dictionary.items():
             if len(item) == 0:
                 exposures_dictionary[key] = [0] * len(exposures_dictionary['Instrument'])
+
+
+        print(exposures_dictionary['ShortFilter'])
+        print(exposures_dictionary['LongFilter'])
+
 
         return exposures_dictionary
 


### PR DESCRIPTION
This PR fixes a small bug in the APT reader, in the case of an observation that has a non CLEAR pupil value. The "filter" value from the APT file (e.g. F162M+F150W2) was being placed in the filter entry of the yaml file, when it should be just the value for the filter wheel (e.g. F150W2). 