### PR TITLE
Minor fix to add the SubpixelDitherType element for WFSC dithers

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -569,7 +569,7 @@ class ReadAPTXML():
                 value = field.text
                 observation_dict[key] = value
 
-             if observation_dict["PrimaryDitherType"] == "WFSC":
+            if observation_dict["PrimaryDitherType"] == "WFSC":
                 observation_dict["SubpixelDitherType"] = "WFSC"
                 
             # Determine if there is an aperture override

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -569,8 +569,9 @@ class ReadAPTXML():
                 value = field.text
                 observation_dict[key] = value
 
-            if observation_dict["PrimaryDitherType"] == "WFSC":
-                observation_dict["SubpixelDitherType"] = "WFSC"
+            if "PrimaryDitherType" in observation_dict.keys():
+                if observation_dict["PrimaryDitherType"] == "WFSC":
+                    observation_dict["SubpixelDitherType"] = "WFSC"
                 
             # Determine if there is an aperture override
             override = obs.find('.//' + self.apt + 'FiducialPointOverride')

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -569,6 +569,9 @@ class ReadAPTXML():
                 value = field.text
                 observation_dict[key] = value
 
+             if observation_dict["PrimaryDitherType"] == "WFSC":
+                observation_dict["SubpixelDitherType"] = "WFSC"
+                
             # Determine if there is an aperture override
             override = obs.find('.//' + self.apt + 'FiducialPointOverride')
             FiducialPointOverride = True if override is not None else False


### PR DESCRIPTION
 It looks like APT 2020.5 does not export the "SubpixelDitherType" XML element anymore for the case of WFSC dithers, which is needed by MIRAGE.  This PR simply creates the needed element if the PrimaryDitherType is "WFSC".