### PR TITLE
Update dependency install commands

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,9 +25,9 @@ These are: **jwst**, which is the JWST calibration pipeline software, and two pa
     conda activate mirage
     pip install healpy==1.12.5
     pip install mirage
-    pip install git+https://github.com/npirzkal/GRISMCONF#egg=grismconf
-    pip install git+https://github.com/npirzkal/NIRCAM_Gsim#egg=nircam_gsim
-    pip install git+https://github.com/spacetelescope/jwst@0.16.2
+    pip install grismconf
+    pip install nircam_gsim
+    pip install jwst
 
 .. tip::
     Some of Mirage's dependencies rely on `Healpy <https://healpy.readthedocs.io/en/latest/>`_,. Healpy has released different wheels for different versions of Mac OSX. For example, healpy version 1.12.5
@@ -58,9 +58,9 @@ Create and activate a new environment. In this example we call the environment "
     cd mirage
     pip install healpy==1.12.5
     pip install .
-    pip install git+https://github.com/npirzkal/GRISMCONF#egg=grismconf
-    pip install git+https://github.com/npirzkal/NIRCAM_Gsim#egg=nircam_gsim
-    pip install git+https://github.com/spacetelescope/jwst@0.16.2
+    pip install grismconf
+    pip install nircam_gsim
+    pip install jwst
 
 .. tip::
     Some of Mirage's dependencies rely on `Healpy <https://healpy.readthedocs.io/en/latest/>`_,. Healpy has released different wheels for different versions of Mac OSX. For example, healpy version 1.12.5


### PR DESCRIPTION
This PR brings up to date the installation commands for a few Mirage dependencies, now that they are available via Pypi.