### PR TITLE
Update jwst version spec to use @

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -27,7 +27,7 @@ These are: **jwst**, which is the JWST calibration pipeline software, and two pa
     pip install mirage
     pip install git+https://github.com/npirzkal/GRISMCONF#egg=grismconf
     pip install git+https://github.com/npirzkal/NIRCAM_Gsim#egg=nircam_gsim
-    pip install git+https://github.com/spacetelescope/jwst#0.16.2
+    pip install git+https://github.com/spacetelescope/jwst@0.16.2
 
 .. tip::
     Some of Mirage's dependencies rely on `Healpy <https://healpy.readthedocs.io/en/latest/>`_,. Healpy has released different wheels for different versions of Mac OSX. For example, healpy version 1.12.5

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,6 @@ dependencies:
     - batman-package
     - jwst-backgrounds>=1.1.1
     - pysiaf>=0.6.1
-    - git+https://github.com/spacetelescope/jwst#0.15.1
+    - git+https://github.com/spacetelescope/jwst@0.16.2
     - git+https://github.com/npirzkal/GRISMCONF
     - git+https://github.com/npirzkal/NIRCAM_Gsim


### PR DESCRIPTION
Tweak the version number specification for the `jwst` package. Currently in one spot of the documentation, as well as the environment file, the command for installing jwst was given as:
`git+https://github.com/spacetelescope/jwst#0.15.1`, when in fact there should be an `@` where the `#` is. With the `#` in place, the installation process would ignore the version number and install the development version of the `jwst` package. This PR fixes that, so that the specified version of the pipeline is installed.