### PR TITLE
Have APT reader handle string options for primary dither number

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -587,7 +587,6 @@ class ReadAPTXML():
                     test = np.int(number_of_primary_dithers)
                 except ValueError:
                     number_of_primary_dithers = observation_dict[dither_key_name][0]
-                    observation_dict[dither_key_name] = number_of_primary_dithers
 
             else:
                 self.logger.info('Primary dither element {} not found, use default primary dithers value (1).'.format(dither_key_name))

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -582,12 +582,12 @@ class ReadAPTXML():
                     # Handle the special case for 2PLUS
                     number_of_primary_dithers = 2
 
-                if observation_dict[dither_key_name] in ['2TIGHTGAPS']:
+                # Deal with cases like 2TIGHTGAPS, 8NIRSPEC, etc.
+                try:
+                    test = np.int(number_of_primary_dithers)
+                except ValueError:
                     number_of_primary_dithers = observation_dict[dither_key_name][0]
-
-                # Special case for 8NIRSPEC dither pattern
-                if number_of_primary_dithers == '8NIRSPEC':
-                    number_of_primary_dithers = '8'
+                    observation_dict[dither_key_name] = number_of_primary_dithers
 
             else:
                 self.logger.info('Primary dither element {} not found, use default primary dithers value (1).'.format(dither_key_name))

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2934,9 +2934,14 @@ class Observation():
         else:
             outModel.meta.visit.tsovisit = True
 
+        num_primary_dithers = self.params['Output']['total_primary_dither_positions']
+        if isinstance(self.params['Output']['total_primary_dither_positions'], str):
+            num_primary_dithers = np.int(self.params['Output']['total_primary_dither_positions'][0])
+
         outModel.meta.dither.primary_type = self.params['Output']['primary_dither_type'].upper()
         outModel.meta.dither.position_number = self.params['Output']['primary_dither_position']
-        outModel.meta.dither.total_points = self.params['Output']['total_primary_dither_positions']
+        outModel.meta.dither.total_points = num_primary_dithers
+        outModel.meta.dither.dither_points = str(self.params['Output']['total_primary_dither_positions'])
         outModel.meta.dither.pattern_size = 'DEFAULT'
         outModel.meta.dither.subpixel_type = self.params['Output']['subpix_dither_type']
         outModel.meta.dither.subpixel_number = self.params['Output']['subpix_dither_position']
@@ -3219,9 +3224,14 @@ class Observation():
         else:
             outModel[0].header['TSOVISIT'] = True
 
+        num_primary_dithers = self.params['Output']['total_primary_dither_positions']
+        if isinstance(self.params['Output']['total_primary_dither_positions'], str):
+            num_primary_dithers = np.int(self.params['Output']['total_primary_dither_positions'][0])
+
         outModel[0].header['PATTTYPE'] = self.params['Output']['primary_dither_type']
         outModel[0].header['PATT_NUM'] = self.params['Output']['primary_dither_position']
-        outModel[0].header['NUMDTHPT'] = self.params['Output']['total_primary_dither_positions']
+        outModel[0].header['NUMDTHPT'] = num_primary_dithers
+        outModel[0].header['NDITHPTS'] = str(self.params['Output']['total_primary_dither_positions'])
         outModel[0].header['PATTSIZE'] = 'DEFAULT'
         outModel[0].header['SUBPXTYP'] = self.params['Output']['subpix_dither_type']
         outModel[0].header['SUBPXNUM'] = self.params['Output']['subpix_dither_position']


### PR DESCRIPTION
In most cases for NIRCam, the `PrimaryDithers` field in an APT xml file lists the number of primary dithers for the observation. But in a few cases, `PrimaryDithers` can be a string (e.g. "2TIGHTGAPS", "8NIRSPEC"). read_apt_xml.py did have a very specific exception for these two example values, however there were two problems. 

This information needs to make it into 2 different fits keyword headers:

1) NUMDTHPT - is an integer and is the total number of primary dither positions
2) NDITHPTS - is a string, and contains the number OR NAME of primary dither positions

Previously, Mirage was placing the PrimaryDithers string (e.g. "2TIGHTGAPS") into the NUMDTHPT fits header keyword in the Mirage output files. Even though the pipeline does not use this information at all, it was causing the datamodel validation to fail since the datamodel expects an integer in that field.

Also, new options for PrimaryDithers have recently been added to APT (e.g. 3TIGHTGAPS, 4TIGHT, 5TIGHT, 6TIGHT). 

This PR tweaks how Mirage uses the PrimaryDither string. Now the full string is placed into NDITHPTS, and the integer associated with the string is extracted and placed into NUMDTHPT.

Resovles #569 