### PR TITLE
Add missing FGS1_DARK_SEARCH_STRING import

### DIFF
--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -107,6 +107,7 @@ import pysiaf
 
 from ..apt import apt_inputs
 from ..reference_files import crds_tools
+from ..utils.constants import FGS1_DARK_SEARCH_STRING, FGS2_DARK_SEARCH_STRING
 from ..utils.utils import calc_frame_time, ensure_dir_exists, expand_environment_variable
 from .generate_observationlist import get_observation_dict
 from ..constants import NIRISS_PUPIL_WHEEL_ELEMENTS, NIRISS_FILTER_WHEEL_ELEMENTS


### PR DESCRIPTION
This PR adds an import statement for the FGS1_DARK_SEARCH_STRING (from #557 ) to the yaml_generator. 