### PR TITLE
Update units in magnitude_to_countrate() docstring

### DIFF
--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -720,7 +720,7 @@ def magnitude_to_countrate(instrument, filter_name, magsys, mag, photfnu=None, p
     Returns
     -------
     count_rate : float or list
-        Count rate (e/s) corresponding to the input magnutude(s)
+        Count rate (ADU/s) corresponding to the input magnutude(s)
 
     """
     # For NIRISS filters in the filter wheel, we increase the count rate by a


### PR DESCRIPTION
Fixes a mistake in the docstring of magnitude_to_countrate(). The returned results are in units of ADU/sec rather than e/s.

Resolves #387 