### PR TITLE
Enable logging

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ MIRAGE: Multi-Instrument RAmp GEnerator
    seed_images.rst
    dark_preparation.rst
    observation_generator.rst
+   logging.rst
 ..   api.rst
 
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,0 +1,21 @@
+.. _logging:
+
+Logging with Mirage
+===================
+
+Creation of log files
+---------------------
+
+Currently, logging in Mirage is a 2 step process, born out of the desire to have a single log file for each module called, regardless of whether that is a call to **catalog_seed_image.py** or a call to **imaging_simulator.py** (which in turn calls catalog_seed_image.py, dark_prep.py, and obs_generator.py).
+
+While Mirage is running, it will write log messages to a file called **mirage_latest.log** in the working directory. Upon successful completion, this log file will be copied into a new location. The new location depends on exactly which Mirage modules are being called. In cases where Mirage is using a :ref:`yaml input file <example_yaml>` to create a simulated exposure (via imaging_simulator.py, catalog_seed_image.py, dark_prep.py, obs_generator.py, wfss_simulator.py, or grism_tso_simulator.py), the log file will be copied to a subdirectory called **mirage_logs** which will be located within the output directory specified in the yaml file. The name of the copied log file will also be updated to be the name of the yaml file with the suffix ".log". In practice, this means that in order to find the log files, simply go to the directory containing your newly created simulated data, and look in the **mirage_logs** subdirectory.
+
+If you are calling the **yaml_generator.py** in order to create input yaml files, then the log file will be copied to a subdirectory called **mirage_logs** located in the directory containing the :ref:`APT xml and pointing files <from_apt>`. In this case, the log file name will match the name of the APT xml file, with the suffix "log".
+
+Note that the initial log file, **mirage_latest.log** will remain in the working directory. In the event of a Mirage crash, **mirage_latest.log** will contain the traceback.
+
+Customizing logging
+-------------------
+
+The default beehavior is for Mirage to print all messages with a level of INFO or above to the screen, and to print all messages with a level of DEBUG or above into the log file. Users can customize the logs created by Mirage using the log configuration file contained in the Mirage repository. This file is located in mirage/logging/logging_config.yaml and specifies which types of logs Mirage creates and the message levels that are printed to the logs. By changing these values, users can customize the output log files.
+

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -41,6 +41,7 @@ October 2018 - Major modifications to read programs of all science instruments a
 '''
 import copy
 import os
+import logging
 import re
 import argparse
 import pkg_resources
@@ -52,8 +53,14 @@ from pysiaf import rotations, Siaf
 import yaml
 
 from . import read_apt_xml
+from ..logging import logging_functions
 from ..utils import siaf_interface, constants, utils
-from mirage.utils.constants import NIRCAM_UNSUPPORTED_PUPIL_VALUES
+from mirage.utils.constants import NIRCAM_UNSUPPORTED_PUPIL_VALUES, LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classpath, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 class AptInput:
@@ -70,6 +77,8 @@ class AptInput:
 
     def __init__(self, input_xml=None, pointing_file=None, output_dir=None, output_csv=None,
                  observation_list_file=None):
+        self.logger = logging.getLogger('mirage.apt.apt_inputs')
+
         self.input_xml = input_xml
         self.pointing_file = pointing_file
         self.output_dir = output_dir
@@ -100,8 +109,8 @@ class AptInput:
         for obs in intab['obs_label']:
             match = obs == epochs['observation'].data
             if np.sum(match) == 0:
-                print("No valid epoch line found for observation {}".format(obs))
-                print(epochs['observation'].data)
+                self.logger.error("No valid epoch line found for observation {}".format(obs))
+                self.logger.error('{}'.format(epochs['observation'].data))
                 epoch_start.append(default_date)
                 epoch_pav3.append(0.)
             else:
@@ -337,7 +346,7 @@ class AptInput:
 
         if verbose:
             for key in self.exposure_tab.keys():
-                print('{:>20} has {:>10} items'.format(key, len(self.exposure_tab[key])))
+                self.logger.info('{:>20} has {:>10} items'.format(key, len(self.exposure_tab[key])))
 
         # Create a pysiaf.Siaf instance for each instrument in the proposal
         self.siaf = {}
@@ -352,7 +361,7 @@ class AptInput:
             indir, infile = os.path.split(self.input_xml)
             self.output_csv = os.path.join(self.output_dir, 'Observation_table_for_' + infile.split('.')[0] + '.csv')
         ascii.write(Table(self.exposure_tab), self.output_csv, format='csv', overwrite=True)
-        print('csv exposure list written to {}'.format(self.output_csv))
+        self.logger.info('csv exposure list written to {}'.format(self.output_csv))
 
     def check_aperture_override(self):
         if bool(self.exposure_tab['FiducialPointOverride']) is True:
@@ -378,7 +387,7 @@ class AptInput:
                         guider_aperture = 'FGS{}_FULL'.format(guider_number)
                         fixed_apertures.append(guider_aperture)
                     else:
-                        print(instrument, aperture, inst_match_ap, aperture_key[instrument.lower()])
+                        self.logger.error('{} {} {} {}'.format(instrument, aperture, inst_match_ap, aperture_key[instrument.lower()]))
                         raise ValueError('Unknown FiducialPointOverride in program. Instrument = {} but aperture = {}.'.format(instrument, aperture))
                 else:
                     fixed_apertures.append(aperture)
@@ -623,18 +632,18 @@ class AptInput:
         """
         filter_match = [True if filter_name in mtch else False for mtch in apertures]
         if any(filter_match):
-            print('EXACT FILTER MATCH')
-            print(filter_match)
+            self.logger.debug('EXACT FILTER MATCH')
+            self.logger.debud('{}'.format(filter_match))
             apertures = list(np.array(apertures)[filter_match])
         else:
-            print('NO EXACT FILTER MATCH')
+            self.logger.debug('NO EXACT FILTER MATCH')
             filter_int = int(filter_name[1:4])
             aperture_int = np.array([int(ap.split('_')[-1][1:4]) for ap in apertures])
             wave_diffs = np.abs(aperture_int - filter_int)
             min_diff_index = np.where(wave_diffs == np.min(wave_diffs))[0]
             apertures = list(apertures[min_diff_index])
 
-            print(filter_int, aperture_int, min_diff_index, apertures)
+            self.logger.debug('{} {} {} {}'.format(filter_int, aperture_int, min_diff_index, apertures))
 
         return apertures
 
@@ -746,7 +755,7 @@ class AptInput:
                         # adopt value passed to function
                         pass
                     if verbose:
-                        print('Extracted proposal ID {}'.format(propid))
+                        self.logger.info('Extracted proposal ID {}'.format(propid))
                     continue
 
                 elif (len(line) > 1):
@@ -772,7 +781,7 @@ class AptInput:
                         obsnum = str(obsnum).zfill(3)
                         visitnum = str(visitnum).zfill(3)
                         if (skip is True) and (verbose):
-                            print('Skipping observation {} ({})'.format(obsnum, obslabel))
+                            self.logger.info('Skipping observation {} ({})'.format(obsnum, obslabel))
 
                     try:
                         # Skip the line at the beginning of each
@@ -858,7 +867,7 @@ class AptInput:
 
                     except ValueError as e:
                         if verbose:
-                            print('Skipping line:\n{}\nproducing error:\n{}'.format(line, e))
+                            self.logger.info('Skipping line:\n{}\nproducing error:\n{}'.format(line, e))
                         pass
 
         pointing = {'exposure': exp, 'dither': dith, 'aperture': aperture,

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -108,6 +108,7 @@ class ReadAPTXML():
             tracking_type = self.target_type[matched_key[0]]
         return tracking_type
 
+    @logging_functions.log_fail
     def read_xml(self, infile, verbose=False):
         """Main function. Read in the .xml file from APT, and output dictionary of parameters.
 
@@ -438,6 +439,10 @@ class ReadAPTXML():
         #filebase = os.path.split(infile)[1]
         #tmpoutfile = '{}{}'.format(filebase.split('.xml')[0], '.txt')
         #ascii.write(final_table, os.path.join(tmpoutdir, tmpoutfile), overwrite=True)
+
+
+        print('CCCC', len(self.observation_info))
+
 
         return self.APTObservationParams
 

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -108,7 +108,6 @@ class ReadAPTXML():
             tracking_type = self.target_type[matched_key[0]]
         return tracking_type
 
-    @logging_functions.log_fail
     def read_xml(self, infile, verbose=False):
         """Main function. Read in the .xml file from APT, and output dictionary of parameters.
 
@@ -439,10 +438,6 @@ class ReadAPTXML():
         #filebase = os.path.split(infile)[1]
         #tmpoutfile = '{}{}'.format(filebase.split('.xml')[0], '.txt')
         #ascii.write(final_table, os.path.join(tmpoutdir, tmpoutfile), overwrite=True)
-
-
-        print('CCCC', len(self.observation_info))
-
 
         return self.APTObservationParams
 

--- a/mirage/catalogs/hdf5_catalog.py
+++ b/mirage/catalogs/hdf5_catalog.py
@@ -24,8 +24,16 @@ Use
 
 import astropy.units as u
 import h5py
+import logging
+import os
 
-from mirage.utils.constants import FLAMBDA_CGS_UNITS, FLAMBDA_MKS_UNITS, FNU_CGS_UNITS, FNU_MKS_UNITS
+from mirage.logging import logging_functions
+from mirage.utils.constants import FLAMBDA_CGS_UNITS, FLAMBDA_MKS_UNITS, FNU_CGS_UNITS, FNU_MKS_UNITS, \
+                                   LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def open(filename):
@@ -47,6 +55,7 @@ def open(filename):
         and a wavelength unit
         'fluxes' is an astropy.units Quantity composed of a list of flux values with flux unit
     """
+    logger = logging.getLogger('mirage.catalogs.hdf5_catalog.open')
     contents = {}
     with h5py.File(filename, 'r') as file_obj:
         no_wave_units = False
@@ -98,9 +107,9 @@ def open(filename):
 
             contents[int(key)] = {'wavelengths': waves, 'fluxes': fluxes}
     if no_wave_units:
-        print("{}: No wavelength units provided. Assuming MIRCONS.".format(filename))
+        logger.info("{}: No wavelength units provided. Assuming MIRCONS.".format(filename))
     if no_flux_units:
-        print("{}: No flux density units provided. Assuming F_lambda in CGS (erg/sec/cm^2/A)".format(filename))
+        logger.info("{}: No flux density units provided. Assuming F_lambda in CGS (erg/sec/cm^2/A)".format(filename))
     return contents
 
 
@@ -123,6 +132,7 @@ def open_tso(filename):
         and a time unit
         'fluxes' is an astropy.units Quantity composed of a list of flux values with flux unit
     """
+    logger = logging.getLogger('mirage.catalogs.hdf5_catalog.open_tso')
     contents = {}
     with h5py.File(filename, 'r') as file_obj:
         no_time_units = False
@@ -165,9 +175,9 @@ def open_tso(filename):
 
             contents[int(key)] = {'times': times, 'fluxes': fluxes}
     if no_time_units:
-        print("{}: No time units provided. Assuming SECONDS.".format(filename))
+        logger.info("{}: No time units provided. Assuming SECONDS.".format(filename))
     if no_flux_units:
-        print("{}: No flux density units provided. Assuming light curve is normalized.".format(filename))
+        logger.info("{}: No flux density units provided. Assuming light curve is normalized.".format(filename))
     return contents
 
 
@@ -287,6 +297,7 @@ def string_to_units(unit_string):
     -------
     units : astropy.units Quantity
     """
+    logger = logging.getLogger('mirage.catalogs.hdf5_catalog.string_to_units')
     if unit_string.lower() in ['flam', "flam_cgs"]:
         return FLAMBDA_CGS_UNITS
     elif unit_string.lower() == 'flam_mks':
@@ -301,7 +312,7 @@ def string_to_units(unit_string):
         try:
             return u.Unit(unit_string)
         except ValueError as e:
-            print(e)
+            logger.error(e)
 
 
 def units_to_string(unit):

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -677,7 +677,8 @@ class DarkPrep():
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning dark_prep..\n')
-        self.logger.info('Reading parameter file: {}'.format(self.paramfile))
+        self.logger.info('Reading parameter file: {}\n'.format(self.paramfile))
+        self.logger.info('Original log file name: ./{}'.format(STANDARD_LOGFILE_NAME))
 
         # Make filter/pupil values respect the filter/pupil wheel they are in
         self.params['Readout']['filter'], self.params['Readout']['pupil'] = \

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -74,6 +74,9 @@ class DarkPrep():
             If True, the check for the existence of the MIRAGE_DATA
             directory is skipped. This is primarily for Travis testing
         """
+        # Initialize the log using dictionary from the yaml file
+        self.logger = logging.getLogger(__name__)
+
         self.offline = offline
         self.file_splitting = file_splitting
 
@@ -671,9 +674,6 @@ class DarkPrep():
         """MAIN FUNCTION"""
         # Read in the yaml parameter file
         self.read_parameter_file()
-
-        # Initialize the log using dictionary from the yaml file
-        self.logger = logging.getLogger(__name__)
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning dark_prep..\n')

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -670,6 +670,7 @@ class DarkPrep():
 
         return linDarkobj
 
+    @logging_functions.log_fail
     def prepare(self):
         """MAIN FUNCTION"""
         # Read in the yaml parameter file

--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -220,7 +220,7 @@ class GrismTSO():
 
         self.logger.info('Splitting background and TSO source into multiple yaml files.')
         self.logger.info('Running background sources through catalog_seed_image.')
-        self.logger.info('background param file is:', self.background_paramfile)
+        self.logger.info('background param file is: {}'.format(self.background_paramfile))
 
         # Stellar spectrum hdf5 file will be required, so no need to create one here.
         # Create hdf5 file with spectra of all sources if requested
@@ -236,6 +236,7 @@ class GrismTSO():
         # Run the catalog_seed_generator on the non-TSO (background) sources. Even if
         # no source catalogs are given, we run using the dummy catalog created earlier,
         # because we need to add the 2D dispersed background at this point.
+        self.logger.info('Running catalog_seed_generator on background sources')
         background_direct = catalog_seed_image.Catalog_seed()
         background_direct.paramfile = self.background_paramfile
         background_direct.make_seed()
@@ -251,7 +252,7 @@ class GrismTSO():
                                  background_direct.extended_seed_filename]
         for seed_file in background_seed_files:
             if seed_file is not None:
-                self.logger.info("Dispersing seed image:", seed_file)
+                self.logger.info("Dispersing seed image: {}".format(seed_file))
                 disp = self.run_disperser(seed_file, orders=self.orders,
                                           add_background=not background_done,
                                           background_waves=bkgd_waves,
@@ -267,6 +268,7 @@ class GrismTSO():
                     background_dispersed += disp.final
 
         # Run the catalog_seed_generator on the TSO source
+        self.logger.info('Running catalog_seed_generator on TSO source')
         tso_direct = catalog_seed_image.Catalog_seed()
         tso_direct.paramfile = self.tso_paramfile
         tso_direct.make_seed()
@@ -446,7 +448,7 @@ class GrismTSO():
                 self.part_frame_start_number = split_meta.part_frame_start_number[counter]
                 counter += 1
 
-                self.logger.info('Overall integration number: ', overall_integration_number)
+                self.logger.info('Overall integration number: {}'.format(overall_integration_number))
                 segment_file_name = '{}seg{}_part{}_seed_image.fits'.format(segment_file_base,
                                                                             str(self.segment_number).zfill(3),
                                                                             str(self.segment_part_number).zfill(3))

--- a/mirage/imaging_simulator.py
+++ b/mirage/imaging_simulator.py
@@ -110,7 +110,6 @@ class ImgSim():
         self.linDark = obs.linDark
 
         self.logger.info('\nImaging simulator complete')
-
         logging_functions.move_logfile_to_standard_location(self.paramfile, STANDARD_LOGFILE_NAME)
 
     def get_output_dir(self):

--- a/mirage/logging/logging_config.yaml
+++ b/mirage/logging/logging_config.yaml
@@ -1,0 +1,23 @@
+version: 1
+formatters:
+  simple:
+    format: '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: simple
+    stream: ext://sys.stdout
+  file:
+    class: logging.FileHandler
+    level: DEBUG
+    mode: w
+    formatter: simple
+loggers:
+  simpleExample:
+    level: DEBUG
+    handlers: [console, file]
+    propagate: no
+root:
+  level: DEBUG
+  handlers: [console, file]

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -3,6 +3,7 @@
 """This module contains functions related to logging in Mirage
 """
 
+import datetime
 import logging
 from logging.config import dictConfig
 import os
@@ -33,6 +34,41 @@ def create_logger(filename, output_log_file):
     logger = logging.getLogger('mirage')
 
 
+def create_standard_logfile_name(base_file, log_type='catalog_seed'):
+    """Construct the name for the final log file.
+
+    Parameters
+    ----------
+    base_file : str
+        Name of the file on which the name of the log file will be based.
+        For a ```log_type``` of "catalog_seed" or "fits_seed" this should
+        be one of the yaml input files used by i.e. catalog_seed_image.
+        For a ```log_type``` of "yaml_generator" this should be the xml
+        file from APT describing the proposal.
+
+    log_type : str
+        Type of log file being created. Must be one of:
+        'catalog_seed': for log files from catalog_seed_image, dark_prep,
+                        obs_generator, imaging_simulator, wfss_simulator,
+                        grism_tso_simulator
+        'fits_seed': for log files from fits_seed_image
+        'yaml_generator': for log files from yaml_generator, apt_reader
+
+    Reutrns
+    -------
+    log_name : str
+        Name of the log file, based on base_file and log type
+    """
+    log_type = log_type.lower()
+    if log_type == 'catalog_seed':
+        log_name = base_file.replace('.yaml', '.log')
+    elif log_type == 'fits_seed':
+        log_name = base_file.replace('.yaml', 'fits_seed_image.log')
+    elif log_type == 'yaml_generator':
+        time_stamp = datetime.datetime.now().strftime('%d-%b-%YT%H:%m:%S:%f')
+        log_name = base_file.replace('.xml', '_{}.log'.format(time_stamp))
+    return log_name
+
 def get_output_dir(yaml_file):
     """Get the output directory name from self.paramfile
 
@@ -51,7 +87,7 @@ def get_output_dir(yaml_file):
     return outdir
 
 
-def move_logfile_to_standard_location(yaml_file, input_log_file, yaml_outdir=None):
+def move_logfile_to_standard_location(base_file, input_log_file, yaml_outdir=None, log_type='catalog_seed'):
     """Copy the log file from the current working directory and standard
     name to a ```mirage_logs``` subdirectory below the simulation data
     output directory. Rename the log to match the input yaml file name
@@ -59,8 +95,12 @@ def move_logfile_to_standard_location(yaml_file, input_log_file, yaml_outdir=Non
 
     Parameters
     ----------
-    yaml_file : str
-        Name of input yaml file used for the simulation
+    base_file : str
+        Name of the file on which the name of the log file will be based.
+        For a ```log_type``` of "catalog_seed" or "fits_seed" this should
+        be one of the yaml input files used by i.e. catalog_seed_image.
+        For a ```log_type``` of "yaml_generator" this should be the xml
+        file from APT describing the proposal.
 
     input_log_file : str
         Name of the log file to be copied
@@ -70,18 +110,36 @@ def move_logfile_to_standard_location(yaml_file, input_log_file, yaml_outdir=Non
         is the directory listed in the Output:directory entry of the yaml
         file. It is here as an optional parameter to save having to read
         the yaml file
+
+    log_type : str
+        Type of log file being created. Must be one of:
+        'catalog_seed': for log files from catalog_seed_image, dark_prep,
+                        obs_generator, imaging_simulator, wfss_simulator,
+                        grism_tso_simulator
+        'fits_seed': for log files from fits_seed_image
+        'yaml_generator': for log files from yaml_generator, apt_reader
     """
-    final_logfile_name = yaml_file.replace('.yaml', '.log')
+    # Construct the log filename
+    final_logfile_name = create_standard_logfile_name(os.path.basename(base_file), log_type=log_type)
+
+    # Get the directory name in which to place the log file
     if yaml_outdir is None:
-        yaml_outdir = get_output_dir(yaml_file)
+        yaml_outdir = get_output_dir(base_file)
     final_logfile_dir = os.path.join(yaml_outdir, 'mirage_logs')
     if not os.path.exists(final_logfile_dir):
         os.makedirs(final_logfile_dir)
+
+
+    print('FINAL:', final_logfile_dir, final_logfile_name)
+
+
+    # Copy the log into the directory
     shutil.copy2(input_log_file, os.path.join(final_logfile_dir, final_logfile_name))
 
 
 def read_yaml(filename):
-    """Read the contents of a yaml file into a nested dictionary
+    """Read the contents of a yaml file into a nested dictionary. This
+    here to prevent circular import error
 
     Parameters
     ----------
@@ -95,7 +153,7 @@ def read_yaml(filename):
     """
     try:
         with open(filename, 'r') as f:
-            data = yaml.load(f, Loader=yaml.SafeLoader)
+            data = yaml.load(f, Loader=yaml.FullLoader)
     except FileNotFoundError as e:
             print(e)
     return data

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -129,10 +129,6 @@ def move_logfile_to_standard_location(base_file, input_log_file, yaml_outdir=Non
     if not os.path.exists(final_logfile_dir):
         os.makedirs(final_logfile_dir)
 
-
-    print('FINAL:', final_logfile_dir, final_logfile_name)
-
-
     # Copy the log into the directory
     shutil.copy2(input_log_file, os.path.join(final_logfile_dir, final_logfile_name))
 

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -1,0 +1,30 @@
+#! /usr/bin/env python
+
+"""This module contains functions related to logging in Mirage
+"""
+
+import yaml
+import logging
+from logging.config import dictConfig
+
+def create_logger(filename, output_log_file):
+    """Using the provided yaml file, create a logger
+
+    Parameters
+    ----------
+    filename : str
+        Name of a yaml file containing details on the logger, handler, etc
+        to create.
+
+    output_log_file : str
+        Name of the text log file to output the log to.
+    """
+    with open(filename) as fobj:
+        log_info = yaml.safe_load(fobj)
+
+    # Set the filename of the output log
+    log_info['handlers']['file']['filename'] = output_log_file
+
+    # Create the logger using the dictionary from the yaml file
+    dictConfig(log_info)
+    logger = logging.getLogger('mirage')

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -3,9 +3,12 @@
 """This module contains functions related to logging in Mirage
 """
 
-import yaml
 import logging
 from logging.config import dictConfig
+import os
+import shutil
+import yaml
+
 
 def create_logger(filename, output_log_file):
     """Using the provided yaml file, create a logger
@@ -28,3 +31,72 @@ def create_logger(filename, output_log_file):
     # Create the logger using the dictionary from the yaml file
     dictConfig(log_info)
     logger = logging.getLogger('mirage')
+
+
+def get_output_dir(yaml_file):
+    """Get the output directory name from self.paramfile
+
+    Parameters
+    ----------
+    yaml_file : str
+        Name of yaml file to be inspected
+
+    Returns
+    -------
+    outdir : str
+        Output directory specified in self.paramfile
+    """
+    params = read_yaml(yaml_file)
+    outdir = params['Output']['directory']
+    return outdir
+
+
+def move_logfile_to_standard_location(yaml_file, input_log_file, yaml_outdir=None):
+    """Copy the log file from the current working directory and standard
+    name to a ```mirage_logs``` subdirectory below the simulation data
+    output directory. Rename the log to match the input yaml file name
+    with a suffix of `log`
+
+    Parameters
+    ----------
+    yaml_file : str
+        Name of input yaml file used for the simulation
+
+    input_log_file : str
+        Name of the log file to be copied
+
+    yaml_outdir : str
+        Name of the output directory containing the simulated data. This
+        is the directory listed in the Output:directory entry of the yaml
+        file. It is here as an optional parameter to save having to read
+        the yaml file
+    """
+    final_logfile_name = yaml_file.replace('.yaml', '.log')
+    if yaml_outdir is None:
+        yaml_outdir = get_output_dir(yaml_file)
+    final_logfile_dir = os.path.join(yaml_outdir, 'mirage_logs')
+    if not os.path.exists(final_logfile_dir):
+        os.makedirs(final_logfile_dir)
+    shutil.copy2(input_log_file, os.path.join(final_logfile_dir, final_logfile_name))
+
+
+def read_yaml(filename):
+    """Read the contents of a yaml file into a nested dictionary
+
+    Parameters
+    ----------
+    filename : str
+        Name of yaml file to be read in
+
+    Returns
+    -------
+    data : dict
+        Nested dictionary of file contents
+    """
+    try:
+        with open(filename, 'r') as f:
+            data = yaml.load(f, Loader=yaml.SafeLoader)
+    except FileNotFoundError as e:
+            print(e)
+    return data
+

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -109,7 +109,7 @@ def log_fail(func):
         try:
             # Run the function
             func(*args, **kwargs)
-            logging.info('Completed Successfully')
+            #logging.info('Completed Successfully')
 
         except Exception:
             logging.critical(traceback.format_exc())

--- a/mirage/logging/logging_functions.py
+++ b/mirage/logging/logging_functions.py
@@ -4,10 +4,12 @@
 """
 
 import datetime
+from functools import wraps
 import logging
 from logging.config import dictConfig
 import os
 import shutil
+import traceback
 import yaml
 
 
@@ -85,6 +87,36 @@ def get_output_dir(yaml_file):
     params = read_yaml(yaml_file)
     outdir = params['Output']['directory']
     return outdir
+
+
+def log_fail(func):
+    """Decorator to log crashes in the decorated code.
+
+    Parameters
+    ----------
+    func : func
+        The function to decorate.
+
+    Returns
+    -------
+    wrapped : func
+        The wrapped function.
+    """
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+
+        try:
+            # Run the function
+            func(*args, **kwargs)
+            logging.info('Completed Successfully')
+
+        except Exception:
+            logging.critical(traceback.format_exc())
+            logging.critical('CRASHED')
+            raise
+
+    return wrapped
 
 
 def move_logfile_to_standard_location(base_file, input_log_file, yaml_outdir=None, log_type='catalog_seed'):

--- a/mirage/psf/deployments.py
+++ b/mirage/psf/deployments.py
@@ -13,6 +13,7 @@ Use
         ote = remove_piston_tip_tilt(ote, out_dir=out_dir)
 """
 
+import logging
 import os
 import time
 import yaml
@@ -20,6 +21,13 @@ import yaml
 from astropy.io import fits
 import numpy as np
 import webbpsf
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def load_ote_from_deployment_yaml(deployments_file, out_dir, save=True):
@@ -132,6 +140,7 @@ def generate_deployment_errors(save=True, out_dir=None):
     Deployment tolerances taken from JWST WFS&C Commissioning and Operations Plan (OTE-24):
     D36168 / 2299462 Rev C Page 10
     """
+    logger = logging.getLogger('mirage.psf.deployments.generate_deployment_errors')
 
     deployment_errors = {
         'sm_piston': np.random.normal(loc=0, scale=2500/5),  # microns
@@ -153,7 +162,7 @@ def generate_deployment_errors(save=True, out_dir=None):
         save_file = os.path.join(out_dir, 'deployment_errors_{}.yaml'.format(time.strftime("%Y%m%d_%H%M%S")))
         with open(save_file, 'w') as f:
             yaml.dump(deployment_errors, f, default_flow_style=False)
-        print('Saved deployment errors to {}'.format(save_file))
+        logger.info('Saved deployment errors to {}'.format(save_file))
     elif save:
         raise IOError('Cannot save deployment errors to yaml; no out_dir provided')
 
@@ -178,6 +187,8 @@ def reduce_deployment_errors(deployment_errors, reduction_factor=0.2, save=True,
     deployment_errors : dict
         Dictionary containing lists of reduced deployment errors
     """
+    logger = logging.getLogger('mirage.psf.deployments.reduce_deployment_errors')
+
     for key, value in deployment_errors.items():
         deployment_errors[key] = value * reduction_factor
 
@@ -186,7 +197,7 @@ def reduce_deployment_errors(deployment_errors, reduction_factor=0.2, save=True,
         save_file = os.path.join(out_dir, 'deployment_errors_reduced_{}.yaml'.format(time.strftime("%Y%m%d_%H%M%S")))
         with open(save_file, 'w') as f:
             yaml.dump(deployment_errors, f, default_flow_style=False)
-        print('Saved reduced ({}%) deployment errors to {}'.format(reduction_factor * 100, save_file))
+        logger.info('Saved reduced ({}%) deployment errors to {}'.format(reduction_factor * 100, save_file))
     elif save:
         raise IOError('Cannot save deployment errors to yaml; no out_dir provided')
 
@@ -215,6 +226,8 @@ def apply_deployment_errors(ote, deployment_errors, save=True, out_dir=None):
         List of X & Y tilts for each segment, in microns, to be used later to
         calculate the segment PSF displacement in pixels
     """
+    logger = logging.getLogger('mirage.psf.deployments.apply_deployment_errors')
+
     ote.reset()
     ote.remove_piston_tip_tilt = False  # Reset the piston/tip/tilt
 
@@ -244,7 +257,7 @@ def apply_deployment_errors(ote, deployment_errors, save=True, out_dir=None):
         save_file = os.path.join(out_dir, 'OPD_withtilt_{}.fits'.format(time.strftime("%Y%m%d_%H%M%S")))
         hdu = fits.PrimaryHDU(ote.opd, header=ote.opd_header)
         hdu.writeto(save_file)
-        print('Saved OPD to {}'.format(save_file))
+        logger.info('Saved OPD to {}'.format(save_file))
     elif save:
         raise IOError('Cannot save deployment errors to yaml; no out_dir provided')
 
@@ -268,6 +281,8 @@ def remove_piston_tip_tilt(ote, save=True, out_dir=None):
     ote : webbpsf.opds.OTE_Linear_Model_WSS object
         Adjustable OTE object without piston/tip/tilt
     """
+    logger = logging.getLogger('mirage.psf.deployments.remove_piston_tip_tilt')
+
     ote.remove_piston_tip_tilt = True
 
     # Also manually zero out the piston/tip/tilt
@@ -279,7 +294,7 @@ def remove_piston_tip_tilt(ote, save=True, out_dir=None):
         save_file = os.path.join(out_dir, 'OPD_notilt_{}.fits'.format(time.strftime("%Y%m%d_%H%M%S")))
         hdu = fits.PrimaryHDU(ote.opd, header=ote.opd_header)
         hdu.writeto(save_file)
-        print('Saved OPD with piston/tip/tilt removed to {}'.format(save_file))
+        logger.info('Saved OPD with piston/tip/tilt removed to {}'.format(save_file))
     elif save:
         raise IOError('Cannot save deployment errors to yaml; no out_dir provided')
 

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -30,6 +30,7 @@ Use
 
 from copy import copy
 from glob import glob
+import logging
 import os
 import warnings
 
@@ -37,9 +38,14 @@ from astropy.io import fits
 import numpy as np
 from webbpsf.utils import to_griddedpsfmodel
 
-from mirage.utils.constants import NIRISS_PUPIL_WHEEL_FILTERS, NIRCAM_PUPIL_WHEEL_FILTERS
+from mirage.logging import logging_functions
+from mirage.utils.constants import NIRISS_PUPIL_WHEEL_FILTERS, NIRCAM_PUPIL_WHEEL_FILTERS, \
+                                   LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
 from mirage.utils.utils import expand_environment_variable, standardize_filters
 
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def confirm_gridded_properties(filename, instrument, detector, filtername, pupilname,
@@ -200,6 +206,8 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
         Object containing PSF library
 
     """
+    logger = logging.getLogger('mirage.psf.psf_selection.get_gridded_psf_library')
+
     # First, as a way to save time, let's assume a file naming convention
     # and search for the appropriate file that way. If we find a match,
     # confirm the properties of the file via the header. This way we don't
@@ -250,7 +258,7 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
         library_file = get_library_file(instrument, detector, filtername, pupilname,
                                         wavefront_error, wavefront_error_group, library_path)
 
-    print("PSFs will be generated using: {}".format(os.path.abspath(library_file)))
+    logger.info("PSFs will be generated using: {}".format(os.path.abspath(library_file)))
 
     lib_head = fits.getheader(library_file)
     itm_sim = lib_head.get('ORIGIN', '') == 'ITM'
@@ -259,7 +267,7 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
         try:
             library = to_griddedpsfmodel(library_file)
         except OSError:
-            print("OSError: Unable to open {}.".format(library_file))
+            logger.error("OSError: Unable to open {}.".format(library_file))
     else:
         # Handle input ITM images
         library = _load_itm_library(library_file)
@@ -308,6 +316,8 @@ def get_library_file(instrument, detector, filt, pupil, wfe, wfe_group,
     matches : str
         Name of the PSF library file for the instrument and filter name
     """
+    logger = logging.getLogger('mirage.psf.psf_selection.get_library_file')
+
     psf_files = glob(os.path.join(library_path, '*.fits'))
 
     # Determine if the PSF path is default or not
@@ -441,7 +451,7 @@ def get_library_file(instrument, detector, filt, pupil, wfe, wfe_group,
     if len(matches) == 1:
         return matches[0]
     elif len(matches) == 0:
-        print('Requested parameters:\ninstrument {}\ndetector {}\nfilt {}\npupil {}\nwfe {}\n'
+        logger.info('Requested parameters:\ninstrument {}\ndetector {}\nfilt {}\npupil {}\nwfe {}\n'
               'wfe_group {}\nlibrary_path {}\n'.format(instrument, detector, filt, pupil, wfe,
                                                        wfe_group, library_path))
         raise ValueError("No PSF library file found matching requested parameters.")
@@ -489,6 +499,8 @@ def get_psf_wings(instrument, detector, filtername, pupilname, wavefront_error, 
         and column are not returned, in order to avoid edge effects
 
     """
+    logger = logging.getLogger('mirage.psf.psf_selection.get_psf_wings')
+
     # First, as a way to save time, let's assume a file naming convention
     # and search for the appropriate file that way. If we find a match,
     # confirm the properties of the file via the header. This way we don't
@@ -517,7 +529,7 @@ def get_psf_wings(instrument, detector, filtername, pupilname, wavefront_error, 
         wings_file = get_library_file(instrument, detector, filtername, pupilname,
                                       wavefront_error, wavefront_error_group, library_path, wings=True)
 
-    print("PSF wings will be from: {}".format(os.path.basename(wings_file)))
+    logger.info("PSF wings will be from: {}".format(os.path.basename(wings_file)))
     with fits.open(wings_file) as hdulist:
         psf_wing = hdulist['DET_DIST'].data
     # Crop the outer row and column in order to remove any potential edge
@@ -526,7 +538,7 @@ def get_psf_wings(instrument, detector, filtername, pupilname, wavefront_error, 
 
     for shape in psf_wing.shape:
         if shape % 2 == 0:
-            print(("WARNING: PSF wing file contains an even number of rows or columns. "
+            logger.error(("WARNING: PSF wing file contains an even number of rows or columns. "
                    "These must be even."))
             raise ValueError
     return psf_wing

--- a/mirage/psf/segment_psfs.py
+++ b/mirage/psf/segment_psfs.py
@@ -259,7 +259,7 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
     pool_start_time = time.time()
     results = pool.map(calc_psfs_for_one_segment, segments)
     pool_stop_time = time.time()
-    logger.info('\n=========== Elapsed time (all segments):', pool_stop_time - pool_start_time, '============\n')
+    logger.info('\n=========== Elapsed time (all segments): {} ============\n'.format(pool_stop_time - pool_start_time))
     pool.close()
 
 

--- a/mirage/psf/segment_psfs.py
+++ b/mirage/psf/segment_psfs.py
@@ -19,6 +19,7 @@ Use
         lib = get_gridded_segment_psf_library_list(instrument, detector, filter,
                 out_dir, pupilname="CLEAR")
 """
+import logging
 import os
 import time
 
@@ -32,7 +33,14 @@ from webbpsf.utils import to_griddedpsfmodel
 import multiprocessing
 import functools
 
+from mirage.logging import logging_functions
 from mirage.psf.psf_selection import get_library_file
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def _generate_psfs_for_one_segment(inst, ote, segment_tilts, out_dir, boresight, lib, detectors, filters, fov_pixels, nlambda, overwrite, i):
@@ -44,10 +52,12 @@ def _generate_psfs_for_one_segment(inst, ote, segment_tilts, out_dir, boresight,
 	See doc string of generate_segment_psfs for input parameter definitions.
 
 	"""
+    logger = logging.getLogger('mirage.psf.segment_psfs._generate_psfs_for_one_segment')
+
     i_segment = i + 1
 
     segname = webbpsf.webbpsf_core.segname(i_segment)
-    print('GENERATING SEGMENT {} DATA'.format(segname))
+    logger.info('GENERATING SEGMENT {} DATA'.format(segname))
 
     det_filt_match = False
     for det in sorted(detectors):
@@ -113,7 +123,7 @@ def _generate_psfs_for_one_segment(inst, ote, segment_tilts, out_dir, boresight,
             primaryhdu.header.extend(tuples)
             hdu = fits.HDUList(primaryhdu)
             hdu.writeto(filepath, overwrite=overwrite)
-            print('Saved gridded library file to {}'.format(filepath))
+            logger.info('Saved gridded library file to {}'.format(filepath))
 
     if inst.name.lower()=='nircam' and det_filt_match == False:
         raise ValueError('No matching filters and detectors given - all '
@@ -178,6 +188,8 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
         Optional; additional options to set on the NIRCam or FGS class instance used in this function.
         Any items in this dict will be added into the .options dict prior to the PSF calculations.
     """
+    logger = logging.getLogger('mirage.psf.segment_psfs.generate_segment_psfs')
+
     # Create webbpsf NIRCam instance
     inst = webbpsf.Instrument(instrument)
 
@@ -218,16 +230,16 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
         if isinstance(jitter, float):
             inst.options['jitter'] = 'gaussian'
             inst.options['jitter_sigma'] = jitter
-            print('Adding jitter', jitter)
+            logger.info('Adding jitter', jitter)
         elif isinstance(jitter, str):
             allowed_strings = ['PCS=Coarse_Like_ITM', 'PCS=Coarse']
             if jitter in allowed_strings:
                 inst.options['jitter'] = jitter
-                print('Adding {} jitter'.format(jitter))
+                logger.info('Adding {} jitter'.format(jitter))
             else:
-                print("Invalid jitter string. Must be one of: {}. Ignoring and using defaults.".format(allowed_strings))
+                logger.warning("Invalid jitter string. Must be one of: {}. Ignoring and using defaults.".format(allowed_strings))
         else:
-            print("Wrong input to jitter, assuming defaults")
+            logger.warning("Wrong input to jitter, assuming defaults")
     if inst_options is not None:
         inst.options.update(inst_options)
 
@@ -236,7 +248,7 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
                                                   # some parts of PSF calc are themselves parallelized so using
                                                   # fewer processes than number of cores is likely reasonable.
     pool = multiprocessing.Pool(processes=nproc)
-    print(f"Will perform parallelized calculation using {nproc} processes")
+    logger.info(f"Will perform parallelized calculation using {nproc} processes")
 
     # Set up a function instance with most arguments fixed
     calc_psfs_for_one_segment = functools.partial(_generate_psfs_for_one_segment, inst, ote, segment_tilts,
@@ -247,7 +259,7 @@ def generate_segment_psfs(ote, segment_tilts, out_dir, filters=['F212N', 'F480M'
     pool_start_time = time.time()
     results = pool.map(calc_psfs_for_one_segment, segments)
     pool_stop_time = time.time()
-    print('\n=========== Elapsed time (all segments):', pool_stop_time - pool_start_time, '============\n')
+    logger.info('\n=========== Elapsed time (all segments):', pool_stop_time - pool_start_time, '============\n')
     pool.close()
 
 
@@ -279,11 +291,13 @@ def get_gridded_segment_psf_library_list(instrument, detector, filtername,
         List of object containing segment PSF libraries
 
     """
+    logger = logging.getLogger('mirage.psf.segment_psfs.get_gridded_segment_psf_library_list')
+
     library_list = get_segment_library_list(instrument, detector, filtername, library_path, pupil=pupilname)
 
-    print("Segment PSFs will be generated using:")
+    logger.info("Segment PSFs will be generated using:")
     for filename in library_list:
-        print(os.path.basename(filename))
+        logger.info(os.path.basename(filename))
 
     libraries = []
     for filename in library_list:

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -77,6 +77,9 @@ class Observation():
             If True, the check for the existence of the MIRAGE_DATA
             directory is skipped. This is primarily for Travis testing
         """
+        # Initialize the log using dictionary from the yaml file
+        self.logger = logging.getLogger(__name__)
+
         self.linDark = None
         self.seed = None
         self.segmap = None
@@ -1064,9 +1067,6 @@ class Observation():
         """MAIN FUNCTION"""
         # Read in the parameter file
         self.read_parameter_file()
-
-        # Initialize the log using dictionary from the yaml file
-        self.logger = logging.getLogger(__name__)
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning observation generator....\n')

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -3339,7 +3339,7 @@ class Observation():
         # assume that the input is 2D, since we are using it to build a signal rate frame
         imageshape = image.shape
         if len(imageshape) != 2:
-            self.printfunc("Error: image %s is not two-dimensional" % (name))
+            self.logger.error("Error: image {} is not two-dimensional".format(name))
             return None, None
 
         imageshape = image.shape

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1063,6 +1063,7 @@ class Observation():
                                          (self.params['Readout']['nframe']+self.params['Readout']['nskip']))
         return crhits, crs_perframe
 
+    @logging_functions.log_fail
     def create(self):
         """MAIN FUNCTION"""
         # Read in the parameter file

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -957,7 +957,7 @@ class Observation():
         self.logger.info("Reconstructing seed image from multiple files")
         for i, filename in enumerate(filenames):
 
-            self.logger.info('File: ', filename)
+            self.logger.info('{}'.format(filename))
 
             # Read in the data from one file
             seed_data, seg_data, header_data = self.read_seed(filename)
@@ -1070,7 +1070,8 @@ class Observation():
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning observation generator....\n')
-        self.logger.info('Reading parameter file: {}'.format(self.paramfile))
+        self.logger.info('Reading parameter file: {}\n'.format(self.paramfile))
+        self.logger.info('Original log file name: ./{}'.format(STANDARD_LOGFILE_NAME))
 
         # Make filter/pupil values respect the filter/pupil wheel they are in
         self.params['Readout']['filter'], self.params['Readout']['pupil'] = \

--- a/mirage/ramp_generator/unlinearize.py
+++ b/mirage/ramp_generator/unlinearize.py
@@ -6,13 +6,24 @@ image or ramp. Introduce non-linearity into a linear
 input ramp.
 '''
 
