### PR TITLE
Add option for downloading a single dark for each detector

### DIFF
--- a/docs/reference_files.rst
+++ b/docs/reference_files.rst
@@ -14,13 +14,15 @@ After installing Mirage, these reference files can be downloaded using the *down
 
   from mirage.reference_files import downloader
   download_path = '/path/into/which/files/are/downlaoded/'
-  downloader.download_reffiles(download_path, instrument='all', dark_type='linearized', skip_darks=False, skip_cosmic_rays=False, skip_psfs=False, skip_grism=False)
+  downloader.download_reffiles(download_path, instrument='all', dark_type='linearized', skip_darks=False, single_dark=False, skip_cosmic_rays=False, skip_psfs=False, skip_grism=False)
 
 The ``instrument`` keyword controls which subset of reference files are downloaded. You can give it the name of a single instrument, a string containing a comma-separated list of instruments, or the string ``all``, which will download reference files for NIRCam, NIRISS, and FGS.
 
 The ``dark_type`` keyword controls which dark current exposures are downloaded. *Mirage* requires linearized dark current exposures when creating simulated data. A user may provide raw dark current files, which *Mirage* will linearize on the fly, or linearized dark current files, which will save processing time. Set this keyword to ``linearized`` to download only the linearized versions of the darks, ``raw`` to download only the raw versions, or ``both`` for both. If omitted by the user, the script will default to downloading only the linearized darks. Note that the darks are by far the largest reference files in the collection (3GB per file, with 5 files per NIRCam detector, 20 files for NIRISS, and 8 files for FGS) and will take the most time to download.
 
 If True, the ``skip_dark`` parameter will cause the script not to download the dark current files for the given instrument. Similarly, the ``skip_cosmic_rays`` and ``skip_psfs`` parameters, if True, will cause the script to skip downloading the cosmic ray library and PSF library, respectively, for the indicated instruments. The default for all three of these parameters is False.
+
+If True, the ``single_dark`` parameter will cause the script to download only a single dark current file for each detector of the selected instruments. Downloading only a single dark rather than the full collection of darks will save significant time and disk space. This is intended as a quick-start of sorts, for those interested in testing Mirage. However, we recommend against creating a large amount of simulated data all based on only a single dark for each detector.
 
 When called, the function will download the appropriate files from the `STScI Box repository <https://stsci.app.box.com/folder/69205492331>`_, unzip the files, and create the directory structure Mirage expects. It will then remind you to point your MIRAGE_DATA environment variable to the top-level location of these files, so that Mirage knows where to find them. You
 may wish to add this definition to your .bashrc or .cshrc file.


### PR DESCRIPTION
This PR adds an option to the reference file downloader to download only a single dark current file per detector. This is intended for those who want a quick start of sorts, to test out Mirage, without downloading all of the reference files. This is done via the added `single_dark` keyword in the downloader script.

Resolves #562 