### PR TITLE
Be sure darks for the correct FGS detector are used

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -38,6 +38,7 @@ import astropy.units as u
 
 import mirage
 from mirage.utils import read_fits, utils, siaf_interface
+from mirage.utils.constants import FGS1_DARK_SEARCH_STRING, FGS2_DARK_SEARCH_STRING
 from mirage.utils.file_splitting import find_file_splits
 from mirage.utils.timer import Timer
 from mirage.reference_files import crds_tools
@@ -703,7 +704,12 @@ class DarkPrep():
                 dark_dir = os.path.split(self.params['Reffiles']['linearized_darkfile'])[0]
             else:
                 dark_dir = os.path.split(self.params['Reffiles']['dark'])[0]
-            dark_list = glob(os.path.join(dark_dir, '*.fits'))
+            search_string = '*.fits'
+            if 'FGS1' in self.params['Readout']['array_name']:
+                search_string = FGS1_DARK_SEARCH_STRING
+            elif 'FGS2' in self.params['Readout']['array_name']:
+                search_string = FGS2_DARK_SEARCH_STRING
+            dark_list = glob(os.path.join(dark_dir, search_string))
         else:
             if self.runStep['linearized_darkfile']:
                 dark_list = [self.params['Reffiles']['linearized_darkfile']]

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -21,6 +21,11 @@ EXPTYPES = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
                        "wfss": "NIS_WFSS"},
             "fgs": {"imaging": "FGS_IMAGE"}}
 
+# SEARCH STRINGS TO USE FOR FGS DARKS (needed because darks for the two
+# detectors are mixed in a single directory)
+FGS1_DARK_SEARCH_STRING = '*_497_*fits'
+FGS2_DARK_SEARCH_STRING = '*_498_*fits'
+
 # Supported NIRISS filters
 NIRISS_FILTER_WHEEL_FILTERS = ['F277W', 'F356W', 'F380M', 'F430M', 'F444W', 'F480M']
 NIRISS_PUPIL_WHEEL_FILTERS = ['F090W', 'F115W', 'F158M', 'F140M', 'F150W', 'F200W']

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1602,14 +1602,12 @@ class SimInput:
             else:  # niriss and fgs
                 for det in self.det_list[instrument]:
                     if det == 'G1':
-                        self.dark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/raw',
-                                                                            '*30632_1x88_FGSF03511-D-NR-G1-5346180117_1_497_SE_2015-12-12T19h00m12_dms_uncal*.fits'))
-                        self.lindark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/linearized', '*_497_*fits'))
+                        self.dark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/raw', FGS1_DARK_SEARCH_STRING))
+                        self.lindark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/linearized', FGS1_DARK_SEARCH_STRING))
 
                     elif det == 'G2':
-                        self.dark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/raw',
-                                                                            '*30670_1x88_FGSF03511-D-NR-G2-5346181816_1_498_SE_2015-12-12T21h31m01_dms_uncal*.fits'))
-                        self.lindark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/linearized', '*_498_*fits'))
+                        self.dark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/raw', FGS2_DARK_SEARCH_STRING))
+                        self.lindark_list[instrument][det] = glob(os.path.join(self.datadir, 'fgs/darks/linearized', FGS2_DARK_SEARCH_STRING))
 
                     elif det == 'NIS':
                         self.dark_list[instrument][det] = glob(os.path.join(self.datadir, 'niriss/darks/raw',


### PR DESCRIPTION
This PR contains code that ensures that dark current files for the proper FGS detector are used in the case of an exposure with multiple integrations. The same logic is now used in the yaml_generator as well as within dark_prep, so that results will be consistent.

Resolves #556  