### PR TITLE
Obs creation from segmented images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,14 @@ mirage/catalogs/*.list
 *.csv
 *.txt~
 
+# Log files #
+#############
+tests/mirage_logs/*
+tests/test_data/*/mirage_logs/*
+tests/test_data/*/*/mirage_logs/*
+
 # exceptions
 !tests/test_data/*/*.yaml
-!tests/test_data/*/mirage_logs/
-!tests/test_data/*/*/mirage_logs/
 
 # Other #
 #########

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ mirage/catalogs/*.list
 
 # exceptions
 !tests/test_data/*/*.yaml
+!tests/test_data/*/mirage_logs/
+!tests/test_data/*/*/mirage_logs/
 
 # Other #
 #########

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -3295,9 +3295,6 @@ class Observation():
                     mapping[dark_element] = self.seed
             else:
                 mapping = self.map_seeds_to_dark()
-            #else:
-            #    raise ValueError("Unsupported length of self.linDark ({}) and self.seed ({})."
-            #                     .format(len(self.linDark), len(self.seed)))
         elif isinstance(self.seed, np.ndarray):
             for dark_element in self.linDark:
                 mapping[dark_element] = self.seed

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -951,7 +951,8 @@ class Observation():
                 nints = header_data['SEGINT']
                 ngroups = header_data['SEGGROUP']
 
-                self.logger.info('Final seed image shape: ({}, {}, {}, {})'.format(nints, ngroups, ydim, xdim))
+                self.logger.info(('Final seed image shape before averaging/skipping frames to create groups: '
+                                  '({}, {}, {}, {})'.format(nints, ngroups, ydim, xdim)))
                 seed = np.zeros((nints, ngroups, ydim, xdim))
                 segmap = seg_data
 
@@ -3293,8 +3294,10 @@ class Observation():
                 for dark_element in self.linDark:
                     mapping[dark_element] = self.seed
             else:
-                raise ValueError("Unsupported length of self.linDark ({}) and self.seed ({})."
-                                 .format(len(self.linDark), len(self.seed)))
+                mapping = self.map_seeds_to_dark()
+            #else:
+            #    raise ValueError("Unsupported length of self.linDark ({}) and self.seed ({})."
+            #                     .format(len(self.linDark), len(self.seed)))
         elif isinstance(self.seed, np.ndarray):
             for dark_element in self.linDark:
                 mapping[dark_element] = self.seed

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -615,7 +615,7 @@ class Catalog_seed():
                         counter += 1
 
                         # Save the seed image segment to a file
-                        self.logger.debug('\n\n\ntotal_seed_segments_and_parts: ', self.total_seed_segments_and_parts)
+                        self.logger.debug('\n\n\nTotal_seed_segments_and_parts: {}'.format(self.total_seed_segments_and_parts))
                         seg_string = str(self.segment_number).zfill(3)
                         part_string = str(self.segment_part_number).zfill(3)
                         self.seed_file = '{}_{}_{}_seg{}_part{}_seed_image.fits'.format(self.basename, self.params['Readout']['filter'],


### PR DESCRIPTION
This PR fixes a bug where cases with multiple seed image files but a single dark file was failing. I made a small update to the mapping function in obs_generator for this. I found this error while running a case where the seed image was broken into 2 files (part1 and part2), while the dark image was not. This was primarily because the observation used a subarray and a SHALLOW readout pattern, and the 5x difference between the number of frames and the number of groups pushed the seed image over the file splitting threshold. With this fix, the general case where there is a different number of seed image files compared to dark files, the mapping should be done correctly.