### PR TITLE
Add function for reading AMI template from APT file

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -818,7 +818,8 @@ class AptInput:
                                                          or 'FGS' in elements[4]
                                                          or 'NRS' in elements[4]
                                                          or 'MIR' in elements[4])
-                            ) or (('TA' in elements[4]) & ('NRC' in elements[4])):
+                            ) or (('TA' in elements[4]) & ('NRC' in elements[4]
+                                                           or 'NIS' in elements[4])):
                             if (elements[18] == 'PARALLEL') and ('MIRI' in elements[4]):
                                 skip = True
 
@@ -837,7 +838,7 @@ class AptInput:
                             # groups. For now just keep everything in a single visit group.
                             vgrp = '01'
                             visit_grp.append(vgrp)
-                            # Parallel sequence id hard coded to 1 (Simulated instrument as prime rather than
+                            # Parallel sequence is hard coded to 1 (Simulated instrument as prime rather than
                             # parallel) at the moment. Future improvements may allow the proper sequence
                             # number to be constructed.
                             seq = '1'

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1908,8 +1908,20 @@ class SimInput:
             # set the FilterWheel and PupilWheel for NIRISS
             if input['APTTemplate'] in ['NirissAmi']:
                 filter_name = input['Filter']
-                input[filtkey] = filter_name
-                input[pupilkey] = 'NRM'
+
+                # TA and direct images will be set to imaging mode
+                # rather than ami mode
+                if input['Mode'].lower() == 'imaging':
+                    if filter_name in NIRISS_PUPIL_WHEEL_ELEMENTS:
+                        input[pupilkey] = filter_name
+                        input[filtkey] = 'CLEAR'
+                    elif filter_name in NIRISS_FILTER_WHEEL_ELEMENTS:
+                        input[pupilkey] = 'CLEARP'
+                        input[filtkey] = filter_name
+                else:
+                    input[filtkey] = filter_name
+                    input[pupilkey] = 'NRM'
+
             elif input['APTTemplate'] not in ['NirissExternalCalibration', 'NirissWfss']:
                 filter_name = input['Filter']
                 if filter_name in NIRISS_PUPIL_WHEEL_ELEMENTS:


### PR DESCRIPTION
This PR creates a new function for reading in NIRISS AMI observations from APT files. Previously AMI observations were read in using the `read_generic_imaging()` function. However, with the addition of optional TA and direct images within the AMI template, it was easier to create a new function that handles only AMI observations.

Note that when TA observations are present, Mirage assumes 4 TA exposures. This information is not in the xml file from APT, but is in the pointing file, and I've confirmed with the NIRISS team that this is expected. (All development was done using APT 2020.5). 