### PR TITLE
Improve OTE segment PSF handling to use hexike keywords, if present

### DIFF
--- a/mirage/psf/segment_psfs.py
+++ b/mirage/psf/segment_psfs.py
@@ -444,6 +444,18 @@ def get_segment_offset(segment_number, detector, library_list):
     x_arcsec += x_boresight_offset
     y_arcsec += y_boresight_offset
 
+    # Optionally, for more recent versions of webbpsf, the FITS header may simply contain the
+    # Hexike tilt coefficient that we want to use. If so, use that instead of all of the above!
+    # This method is superior, because it more correctly (and more simply) book-keeps the cross terms
+    # between different OTE pose terms into optical tip and tilt. In particular, this is needed for
+    # accurate modeling of radial translation corrections when using incoherent PSF calculations.
+    if f'S{segment_number:02d}XTILT' in header:
+        hexike_to_arcsec = 206265/webbpsf.constants.JWST_SEGMENT_RADIUS
+        # recall that Hexike tilt _around the X axis_ produces an offset _into Y_, and vice versa.
+        x_arcsec =  header[f'S{segment_number:02d}YTILT'] * hexike_to_arcsec
+        # also recall coord flip of Y axis from OTE L.O.M in entrance pupil to exit pupil
+        y_arcsec = -header[f'S{segment_number:02d}XTILT'] * hexike_to_arcsec
+
     # Optionally, arbitrary boresight offset may also be present in the FITS header metadata.
     # If so, include that in the PSF too. Be careful about coordinate sign for the V2 axis!
     try:


### PR DESCRIPTION
Debugging another complexity in WFSC segment PSF calculations; this is a fix for an issue encountered during the OTE team's WFTP10 practice. 

In short, this provides an alternate way of calculating the position of segment PSFs, making use of a set of optional FITS keywords that record the piston, tip, tilt hexike values directly from within the WebbPSF calculation. This is both simpler and more comprehensive than trying to reconstruct these term-by-term within MIRAGE. This makes use of a feature recently added in Webbpsf to make these keywords, and even more recently to propagate those into the FITS header for segment PSF grid files. ("even more recently" = I need to go make the PR for that, right after this...). 

I implemented this in such a way that it's back-compatible for MIRAGE: if the new header keywords are present, they override the calculation inside MIRAGE; otherwise no change. Eventually we can just use this and remove 90+% of the `get_segment_psfs` function, but for now I didn't want to do that lest I break something else. 

More explanation and optical details about how/why this works are available upon request; the bottom line is this fix is needed to avoid egregiously bad artifacts in FGS sims during GA-02. 