### PR TITLE
Update filter and mag_sys keywords

### DIFF
--- a/docs/catalog_creation.rst
+++ b/docs/catalog_creation.rst
@@ -19,7 +19,7 @@ The examples below create point source catalogs containing 10 sources. By supply
 
 Columns containing AB magnitudes in the NIRCam F200W and F212N filters, as well as the NIRISS F090W filter are added to the catalog using the `add_magnitude_column` method. Note that the instrument and filter names associated with the magnitude values must be supplied in these calls. The filter value can be a string containing the filter wheel and pupil wheel values to be used, separated by a "/" (e.g. "F444W/F405N", "F444W/CLEAR", "F150W/WLM8"). As a shorthand, in cases where the CLEAR element in the pupil wheel is used, you can provide only the filter wheel value in the string (e.g. "F444W", "F090W"). Similarly, for the "standard" narrow band filter combinations (defined here: XXXXXX), you can provide only the name of the narrow band filter, and Mirage will assume that you are using one of the standard cases (e.g. specifying "F405N" will have Mirage assume you mean F405N crossed with F444W). For non-standard filter crossing, use the "/" format above and specify both filters.
 
-The `mag_sys` keyword is optional and allows uses to specify the magnitude system. Allowed values are "abmag", "stmag", and "vegamag". The default is "abmag". **Note that all magnitude columns in a given catalog MUST be in the same magnitude system.**
+The `magnitude_system` keyword is optional and allows uses to specify the magnitude system. Allowed values are "abmag", "stmag", and "vegamag". The default is "abmag". **Note that all magnitude columns in a given catalog MUST be in the same magnitude system.**
 
 The `starting_index` keyword is also optional. The value of the keyword is the first value to be placed in the "index" column of the catalog. Index values will increment upwards from this starting value for each source. With this keyword, users creating multiple catalogs to be input into a single simulation can be sure that every source going into the simulation has a unique index number. See the :ref:`Source Index Numbers <source_index_numbers>` section for more details.
 
@@ -42,11 +42,11 @@ The `save` method will save the table in an ascii file in the appropriate format
     nis_f090w_mag = np.random.random(10) + 15.5
 
     ptsrc = catalog_generator.PointSourceCatalog(ra=ra_list, dec=dec_list, starting_index=1)
-    ptsrc.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter='F200W', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter='F212N', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nrc_f405n_mag, instrument='nircam', filter='F444W/F405N', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nrc_f150_wlp8_mag, intsrument='nircam', filter='F150W/WLP8', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter='F090W', mag_sys='abmag')
+    ptsrc.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter_name='F200W', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter_name='F212N', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nrc_f405n_mag, instrument='nircam', filter_name='F444W/F405N', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nrc_f150_wlp8_mag, intsrument='nircam', filter_name='F150W/WLP8', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter_name='F090W', magnitude_system='abmag')
     ptsrc.save('point_sources.cat')
     ptsrc.table()
 
@@ -56,9 +56,9 @@ The `save` method will save the table in an ascii file in the appropriate format
     y_list = np.random.random(10) * 2048
 
     ptsrc = catalog_generator.PointSourceCatalog(x=x_list, y=y_list, starting_index=1)
-    ptsrc.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter='F200W', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter='F212N', mag_sys='abmag')
-    ptsrc.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter='F090W', mag_sys='abmag')
+    ptsrc.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter_name='F200W', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter_name='F212N', magnitude_system='abmag')
+    ptsrc.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter_name='F090W', magnitude_system='abmag')
     ptsrc.save('point_sources_xy.cat')
 
 
@@ -85,9 +85,9 @@ The example below creates a galaxy catalog. The main difference compared to the 
     gal = catalog_generator.GalaxyCatalog(ra=ra_list, dec=dec_list, ellipticity=ellipticity,
                                           sersic_index=sersic_index, position_angle=position_angle,
                                           starting_index=11)
-    gal.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter='F200W', mag_sys='abmag')
-    gal.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter='F212N', mag_sys='abmag')
-    gal.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter='F090W', mag_sys='abmag')
+    gal.add_magnitude_column(nrc_f200w_mag, instrument='nircam', filter_name='F200W', magnitude_system='abmag')
+    gal.add_magnitude_column(nrc_f212n_mag, instrument='nircam', filter_name='F212N', magnitude_system='abmag')
+    gal.add_magnitude_column(nis_f090w_mag, instrument='niriss', filter_name='F090W', magnitude_system='abmag')
     gal.save('galaxies.cat')
     gal.table()
 


### PR DESCRIPTION
This PR updates the documentation on source catalog creation to use the updated `filter_name` and `magnitude_system` keywords, rather than the deprecated `filter` and `mag_sys`.

Resolves #617 