### PR TITLE
Add link to NIRISS ghosts on JDox

### DIFF
--- a/docs/ghosts.rst
+++ b/docs/ghosts.rst
@@ -18,6 +18,9 @@ The addition of ghosts is not currently supported.
 NIRISS
 ++++++
 
+Optical ghosts in NIRISS have been observed and characterized in ground testing data. A detailed description of the ghosts is given in the `Ghosts section <https://jwst-docs.stsci.edu/near-infrared-imager-and-slitless-spectrograph/niriss-instrumentation/niriss-gr150-grisms#NIRISSGR150Grisms-Ghosts>`_ of the NIRISS GR150 Grisms Jdox page.
+
+
 Controlling the Addition of Ghosts
 ----------------------------------
 


### PR DESCRIPTION
This PR adds a link to the NIRISS ghost description on JDox to the Mirage documentation. 