### PR TITLE
Force dark_prep object data to be 32-bit floats

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -920,10 +920,10 @@ class DarkPrep():
                 if file_index == 0:
                     #print('self.linDark shape is {}. Expecting it to be 4D'.format(self.linDark.data.shape))
                     junk, num_grps, ydim, xdim = self.linDark.data.shape
-                    final_dark = np.zeros((number_of_ints, num_grps, ydim, xdim))
-                    final_sbandrefpix = np.zeros((number_of_ints, num_grps, ydim, xdim))
-                    final_zerodata = np.zeros((number_of_ints, ydim, xdim))
-                    final_zero_sbandrefpix = np.zeros((number_of_ints, ydim, xdim))
+                    final_dark = np.zeros((number_of_ints, num_grps, ydim, xdim), dtype=np.float32)
+                    final_sbandrefpix = np.zeros((number_of_ints, num_grps, ydim, xdim), dtype=np.float32)
+                    final_zerodata = np.zeros((number_of_ints, ydim, xdim), dtype=np.float32)
+                    final_zero_sbandrefpix = np.zeros((number_of_ints, ydim, xdim), dtype=np.float32)
 
                 if not use_all_files:
                     print('Setting integration {} to use file {}\n'.format(file_index, os.path.split(filename)[1]))


### PR DESCRIPTION
Recent tests creating dark prep objects to be used in the collection of Mirage reference files have shown that those output data are 64-bit floats. The data returned from the pipeline run are 32-bit floats. When these data are repackaged into numpy arrays they are changed to 64-bit. This is doubling file sizes such that each 108-group dark is 6.8GB with no increase in data quality. This PR sets the data types of those numpy arrays to be 32-bit floats, in line with pipeline outputs.