### PR TITLE
Remove the check/adjustment to the max number of groups.

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -141,27 +141,6 @@ class DarkPrep():
         except ValueError:
             self.logger.error("WARNING: Input value of nint is not an integer.")
 
-        # Make sure that the requested number of groups is
-        # less than or equal to the maximum allowed. If you're
-        # continuing on with an unknown readout pattern (not
-        # recommended) then assume a max of 10 groups.
-        # For science operations, ngroup is going to be limited
-        # to 10 for all readout patterns except for the DEEP
-        # patterns, which can go to 20. (FOR FULL FRAME!!)
-        # Subarray exposures can use more!!
-        match = self.readpatterns['name'] == self.params['Readout']['readpatt'].upper()
-        if sum(match) == 1:
-            maxgroups = self.readpatterns['maxgroups'].data[match][0]
-        if sum(match) == 0:
-            logger.error(("Unrecognized readout pattern {}. Assuming a maximum allowed number of groups of 10."
-                   .format(self.params['Readout']['readpatt'])))
-            maxgroups = 10
-
-        if (self.params['Readout']['ngroup'] > maxgroups):
-            logger.error(("WARNING: {} is limited to a maximum of {} groups. Proceeding with ngroup = {}."
-                   .format(self.params['Readout']['readpatt'], maxgroups, maxgroups)))
-            self.params['Readout']['ngroup'] = maxgroups
-
         # Check for entries in the parameter file that are None or blank,
         # indicating the step should be skipped. Create a dictionary of steps
         # and populate with True or False

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -741,25 +741,6 @@ class Observation():
             self.params['Readout']['filter'] = 'NA'
             self.params['Readout']['pupil'] = 'NA'
 
-        # Make sure that the requested number of groups is less than or
-        # equal to the maximum allowed.
-        # For full frame science operations, ngroup is going to be limited
-        # to 10 for all readout patterns
-        # except for the DEEP patterns, which can go to 20.
-        match = self.readpatterns['name'] == self.params['Readout']['readpatt'].upper()
-        if sum(match) == 1:
-            if 'FULL' in self.params['Readout']['array_name']:
-                maxgroups = self.readpatterns['maxgroups'].data[match][0]
-            else:
-                # I'm not sure what the limit is for subarrays, if any
-                maxgroups = 999
-
-        if (self.params['Readout']['ngroup'] > maxgroups):
-            self.logger.warning(("WARNING: {} is limited to a maximum of {} groups. "
-                                 "Proceeding with ngroup = {}."
-                                 .format(self.params['Readout']['readpatt'], maxgroups, maxgroups)))
-            self.params['Readout']['readpatt'] = maxgroups
-
         # Check for entries in the parameter file that are None or blank,
         # indicating the step should be skipped. Create a dictionary of steps
         # and populate with True or False

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -4235,22 +4235,6 @@ class Catalog_seed():
         # readout pattern definition file
         self.read_pattern_check()
 
-        # Make sure that the requested number of groups is
-        # less than or equal to the maximum allowed.
-        # For full frame science operations, ngroup is going
-        # to be limited to 10 for all readout patterns
-        # except for the DEEP patterns, which can go to 20.
-        # match = self.readpatterns['name'] == self.params['Readout']['readpatt'].upper()
-        # if sum(match) == 1:
-        #    maxgroups = self.readpatterns['maxgroups'].data[match][0]
-        # if sum(match) == 0:
-        #    print("Unrecognized readout pattern {}. Assuming a maximum allowed number of groups of 10.".format(self.params['Readout']['readpatt']))
-        #    maxgroups = 10
-
-        # if (self.params['Readout']['ngroup'] > maxgroups):
-        #    print("WARNING: {} is limited to a maximum of {} groups. Proceeding with ngroup = {}.".format(self.params['Readout']['readpatt'], maxgroups, maxgroups))
-        #    self.params['Readout']['readpatt'] = maxgroups
-
         # Check for entries in the parameter file that are None or blank,
         # indicating the step should be skipped. Create a dictionary of steps
         # and populate with True or False


### PR DESCRIPTION
This PR removes the check on the number of groups in the input yaml file. Previously if the requested number of groups was higher than the given limit (which came from APT), then Mirage would lower the number of groups in the simulation to match the maximum allowed. This logic was removed from `catalog_seed_generator.py` a while ago, but remained in `dark_prep.py` and `obs_generator.py`. Since Mirage inputs mostly come from APT anyway, I don't think Mirage needs to enforce a maximum groups rule. This is something better left to APT itself, with its complex rules based on data volumes and data rates.

Resolves #566 