### PR TITLE
Check catalog indexes in POM and AMI modes

### DIFF
--- a/mirage/catalogs/utils.py
+++ b/mirage/catalogs/utils.py
@@ -79,7 +79,7 @@ def determine_used_cats(obs_mode, cat_dict):
     cats : list
         List of catalogs that will be used for the given observing mode
     """
-    if obs_mode == 'imaging':
+    if obs_mode in ['imaging', 'pom', 'ami']:
         possible_cats = [cat_dict[entry] for entry in IMAGING_ALLOWED_CATALOGS]
     elif obs_mode == 'wfss':
         possible_cats = [cat_dict[entry] for entry in WFSS_ALLOWED_CATALOGS]


### PR DESCRIPTION
This PR adds "pom" and "ami" modes to the list of options when checking catalog index values. These modes were left out in #582 
