### PR TITLE
Check for aperture overrides before calculating exp times

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -318,6 +318,9 @@ class AptInput:
         # Expand the dictionary to have one entry for each detector in each exposure
         self.exposure_tab = self.expand_for_detectors(observation_dictionary)
 
+        # For fiducial point overrides, save the pointing aperture and actual aperture separately
+        self.check_aperture_override()
+
         # Add start times for each exposure
         # Ignore warnings as astropy.time.Time will give a warning
         # related to unknown leap seconds if the date is too far in
@@ -346,8 +349,6 @@ class AptInput:
                     temp_table['exposure'][prime_index] = ['{:05d}'.format(n+1) for n in np.arange(len(prime_index))]
                     temp_table['exposure'][parallel_index] = ['{:05d}'.format(n+1) for n in np.arange(len(parallel_index))]
         self.exposure_tab['exposure'] = list(temp_table['exposure'])
-
-        self.check_aperture_override()
 
         if verbose:
             for key in self.exposure_tab.keys():


### PR DESCRIPTION
This PR fixes a small bug dealing with fiducial point overrides in the case where we have an FGS observation with an override to a NIRCam aperture. In this case, the 'aperture' entry in the obs_dict dictionary was set to the NIRCam aperture used as the fiducial point, rather than the aperture of the actual observation. This was causing problems when Mirage was attempting to find the aperture name in the subarray definition file, because the NIRCam apertures are not in the file listing the FGS apertures. 

This PR moves the `check_override_aperture()` function up so that it is called before the subarray matching work above (which is in `make_start_time()`). This function puts the override NIRCam aperture into the 'pointing_aperture' entry of the observation dictionary, and puts the observation aperture (e.g. FGS1_FULL) in the 'aperture' entry.