### PR TITLE
Add warning if grism_source_image is inconsistent with mode

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -4343,6 +4343,10 @@ class Catalog_seed():
                                 "It should be a comma-separated list of x and y pixel positions."
                                 .format(self.params['simSignals']['extendedCenter'])))
 
+        # Check for consistency between the mode and grism_source_image value
+        if ((self.params['Inst']['mode'] in ['wfss', 'ts_grism']) and (not self.params['Output']['grism_source_image'])):
+            raise ValueError('Input yaml file has WFSS or TSO grism mode, but Output:grism_source_image is set to False. Must be True.')
+
     def checkRunStep(self, filename):
         # check to see if a filename exists in the parameter file.
         if ((len(filename) == 0) or (filename.lower() == 'none')):


### PR DESCRIPTION
This PR provides a more easily understood error if someone provides catalog_seed_image() with a yaml file for a WFSS or TSO grism observation, but has grism_source_image within that yaml file set to False.

Resolves #456 