### PR TITLE
WFSC: Enable SAM for full-pupil images

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2146,9 +2146,18 @@ class Catalog_seed():
         if self.runStep['pointsource'] is True:
             if not self.expand_catalog_for_segments:
 
+                # CHECK IN INPUT IF THERE'S A BORESIGHT OFFSET TO BE APPLIED:
+                offset_vector = None
+                infile = glob.glob(os.path.join(self.params['simSignals']['psfpath'], "{}_{}_{}*.fits".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower())))[0]
+                if infile:
+                    header = fits.getheader(infile)                    
+                    if ('BSOFF_V2' in header) and ('BSOFF_V3' in header):
+                        offset_vector = header['BSOFF_V2']*60., header['BSOFF_V3']*60. #convert to arcseconds
+                        
                 # Translate the point source list into an image
                 self.logger.info('Creating point source lists')
-                pslist = self.get_point_source_list(self.params['simSignals']['pointsource'])
+                pslist = self.get_point_source_list(self.params['simSignals']['pointsource'],
+                                                    segment_offset=offset_vector)
                 psfimage, ptsrc_segmap = self.make_point_source_image(pslist)
 
             elif self.expand_catalog_for_segments:

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2595,7 +2595,7 @@ class Catalog_seed():
         V2ref_arcsec = self.siaf.V2Ref
         V3ref_arcsec = self.siaf.V3Ref
         position_angle = self.params['Telescope']['rotation']
-        self.logger.info('    Position angle = ', position_angle)
+#        self.logger.info('    Position angle = ', position_angle)
         attitude_ref = pysiaf.utils.rotations.attitude(V2ref_arcsec, V3ref_arcsec, self.ra, self.dec, position_angle)
 
         # Shift every source by the appropriate offset

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2146,13 +2146,16 @@ class Catalog_seed():
         if self.runStep['pointsource'] is True:
             if not self.expand_catalog_for_segments:
 
-                # CHECK IN INPUT IF THERE'S A BORESIGHT OFFSET TO BE APPLIED:
+                # CHECK IN INPUT PSF FILE IF THERE'S A BORESIGHT OFFSET TO BE APPLIED:
                 offset_vector = None
-                infile = glob.glob(os.path.join(self.params['simSignals']['psfpath'], "{}_{}_{}*.fits".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower())))[0]
-                if infile:
-                    header = fits.getheader(infile)                    
+                infile = glob.glob(os.path.join(self.params['simSignals']['psfpath'], "{}_{}_{}*.fits".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower())))
+                if len(infile) > 0:
+                    header = fits.getheader(infile[0])                    
                     if ('BSOFF_V2' in header) and ('BSOFF_V3' in header):
                         offset_vector = header['BSOFF_V2']*60., header['BSOFF_V3']*60. #convert to arcseconds
+                else:
+                    print("No PSF library matching '{}_{}_{}.fits'; ignoring boresight offset (if any)".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower()))
+
                         
                 # Translate the point source list into an image
                 self.logger.info('Creating point source lists')
@@ -2595,7 +2598,7 @@ class Catalog_seed():
         V2ref_arcsec = self.siaf.V2Ref
         V3ref_arcsec = self.siaf.V3Ref
         position_angle = self.params['Telescope']['rotation']
-#        self.logger.info('    Position angle = ', position_angle)
+        self.logger.info(' Position angle = {}'.format(position_angle))
         attitude_ref = pysiaf.utils.rotations.attitude(V2ref_arcsec, V3ref_arcsec, self.ra, self.dec, position_angle)
 
         # Shift every source by the appropriate offset

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2154,7 +2154,7 @@ class Catalog_seed():
                     if ('BSOFF_V2' in header) and ('BSOFF_V3' in header):
                         offset_vector = header['BSOFF_V2']*60., header['BSOFF_V3']*60. #convert to arcseconds
                 else:
-                    print("No PSF library matching '{}_{}_{}.fits'; ignoring boresight offset (if any)".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower()))
+                    self.logger.info("No PSF library matching '{}_{}_{}.fits'; ignoring boresight offset (if any)".format(self.params['Inst']['instrument'].lower(), self.detector.lower(), self.psf_filter.lower()))
 
                         
                 # Translate the point source list into an image


### PR DESCRIPTION
This PR enables boresight offsets for full-pupil images, as opposed to single-segment images.  Similarly to the single-segment case, it relies on header keyword information to shift the all the sources.

This will support Coarse MIMF and Global Alignment activities, in particular.

I just want to point out that this change should not impact anything other than WFSC-related activities, BUT all MIRAGE simulations will be performing the checks for (1) the existence of the properly-named input image file and, if it exists, (2) the existence of the BSOFF_V2 and BSOFF_V3 header keywords.