### PR TITLE
Skip rescaling for sources not in ascii catalog

### DIFF
--- a/mirage/catalogs/spectra_from_catalog.py
+++ b/mirage/catalogs/spectra_from_catalog.py
@@ -643,8 +643,9 @@ def rescale_normalized_spectra(spectra, catalog_info, magnitude_system, bandpass
             match = catalog_info['index'] == dataset
 
             if not any(match):
-                raise ValueError(('WARNING: No matching target in ascii catalog for normalized source '
-                                  'number {}. Unable to rescale.').format(dataset))
+                #raise ValueError(('WARNING: No matching target in ascii catalog for normalized source '
+                #                  'number {}. Unable to rescale.').format(dataset))
+                continue
             magnitude = catalog_info[mag_colname].data[match][0]
 
             # Create a synphot source spectrum


### PR DESCRIPTION
This PR updates the spectra rescaling that Mirage can do when creating WFSS or grism tso observations. Previously, Mirage would loop over source catalogs and for each source in the user-provided hdf5 file, it would look for a corresponding entry in the ascii catalog file. Any sources present in the hdf5 file but not the ascii catalog would raise an exception. However, this doesn't work in cases where the sources are spread amongst multiple ascii catalogs.

With this small update, Mirage will simply skip over rescaling for a source that is present in the hdf5 file but not the ascii catalog.