+import logging
 import sys
 import numpy as np
+import os
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def unlinearize(image, coeffs, sat, lin_satmap, maxiter=10, accuracy=0.000001, robberto=False,
                 save_accuracy_map=False, accuracy_file='unlinearize_no_convergence.fits'):
     # Insert non-linearity into the linear synthetic sources
+    logger = logging.getLogger('mirage.ramp_generator.unlinearize.unlinearize')
 
     # If the sizes of the satmap or coeffs are different than
     # the data, return an error
@@ -72,9 +83,9 @@ def unlinearize(image, coeffs, sat, lin_satmap, maxiter=10, accuracy=0.000001, r
     # locations.
     if i == maxiter and save_accuracy_map:
         from astropy.io import fits
-        print(("WARNING: some pixels failed to unlinearize correctly within "
-               "the maximum number of iterations. Map of accuracy of the "
-               "unlinearized values saved to {}.".format(accuracy_file)))
+        logger.warning(("WARNING: some pixels failed to unlinearize correctly within "
+                        "the maximum number of iterations. Map of accuracy of the "
+                        "unlinearized values saved to {}.".format(accuracy_file)))
         devcheck = np.copy(dev)
         devcheck[i2] = -1.
         h0 = fits.PrimaryHDU()

--- a/mirage/reference_files/crds_tools.py
+++ b/mirage/reference_files/crds_tools.py
@@ -30,9 +30,15 @@ Use
 
 import datetime
 import os
+import logging
 
+from mirage.logging import logging_functions
 from mirage.utils.utils import ensure_dir_exists
-from mirage.utils.constants import EXPTYPES
+from mirage.utils.constants import EXPTYPES, LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def env_variables():
@@ -58,12 +64,13 @@ def path_check():
     crds_path : str
         Full path to the location of the CRDS reference files
     """
+    logger = logging.getLogger('mirage.reference_files.crds_tools.path_check')
     crds_path = os.environ.get('CRDS_PATH')
     if crds_path is None:
         reffile_dir = '{}/crds_cache'.format(os.environ.get('HOME'))
         os.environ["CRDS_PATH"] = reffile_dir
         ensure_dir_exists(reffile_dir)
-        print('CRDS_PATH environment variable not set. Setting to {}'.format(reffile_dir))
+        logger.info('CRDS_PATH environment variable not set. Setting to {}'.format(reffile_dir))
         return reffile_dir
     else:
         return crds_path

--- a/mirage/seed_image/blot_image.py
+++ b/mirage/seed_image/blot_image.py
@@ -8,6 +8,7 @@ Use in conjunction with crop_mosaic.py
 import sys
 import os
 import glob
+import logging
 from copy import copy
 import argparse
 
@@ -20,8 +21,15 @@ from jwst.assign_wcs import AssignWcsStep
 from jwst.datamodels import container
 import pysiaf
 
-from ..utils import set_telescope_pointing_separated as stp
-from ..utils.siaf_interface import get_instance
+from mirage.logging import logging_functions
+from mirage.utils import set_telescope_pointing_separated as stp
+from mirage.utils.siaf_interface import get_instance
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 class Blot():
@@ -58,6 +66,8 @@ class Blot():
             Name of a CRDS distortion reference file to be used when running
             the assign_wcs pipeline step on the blotted data
         """
+        self.logger = logging.getLogger(__name__)
+
         if isinstance(ra, float):
             self.center_ra = [ra]
         else:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -89,6 +89,9 @@ class Catalog_seed():
             If True, the check for the existence of the MIRAGE_DATA
             directory is skipped. This is primarily for Travis testing
         """
+        # Initialize the log using dictionary from the yaml file
+        self.logger = logging.getLogger(__name__)
+
         self.offline = offline
 
         # Locate the module files, so that we know where to look
@@ -137,9 +140,6 @@ class Catalog_seed():
         # Read in input parameters and quality check
         self.seed_files = []
         self.readParameterFile()
-
-        # Initialize the log using dictionary from the yaml file
-        self.logger = logging.getLogger(__name__)
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning catalog_seed_image..\n')

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -143,7 +143,8 @@ class Catalog_seed():
 
         # Get the log caught up on what's already happened
         self.logger.info('\n\nRunning catalog_seed_image..\n')
-        self.logger.info('Reading parameter file: {}'.format(self.paramfile))
+        self.logger.info('Reading parameter file: {}\n'.format(self.paramfile))
+        self.logger.info('Original log file name: ./{}'.format(STANDARD_LOGFILE_NAME))
 
         # Make filter/pupil values respect the filter/pupil wheel they are in
         self.params['Readout']['filter'], self.params['Readout']['pupil'] = \

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -134,6 +134,7 @@ class Catalog_seed():
         # Initialize timer
         self.timer = Timer()
 
+    @logging_functions.log_fail
     def make_seed(self):
         """MAIN FUNCTION"""
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -449,7 +449,8 @@ class Catalog_seed():
         # logger with the same handler and file destination, so it will
         # append to the original log file created here.
         logging_functions.move_logfile_to_standard_location(self.paramfile, STANDARD_LOGFILE_NAME,
-                                                            yaml_outdir=self.params['Output']['directory'])
+                                                            yaml_outdir=self.params['Output']['directory'],
+                                                            log_type='catalog_seed')
 
     def create_tso_seed(self, split_seed=False, integration_splits=-1, frame_splits=-1):
         """Create a seed image for time series sources. Just like for moving

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -48,7 +48,8 @@ from ..utils import rotations, polynomial, read_siaf_table, utils
 from ..utils import set_telescope_pointing_separated as set_telescope_pointing
 from ..utils import siaf_interface, file_io
 from ..utils.constants import CRDS_FILE_TYPES, MEAN_GAIN_VALUES, SERSIC_FRACTIONAL_SIGNAL, \
-                              SEGMENTATION_MIN_SIGNAL_RATE, SUPPORTED_SEGMENTATION_THRESHOLD_UNITS
+                              SEGMENTATION_MIN_SIGNAL_RATE, SUPPORTED_SEGMENTATION_THRESHOLD_UNITS, \
+                              LOG_CONFIG_FILENAME
 from ..utils.flux_cal import fluxcal_info, sersic_fractional_radius, sersic_total_signal
 from ..utils.timer import Timer
 from ..psf.psf_selection import get_gridded_psf_library, get_psf_wings
@@ -133,7 +134,7 @@ class Catalog_seed():
         self.readParameterFile()
 
         # Initialize the log using dictionary from the yaml file
-        log_config_file = os.path.join(self.modpath, 'config', 'logging_config.yam')
+        log_config_file = os.path.join(self.modpath, 'config', LOG_CONFIG_FILENAME)
         log_output_dir = os.path.abspath(os.path.join(self.params['Output']['directory'], 'logs'))
         utils.ensure_dir_exists(log_output_dir)
         logfile_name = self.paramfile.replace('.yaml', '.log')

--- a/mirage/seed_image/crop_mosaic.py
+++ b/mirage/seed_image/crop_mosaic.py
@@ -8,6 +8,7 @@ and then used as an input to the ramp simulator.
 
 import argparse
 import logging
+import os
 
 from astropy import wcs
 from astropy.io import fits

--- a/mirage/seed_image/crop_mosaic.py
+++ b/mirage/seed_image/crop_mosaic.py
@@ -7,11 +7,21 @@ and then used as an input to the ramp simulator.
 """
 
 import argparse
+import logging
 
 from astropy import wcs
 from astropy.io import fits
 import numpy as np
 from jwst import datamodels
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
+
 
 class Extraction():
     def __init__(self, mosaicfile=None, data_extension_number=0, wcs_extension_number=0,
@@ -50,6 +60,8 @@ class Extraction():
             image will be used for later. This is needed to transform the
             ``dimensions`` from JWST pixels to mosaic pixels.
         """
+        self.logger = logging.getLogger(__name__)
+
         self.mosaicfile = mosaicfile
         self.data_extension_number = data_extension_number
         self.wcs_extension_number = wcs_extension_number
@@ -81,9 +93,9 @@ class Extraction():
 
         # Assume the input mosaic has been drizzled, so remove
         # any SIP coefficients that may be present
-        print('\n\n******************************************************************')
-        print('Assuming input files have been drizzled. Removing SIP coefficients')
-        print('******************************************************************\n\n')
+        self.logger.info('\n\n******************************************************************')
+        self.logger.info('Assuming input files have been drizzled. Removing SIP coefficients')
+        self.logger.info('******************************************************************\n\n')
         mosaic_wcs.sip = None
 
         radec = np.array([[self.center_ra, self.center_dec]])
@@ -142,9 +154,9 @@ class Extraction():
         if maxx > mosaic_shape[1]:
             maxx = mosaic_shape[1]
 
-        print("Coords of center of cropped area", mosaic_center_x, mosaic_center_y)
-        print("X-min, X-max coords: ", minx, maxx)
-        print("Y-min, Y-max coords: ", miny, maxy)
+        self.logger.info("Coords of center of cropped area", mosaic_center_x, mosaic_center_y)
+        self.logger.info("X-min, X-max coords: ", minx, maxx)
+        self.logger.info("Y-min, Y-max coords: ", miny, maxy)
 
         crop = mosaic[self.data_extension_number].data[miny: maxy, minx: maxx]
 
@@ -154,7 +166,7 @@ class Extraction():
         # Save only if outfile is not None
         if self.outfile is not None:
             self.savefits(crop, self.outfile)
-            print("Extracted image saved to {}".format(self.outfile))
+            self.logger.info("Extracted image saved to {}".format(self.outfile))
 
     def populate_datamodel(self, array):
         """Place the image and accopanying WCS information in an

--- a/mirage/seed_image/fits_seed_image.py
+++ b/mirage/seed_image/fits_seed_image.py
@@ -154,7 +154,7 @@ config_files = {'nircam': {'flux_cal': 'NIRCam_zeropoints.list'},
 
 KNOWN_PSF_TELESCOPES = {"JWST", "HST", "SPITZER"}
 
-classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+classpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 log_config_file = os.path.join(classpath, 'logging', LOG_CONFIG_FILENAME)
 logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
@@ -305,7 +305,8 @@ class ImgSeed:
         # Initialize log
         self.logger = logging.getLogger('mirage.seed_image.fits_seed_image')
         self.logger.info('\n\nRunning fits_seed_image....\n')
-        self.logger.info('using parameter file: {}'.format(self.paramfile))
+        self.logger.info('using parameter file: {}\n'.format(self.paramfile))
+        self.logger.info('Original log file name: ./{}'.format(STANDARD_LOGFILE_NAME))
 
         self.detector_channel_value()
         self.distortion_file_value()

--- a/mirage/seed_image/moving_targets.py
+++ b/mirage/seed_image/moving_targets.py
@@ -28,14 +28,26 @@ Author:
 Bryan Hilbert
 '''
 
+import logging
+import os
 import sys
 
 import numpy as np
 from astropy.io import fits
 
+from ..logging import logging_functions
+from ..utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
+
+
 class MovingTarget():
 
     def __init__(self):
+        self.logger = logging.getLogger(__name__)
         self.verbose = False
         self.subsampx = 3
         self.subsampy = 3
@@ -283,8 +295,8 @@ class MovingTarget():
                 else:
                     ioutxmax += 1
             else:
-                print("WARNING: bad stamp/output match. Quitting.")
-                sys.exit()
+                self.logger.error("WARNING: bad stamp/output match. Quitting.")
+                raise ValueError('Bad stamp/output match.')
             return ioutxmin, ioutxmax, istampxmin, istampxmax
         else:
             # If values are NaN then we can't change them to integers

--- a/mirage/seed_image/save_seed.py
+++ b/mirage/seed_image/save_seed.py
@@ -3,10 +3,20 @@
 """
 Utility for saving seed images
 """
+import logging
+
 from astropy.io import fits
 import numpy as np
 
 import mirage
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
+
 
 
 def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength,
@@ -14,22 +24,24 @@ def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength
          filename=None, segmentation_map=None, frametime=None, base_unit='ADU'):
     """Save a seed image
     """
+    logger = logging.getLogger('mirage.seed_image.save_seed.save')
+
     arrayshape = seed_image.shape
     if len(arrayshape) == 2:
         units = '{}/sec'.format(base_unit)
         yd, xd = arrayshape
         tgroup = 0.
-        print('Seed image is 2D.')
+        logger.info('Seed image is 2D.')
     elif len(arrayshape) == 3:
         units = base_unit
         g, yd, xd = arrayshape
         tgroup = frametime * (parameters['Readout']['nframe'] + parameters['Readout']['nskip'])
-        print('Seed image is 3D.')
+        logger.info('Seed image is 3D.')
     elif len(arrayshape) == 4:
         units = base_unit
         integ, g, yd, xd = arrayshape
         tgroup = frametime * (parameters['Readout']['nframe'] + parameters['Readout']['nskip'])
-        print('Seed image is 4D.')
+        logger.info('Seed image is 4D.')
 
     xcent_fov = xd / 2
     ycent_fov = yd / 2

--- a/mirage/seed_image/save_seed.py
+++ b/mirage/seed_image/save_seed.py
@@ -4,6 +4,7 @@
 Utility for saving seed images
 """
 import logging
+import os
 
 from astropy.io import fits
 import numpy as np

--- a/mirage/utils/backgrounds.py
+++ b/mirage/utils/backgrounds.py
@@ -4,11 +4,14 @@ jwst_backgrounds
 """
 import astropy.units as u
 import datetime
+import logging
 import numpy as np
+import os
 
 from jwst_backgrounds import jbt
 
-from mirage.utils.constants import PRIMARY_MIRROR_AREA, PLANCK
+from mirage.logging import logging_functions
+from mirage.utils.constants import PRIMARY_MIRROR_AREA, PLANCK, LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
 from mirage.utils.file_io import read_filter_throughput
 from mirage.utils.flux_cal import fluxcal_info
 
@@ -17,6 +20,11 @@ from mirage.utils.flux_cal import fluxcal_info
 LOW = 0.1
 MEDIUM = 0.5
 HIGH = 0.9
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def calculate_background(ra, dec, filter_file, use_dateobs, gain_value,
@@ -339,17 +347,19 @@ def nircam_background_spectrum(parameters, detector, module):
     fluxes : numpy.ndarray
         1D array of flux density values
     """
+    logger = logging.getLogger('mirage.utils.backgrounds.nircam_background_spectrum')
+
     if parameters['simSignals']['use_dateobs_for_background']:
-        print("Generating background spectrum for observation date: {}"
-              .format(parameters['Output']['date_obs']))
+        logger.info("Generating background spectrum for observation date: {}"
+                     .format(parameters['Output']['date_obs']))
         waves, fluxes = day_of_year_background_spectrum(parameters['Telescope']['ra'],
                                                         parameters['Telescope']['dec'],
                                                         parameters['Output']['date_obs'])
     else:
         if isinstance(parameters['simSignals']['bkgdrate'], str):
             if parameters['simSignals']['bkgdrate'].lower() in ['low', 'medium', 'high']:
-                print("Generating background spectrum based on requested level of: {}"
-                      .format(parameters['simSignals']['bkgdrate']))
+                logger.info("Generating background spectrum based on requested level of: {}"
+                            .format(parameters['simSignals']['bkgdrate']))
                 waves, fluxes = low_med_high_background_spectrum(parameters, detector, module)
             else:
                 raise ValueError("ERROR: Unrecognized background rate. Must be one of 'low', 'medium', 'high'")

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -118,7 +118,7 @@ LOG_CONFIG_FILENAME = 'logging_config.yaml'
 
 # Standard log file names. These are needed because we need to have a
 # log file name before we know the yaml/xml filename
-STANDARD_LOGFILE_NAME = 'temp.log'
+STANDARD_LOGFILE_NAME = 'mirage_latest.log'
 
 
 def grism_factor(instrument_name):

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -115,7 +115,16 @@ SERSIC_FRACTIONAL_SIGNAL = 0.9995
 
 # Configuration file for defining the logs
 LOG_CONFIG_FILENAME = 'logging_config.yaml'
+
+# Standard log file names. These are needed because we need to have a
+# log file name before we know the yaml/xml filename
+#These need to be unique for each call in order to support multiprocessing
+#But we cant use difft standard log filenames, because the utilities need
+#to be able to reference the correct log file regardless of where they are
+#being called from
 STANDARD_LOGFILE_NAME = 'temp.log'
+#STANDARD_FITSSEED_LOGFILE_NAME = 'temp_fits_seed.log'
+#STANDARD_YAML_GEN_LOGFILE_NAME = 'temp_yaml_gen.log'
 
 
 def grism_factor(instrument_name):

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -118,13 +118,7 @@ LOG_CONFIG_FILENAME = 'logging_config.yaml'
 
 # Standard log file names. These are needed because we need to have a
 # log file name before we know the yaml/xml filename
-#These need to be unique for each call in order to support multiprocessing
-#But we cant use difft standard log filenames, because the utilities need
-#to be able to reference the correct log file regardless of where they are
-#being called from
 STANDARD_LOGFILE_NAME = 'temp.log'
-#STANDARD_FITSSEED_LOGFILE_NAME = 'temp_fits_seed.log'
-#STANDARD_YAML_GEN_LOGFILE_NAME = 'temp_yaml_gen.log'
 
 
 def grism_factor(instrument_name):

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -113,6 +113,9 @@ PLANCK = 6.62607004e-34  * u.meter * u.meter * u.kg / u.second
 # Fraction of the total Sersic
 SERSIC_FRACTIONAL_SIGNAL = 0.9995
 
+# Configuration file for defining the logs
+LOG_CONFIG_FILENAME = 'logging_config.yaml'
+
 
 def grism_factor(instrument_name):
     """Return the factor by which the field of view is expanded when

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -115,6 +115,7 @@ SERSIC_FRACTIONAL_SIGNAL = 0.9995
 
 # Configuration file for defining the logs
 LOG_CONFIG_FILENAME = 'logging_config.yaml'
+STANDARD_LOGFILE_NAME = 'temp.log'
 
 
 def grism_factor(instrument_name):

--- a/mirage/utils/file_io.py
+++ b/mirage/utils/file_io.py
@@ -19,10 +19,20 @@ Use
         from mirage.utils import file_io
         gain, gain_head = file_io.read_gain_file(filename)
 """
+import logging
 import os
 
 from astropy.io import ascii, fits
 import numpy as np
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
+
 
 
 def read_filter_throughput(filename):
@@ -60,12 +70,14 @@ def read_gain_file(filename):
     header : dict
         Information contained in the header of the file
     """
+    logger = logging.getLogger('mirage.utils.file_io.read_gain_file')
+
     try:
         with fits.open(filename) as h:
             image = h[1].data
             header = h[0].header
     except (FileNotFoundError, IOError) as e:
-        print(e)
+        logger.error(e)
 
     mngain = np.nanmedian(image)
 

--- a/mirage/utils/file_splitting.py
+++ b/mirage/utils/file_splitting.py
@@ -88,8 +88,8 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
         group_list = np.append(group_list, groups)
         logger.info('Splitting within each integration:')
         integration_list = np.arange(integrations + 1).astype(np.int)
-        logger.info('integration_list: ', integration_list)
-        logger.info('group_list: ', group_list)
+        logger.info('integration_list: {}'.format(integration_list))
+        logger.info('group_list: {}'.format(group_list))
     elif observation > pixel_limit:
         split = True
         logger.info('Splitting by integration:')
@@ -97,8 +97,8 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
         delta_int = np.int(pixel_limit / pix_per_int)
         integration_list = np.arange(0, integrations, delta_int).astype(np.int)
         integration_list = np.append(integration_list, integrations)
-        logger.info('integration_list: ', integration_list)
-        logger.info('group_list: ', group_list)
+        logger.info('integration_list: {}'.format(integration_list))
+        logger.info('group_list: {}'.format(group_list))
 
     return split, group_list, integration_list
 

--- a/mirage/utils/file_splitting.py
+++ b/mirage/utils/file_splitting.py
@@ -6,8 +6,18 @@ DMS pipeline will do the same job. Files that are spllit will have
 ``segNNN`` added to their names, where ``NNN`` is a number.
 """
 import copy
+import logging
 import numpy as np
-from mirage.utils.constants import FILE_SPLITTING_LIMIT
+import os
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import FILE_SPLITTING_LIMIT, LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
+
 
 
 def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
@@ -50,6 +60,8 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
         1d array listing the beginning integration number of each file
         split
     """
+    logger = logging.getLogger('mirage.utils.file_splitting.find_file_splits')
+
     pix_per_group = ydim * xdim
     pix_per_int = groups * pix_per_group
     observation = pix_per_int * integrations
@@ -74,19 +86,19 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
 
         group_list = np.arange(0, groups, delta_group).astype(np.int)
         group_list = np.append(group_list, groups)
-        print('Splitting within each integration:')
+        logger.info('Splitting within each integration:')
         integration_list = np.arange(integrations + 1).astype(np.int)
-        print('integration_list: ', integration_list)
-        print('group_list: ', group_list)
+        logger.info('integration_list: ', integration_list)
+        logger.info('group_list: ', group_list)
     elif observation > pixel_limit:
         split = True
-        print('Splitting by integration:')
+        logger.info('Splitting by integration:')
         group_list = np.array([0, groups])
         delta_int = np.int(pixel_limit / pix_per_int)
         integration_list = np.arange(0, integrations, delta_int).astype(np.int)
         integration_list = np.append(integration_list, integrations)
-        print('integration_list: ', integration_list)
-        print('group_list: ', group_list)
+        logger.info('integration_list: ', integration_list)
+        logger.info('group_list: ', group_list)
 
     return split, group_list, integration_list
 

--- a/mirage/utils/read_fits.py
+++ b/mirage/utils/read_fits.py
@@ -21,9 +21,20 @@ exptype = exposure.type EXP_TYPE
 detector - instrument.detector DETECTOR
 instrument - instrument.name INSTRUME
 '''
+import logging
 import numpy as np
+import os
+
 from astropy.io import fits
 from jwst.datamodels import RampModel
+
+from mirage.logging import logging_functions
+from mirage.utils.constants import LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
+
+
+classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 class Read_fits():
@@ -90,6 +101,7 @@ class Read_fits():
                 self.header[key] = None
 
     def read_datamodel(self):
+        logger = logging.getLogger('mirage.utils.read_fits.read_datamodel')
 
         h = RampModel(self.file)
 
@@ -105,8 +117,7 @@ class Read_fits():
         #zeros, then set it to None here
         #self.zeroframe = h.zeroframe
         if np.all(h.zeroframe == 0):
-            print("Zeroframe in {}".format(self.file))
-            print("All zeros. Returning None.")
+            logger.info("Zeroframe in {} is all zeros. Returning None.".format(self.file))
             self.zeroframe = None
         else:
             self.zeroframe = h.zeroframe

--- a/mirage/utils/utils.py
+++ b/mirage/utils/utils.py
@@ -969,11 +969,13 @@ def read_yaml(filename):
     data : dict
         Nested dictionary of file contents
     """
+    logger = logging.getLogger('mirage.utils.utils.read_yaml')
+
     try:
         with open(filename, 'r') as f:
             data = yaml.load(f, Loader=yaml.FullLoader)
     except FileNotFoundError as e:
-            print(e)
+            logging.error(e)
     return data
 
 

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -599,6 +599,7 @@ class SimInput:
                 self.multiple_catalog_match(filter, cattype, match)
             return match[0]
 
+    @logging_functions.log_fail
     def create_inputs(self):
         """Create observation table """
         self.path_defs()
@@ -623,6 +624,9 @@ class SimInput:
 
             apt.output_dir = self.output_dir
             apt.create_input_table()
+
+
+            stop
 
             self.info = apt.exposure_tab
 

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -251,7 +251,8 @@ class SimInput:
         # Initialize log
         self.logger = logging.getLogger('mirage.yaml.yaml_generator')
         self.logger.info('Running yaml_generator....\n')
-        self.logger.info('using APT xml file: {}'.format(input_xml))
+        self.logger.info('using APT xml file: {}\n'.format(input_xml))
+        self.logger.info('Original log file name: ./{}'.format(STANDARD_LOGFILE_NAME))
 
         parameter_overrides = {'cosmic_rays': cosmic_rays, 'background': background, 'roll_angle': roll_angle,
                                'dates': dates}

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -624,10 +624,6 @@ class SimInput:
 
             apt.output_dir = self.output_dir
             apt.create_input_table()
-
-
-            stop
-
             self.info = apt.exposure_tab
 
             # Add start time info to each element.

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -93,6 +93,7 @@ History
 import sys
 import os
 import argparse
+import logging
 from copy import deepcopy
 from glob import glob
 import datetime
@@ -106,15 +107,21 @@ import pkg_resources
 import pysiaf
 
 from ..apt import apt_inputs
+from ..logging import logging_functions
 from ..reference_files import crds_tools
 from ..utils.constants import FGS1_DARK_SEARCH_STRING, FGS2_DARK_SEARCH_STRING
 from ..utils.utils import calc_frame_time, ensure_dir_exists, expand_environment_variable
 from .generate_observationlist import get_observation_dict
 from ..constants import NIRISS_PUPIL_WHEEL_ELEMENTS, NIRISS_FILTER_WHEEL_ELEMENTS
-from ..utils.constants import CRDS_FILE_TYPES, SEGMENTATION_MIN_SIGNAL_RATE
+from ..utils.constants import CRDS_FILE_TYPES, SEGMENTATION_MIN_SIGNAL_RATE, \
+                              LOG_CONFIG_FILENAME, STANDARD_LOGFILE_NAME
 from ..utils import utils
 
 ENV_VAR = 'MIRAGE_DATA'
+
+classpath = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
+log_config_file = os.path.join(classpath, 'logging', LOG_CONFIG_FILENAME)
+logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 class SimInput:
@@ -241,6 +248,11 @@ class SimInput:
             Whether the class is being called with or without access to
             Mirage reference data. Used primarily for testing.
         """
+        # Initialize log
+        self.logger = logging.getLogger('mirage.yaml.yaml_generator')
+        self.logger.info('Running yaml_generator....\n')
+        self.logger.info('using APT xml file: {}'.format(input_xml))
+
         parameter_overrides = {'cosmic_rays': cosmic_rays, 'background': background, 'roll_angle': roll_angle,
                                'dates': dates}
 
@@ -298,7 +310,7 @@ class SimInput:
                                                      verbose=self.verbose,
                                                      parameter_overrides=parameter_overrides)
         else:
-            print('No input xml file provided. Observation dictionary not constructed.')
+            self.logger.error('No input xml file provided. Observation dictionary not constructed.')
 
         self.reffile_setup()
 
@@ -625,7 +637,7 @@ class SimInput:
             self.make_output_names()
 
         elif self.table_file is not None:
-            print('Reading table file: {}'.format(self.table_file))
+            self.logger.info('Reading table file: {}'.format(self.table_file))
             info = ascii.read(self.table_file)
             self.info = self.table_to_dict(info)
             final_file = self.table_file + '_with_yaml_parameters.csv'
@@ -742,7 +754,7 @@ class SimInput:
 
         table = Table(self.info)
         table.write(final_file, format='csv', overwrite=True)
-        print('Updated observation table file saved to {}'.format(final_file))
+        self.logger.info('Updated observation table file saved to {}'.format(final_file))
 
         # Now go through the lists one element at a time
         # and create a yaml file for each.
@@ -790,7 +802,7 @@ class SimInput:
         mosaic_numbers = sorted(list(set([f.split('_')[0] for f in filenames])))
         obs_ids = sorted(list(set([m[7:10] for m in mosaic_numbers])))
 
-        print('\n')
+        self.logger.info('\n')
 
         total_exposures = 0
         for obs in obs_ids:
@@ -843,17 +855,21 @@ class SimInput:
             else:
                 instrument_string = '    Prime: {}'.format(prime_instrument)
 
-            print('\nObservation {}:'.format(obs))
-            print(instrument_string)
-            print('    {} visit(s)'.format(n_visits))
-            print('    {} activity(ies)'.format(n_activities))
-            #print('    {} exposure(s)'.format(n_exposures))
+            self.logger.info('Observation {}:'.format(obs))
+            self.logger.info(instrument_string)
+            self.logger.info('    {} visit(s)'.format(n_visits))
+            self.logger.info('    {} activity(ies)'.format(n_activities))
+            #self.logger.info('    {} exposure(s)'.format(n_exposures))
             if ((prime_instrument.upper() == 'NIRCAM') or (parallel_instrument.upper() == 'NIRCAM')):
-                print('    {} NIRCam detector(s) in module {}'.format(n_det, module))
-            print('    {} file(s)'.format(total_files))
+                self.logger.info('    {} NIRCam detector(s) in module {}'.format(n_det, module))
+            self.logger.info('    {} file(s)'.format(total_files))
 
-        # print('\n{} exposures total.'.format(total_exposures))
-        print('{} output files written to: {}'.format(len(yamls), self.output_dir))
+        # self.logger.info('\n{} exposures total.'.format(total_exposures))
+        self.logger.info('{} output files written to: {}'.format(len(yamls), self.output_dir))
+        self.logger.info('Yaml generator complete')
+        log_outdir = os.path.dirname(self.input_xml)
+        logging_functions.move_logfile_to_standard_location(self.input_xml, STANDARD_LOGFILE_NAME,
+                                                            yaml_outdir=log_outdir, log_type='yaml_generator')
 
     def create_output_name(self, input_obj, index=0):
         """Put together the JWST formatted fits file name based on observation parameters
@@ -998,7 +1014,7 @@ class SimInput:
         for key in refs:
             if detector in key:
                 return refs[key]
-        print("WARNING: no file found for detector {} in {}"
+        self.logger.error("WARNING: no file found for detector {} in {}"
               .format(detector, refs))
 
     def get_subarray_defs(self, filename=None):
@@ -1356,8 +1372,8 @@ class SimInput:
                 # should never enter this code block given the lines above.
                 if amp == 0:
                     amp = 4
-                    print(('Aperture {} can be used with 1 or 4 readout amplifiers. Defaulting to use 4.'
-                           'In the future this information should be made a user input.'.format(aperture)))
+                    self.logger.info(('Aperture {} can be used with 1 or 4 readout amplifiers. Defaulting to use 4.'
+                                      'In the future this information should be made a user input.'.format(aperture)))
                 namp.append(amp)
 
                 # same activity ID
@@ -1459,9 +1475,9 @@ class SimInput:
         matchlist : list
           Matching catalog names
         """
-        print("WARNING: multiple {} catalogs matched! Using the first.".format(cattype))
-        print("Observation filter: {}".format(filter))
-        print("Matched point source catalogs: {}".format(matchlist))
+        self.logger.warning("WARNING: multiple {} catalogs matched! Using the first.".format(cattype))
+        self.logger.warning("Observation filter: {}".format(filter))
+        self.logger.warning("Matched point source catalogs: {}".format(matchlist))
 
     def no_catalog_match(self, filter, cattype):
         """
@@ -1475,10 +1491,10 @@ class SimInput:
           Type of catalog (e.g. pointsource)
 
         """
-        print("WARNING: unable to find filter ({}) name".format(filter))
-        print("in any of the given {} inputs".format(cattype))
-        print("Using the first input for now. Make sure input catalog names have")
-        print("the appropriate filter name in the filename to get matching to work.")
+        self.logger.warning("WARNING: unable to find filter ({}) name".format(filter))
+        self.logger.warning("in any of the given {} inputs".format(cattype))
+        self.logger.warning("Using the first input for now. Make sure input catalog names have")
+        self.logger.warning("the appropriate filter name in the filename to get matching to work.")
 
     def path_defs(self):
         """Expand input files to have full paths"""
@@ -1669,7 +1685,7 @@ class SimInput:
 
         # If no path explicitly provided, use the default path.
         if self.psf_paths is None:
-            print('No PSF path provided. Using default path as PSF path for all yamls.')
+            self.logger.info('No PSF path provided. Using default path as PSF path for all yamls.')
             paths_out = []
             for instrument in self.info['Instrument']:
                 default_path = self.global_psfpath[instrument.lower()]
@@ -1677,7 +1693,7 @@ class SimInput:
             return paths_out
 
         elif isinstance(self.psf_paths, str):
-            print('Using provided PSF path.')
+            self.logger.info('Using provided PSF path.')
             paths_out = [self.psf_paths] * len(self.info['act_id'])
             return paths_out
 
@@ -1689,7 +1705,7 @@ class SimInput:
                              .format(n_activities, len(self.psf_paths)))
 
         elif isinstance(self.psf_paths, list):
-            print('Using provided PSF paths.')
+            self.logger.info('Using provided PSF paths.')
             paths_out = [self.psf_paths[i] for i in exp_id_indices]
             return paths_out
 
@@ -2292,8 +2308,8 @@ def default_obs_v3pa_on_date(pointing_filename, obs_num, date=None, verbose=Fals
         if pointing_table['obs_num'][i] == f"{obs_num:03d}":
             ra_deg, dec_deg = pointing_table['ra'][i], pointing_table['dec'][i]
             if verbose:
-                print(f"Pointing table row {i} is for obs {obs_num}")
-                print(f" Coords from APT pointing file: {ra_deg} {dec_deg} deg")
+                self.logger.info(f"Pointing table row {i} is for obs {obs_num}")
+                self.logger.info(f" Coords from APT pointing file: {ra_deg} {dec_deg} deg")
             break
     else:
         raise RuntimeError(f"Could not find any info for an observation number {obs_num} in the pointing table.")

--- a/tests/test_niriss_imaging_modes.py
+++ b/tests/test_niriss_imaging_modes.py
@@ -46,7 +46,11 @@ def test_niriss_imaging():
     value1 = numpy.loadtxt('V88888024002P000000000112o_NIS_F480M_uncal_pointsources.list',usecols=[8,])
     value2 = numpy.loadtxt('V88888024002P000000000112o_NIS_NRM_F480M_uncal_pointsources.list',usecols=[8,])
     fluxratio = value2 / value1
-    targetratio = 0.15 / 0.84
+
+    # The 0.15 factor for the NRM and the 0.84 factor from the CLEARP element
+    # are now baked into the PSF from WebbPSF.
+    #targetratio = 0.15 / 0.84
+    targetratio = 1.0
     deviation = abs(fluxratio/targetratio - 1.)
     assert deviation < 1.e-06
     # clean up the output files in the test directory from this test.


### PR DESCRIPTION
This PR adds logging to Mirage. Logging is configured using a yaml configuration file, which should make it easy for users to customize logging details if desired without needing to change any code.

Currently logging is working for imaging_simulator, catalog_seed_image, dark_prep, obs_generator, and utils. Other modules are yet to be done. In the case of the user calling imaging_simulator, the log will contain entires from all three steps, rather than producing one log file for each step.