### PR TITLE
Fix exptype for NIRISS AMI

### DIFF
--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -17,7 +17,7 @@ instrument_abbreviations = {'nircam': 'NRC',
 
 EXPTYPES = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
                        "wfss": "NRC_WFSS", "ts_grism": "NRC_TSGRISM"},
-            "niriss": {"imaging": "NIS_IMAGE", "ami": "NIS_IMAGE", "pom": "NIS_IMAGE",
+            "niriss": {"imaging": "NIS_IMAGE", "ami": "NIS_AMI", "pom": "NIS_IMAGE",
                        "wfss": "NIS_WFSS"},
             "fgs": {"imaging": "FGS_IMAGE"}}
 


### PR DESCRIPTION
Quick fix to correctly populate the EXPTYPE header keyword when creating NIRISS AMI simulations.

Resolves #540 