### PR TITLE
Fix logging typo for segmented darks

### DIFF
--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -754,7 +754,7 @@ class DarkPrep():
         # will have 400 frames open. This is also an unlikely situation, but it could
         # be a problem.
         if len(integration_segment_indexes[:-1]) > 1:
-            self.logging.info(('An estimate of processing time remaining will be provided after the first segment '
+            self.logger.info(('An estimate of processing time remaining will be provided after the first segment '
                                'has been completed.\n\n'))
 
         self.dark_files = []


### PR DESCRIPTION
This PR fixes a small typo in the call to the logger in cases where the dark current object is split into segments.

self.logging -> self.logger