### PR TITLE
Update to allow small-grid-dither

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -599,7 +599,7 @@ class ReadAPTXML():
                     number_of_subpixel_dithers = 3
                 elif "-WITH-NIRISS" in observation_dict['SubpixelDitherType']:
                     number_of_subpixel_dithers = np.int(observation_dict['SubpixelDitherType'][0])
-                elif observation_dict['SubpixelDitherType'] in ['STANDARD', 'IMAGING']:
+                elif observation_dict['SubpixelDitherType'] in ['STANDARD', 'IMAGING', 'SMALL-GRID-DITHER']:
                     number_of_subpixel_dithers = np.int(observation_dict['SubpixelPositions'])
             else:
                 # For parallel instrument we ignore any dither info and set values to 0


### PR DESCRIPTION
This PR adjusts read_apt_xml in order to allow the use of SMALL-GRID-DITHER in the APT file for NIRCam imaging mode.