### PR TITLE
Grism-related config file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ For any questions about the `mirage` project or its software or documentation, p
 
 ## Current Development Team
 - Bryan Hilbert [@bhilbert4](https://github.com/bhilbert4)
-- Johannes Sahlmann [@Johannes-Sahlmann](https://github.com/johannes-sahlmann)
-- Lauren Chambers [@laurenmarietta](https://github.com/laurenmarietta)
+- Nor Pirzkal [@NorPirzkal](https://github.com/npirzkal)
 - Kevin Volk [@KevinVolkSTScI](https://github.com/KevinVolkSTScI)
 - Shannon Osborne [@shanosborne](https://github.com/shanosborne)
 - Marshall Perrin [@mperrin](https://github.com/mperrin)

--- a/docs/reference_files.rst
+++ b/docs/reference_files.rst
@@ -36,7 +36,7 @@ For example:
 Download Grism-related Reference Data
 -------------------------------------
 
-In order to create dispersed images, using WFSS or grism TSO modes, a set of reference files describing the performance of the grisms are necessary. These files include sensitivity curves and dispersion information. These files are currently stored on GitHub in two repositories: one for `NIRCam <https://github.com/npirzkal/GRISM_NIRCAM>`_ and one for `NIRISS <https://github.com/npirzkal/GRISM_NIRISS>`_. To retrieve these files, clone the repositories from GitHub, and then move the files into the appropriate directory within the reference file directory structure. For NIRCam, copy the files in the "V2" folder of the github repository into $MIRAGE_DATA/nircam/GRISM_NIRCAM/current/. For NIRISS, copy the files into the $MIRAGE_DATA/niriss/GRISM_NIRISS/current directory.
+In order to create dispersed images, using WFSS or grism TSO modes, a set of reference files describing the performance of the grisms are necessary. These files include sensitivity curves and dispersion information. These files are currently stored on GitHub in two repositories: one for `NIRCam <https://github.com/npirzkal/GRISM_NIRCAM>`_ and one for `NIRISS <https://github.com/npirzkal/GRISM_NIRISS>`_. To retrieve these files, clone the repositories from GitHub, and then move the files into the appropriate directory within the reference file directory structure. For NIRCam, copy the files from the folder with the latest version number (e.g. "V2") into $MIRAGE_DATA/nircam/GRISM_NIRCAM/current/. For NIRISS, copy the files into the $MIRAGE_DATA/niriss/GRISM_NIRISS/current directory.
 
 
 CRDS Environment Variables

--- a/docs/reference_files.rst
+++ b/docs/reference_files.rst
@@ -36,7 +36,7 @@ For example:
 Download Grism-related Reference Data
 -------------------------------------
 
-In order to create dispersed images, using WFSS or grism TSO modes, a set of reference files describing the performance of the grisms are necessary. These files include sensitivity curves and dispersion information. These files are currently stored on GitHub in two repositories: one for `NIRCam <https://github.com/npirzkal/GRISM_NIRCAM>`_ and one for `NIRISS <https://github.com/npirzkal/GRISM_NIRISS>`_. To retrieve these files, clone the repositories from GitHub, and then move the files into the appropriate directory within the reference file directory structure. For NIRCam, copy the files in the "V2" folder of the github repository into $MIRAGE_DATA/nircam/GRISM_NIRCAM/. For NIRISS, copy the files into the $MIRAGE_DATA/niriss/GRISM_NIRISS/ directory.
+In order to create dispersed images, using WFSS or grism TSO modes, a set of reference files describing the performance of the grisms are necessary. These files include sensitivity curves and dispersion information. These files are currently stored on GitHub in two repositories: one for `NIRCam <https://github.com/npirzkal/GRISM_NIRCAM>`_ and one for `NIRISS <https://github.com/npirzkal/GRISM_NIRISS>`_. To retrieve these files, clone the repositories from GitHub, and then move the files into the appropriate directory within the reference file directory structure. For NIRCam, copy the files in the "V2" folder of the github repository into $MIRAGE_DATA/nircam/GRISM_NIRCAM/current/. For NIRISS, copy the files into the $MIRAGE_DATA/niriss/GRISM_NIRISS/current directory.
 
 
 CRDS Environment Variables

--- a/docs/wfss_simulations.rst
+++ b/docs/wfss_simulations.rst
@@ -72,5 +72,8 @@ Similar to the case for imaging mode simulations, if you have dark current produ
     c = WFSSSim(yfile, override_dark=darks)
     c.create()
 
+Backgrounds in WFSS simulations
++++++++++++++++++++++++++++++++
 
+Dispersed background signals in WFSS exposures are created from pre-computed background images. First, Mirage will take the user-input date or low/medium/high values, and calculate a 1D background spectrum. (Mirage uses the observation date to determine the background only if the :ref:`use_dateobs_for_background <example_yaml>` parameter in the input yaml file is set to True). This 1D background spectrum is then transformed into a 2D dispersed background image using the **disperse_background_1d** function in `NIRCAM_Gsim <https://github.com/npirzkal/NIRCAM_Gsim/blob/master/NIRCAM_Gsim/observations/observations.py#L333>`_ . The 2D background image that will actually be used is then read in from the appropriate pre-computed file, and scaled by the maximum value in the 2D background image that was created from the 1D spectrum.
 

--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -858,6 +858,30 @@ class GrismTSO():
         # Only finalize and/or add the background if requested.
         if finalize:
             if add_background:
+                # Get the configuration file name so that we can then find the
+                # correct 2d dispersed background filename
+                configuration_file = find_wfss_config_filename(loc, self.instrument, self.crossing_filter, dmode)
+                c = grismconf.Config(configuration_file)
+                background_file = c.BCK
+
+                if background_file is not None:
+
+                    # If Back keyword is not given, then the disperser will go find
+                    # the appropriate background file, read it in, and scale it by
+                    # scaling_factor
+                    disp_seed.finalize(BackLevel=scaling_factor, tofits=self.background_image_filename)
+                else:
+                    raise ValueError(("The background file listed in {} is None. This indicates that you "
+                                      "are using an old version of the GRISM_{} files. Please download the "
+                                      "current version of the files and place them in the appropirate directory. "
+                                      "See https://mirage-data-simulator.readthedocs.io/en/latest/reference_files.html"
+                                      "#download-grism-related-reference-data for details.".format(configuration_file,
+                                                                                                       self.instrument.upper())))
+
+
+
+
+
                 background_image = disp_seed.disperse_background_1D([background_waves, background_fluxes])
                 disp_seed.finalize(Back=background_image, BackLevel=None)
             else:

--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -230,7 +230,7 @@ class GrismTSO():
                                                                     output_filename=self.final_SED_file,
                                                                     normalizing_mag_column=self.SED_normalizing_catalog_column)
 
-        bkgd_waves, bkgd_fluxes = backgrounds.nircam_background_spectrum(orig_parameters,
+        bkgd_waves, bkgd_fluxes = backgrounds.get_1d_background_spectrum(orig_parameters,
                                                                          self.detector, self.module)
 
         # Run the catalog_seed_generator on the non-TSO (background) sources. Even if
@@ -858,32 +858,9 @@ class GrismTSO():
         # Only finalize and/or add the background if requested.
         if finalize:
             if add_background:
-                # Get the configuration file name so that we can then find the
-                # correct 2d dispersed background filename
-                configuration_file = find_wfss_config_filename(loc, self.instrument, self.crossing_filter, dmode)
-                c = grismconf.Config(configuration_file)
-                background_file = c.BCK
-
-                if background_file is not None:
-
-                    # If Back keyword is not given, then the disperser will go find
-                    # the appropriate background file, read it in, and scale it by
-                    # scaling_factor
-                    disp_seed.finalize(BackLevel=scaling_factor, tofits=self.background_image_filename)
-                else:
-                    raise ValueError(("The background file listed in {} is None. This indicates that you "
-                                      "are using an old version of the GRISM_{} files. Please download the "
-                                      "current version of the files and place them in the appropirate directory. "
-                                      "See https://mirage-data-simulator.readthedocs.io/en/latest/reference_files.html"
-                                      "#download-grism-related-reference-data for details.".format(configuration_file,
-                                                                                                       self.instrument.upper())))
-
-
-
-
-
                 background_image = disp_seed.disperse_background_1D([background_waves, background_fluxes])
-                disp_seed.finalize(Back=background_image, BackLevel=None)
+                scaling_factor = np.max(background_image)
+                disp_seed.finalize(BackLevel=scaling_factor, tofits=self.background_image_filename)
             else:
                 disp_seed.finalize(Back=None, BackLevel=None)
         return disp_seed

--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -827,8 +827,13 @@ class GrismTSO():
             2D array containing the dispersed seed image
         """
         # Location of the configuration files needed for dispersion
-        loc = os.path.join(self.datadir, "{}/GRISM_{}/".format(self.instrument,
-                                                               self.instrument.upper()))
+        loc = os.path.join(self.datadir, "{}/GRISM_{}/current/".format(self.instrument,
+                                                                       self.instrument.upper()))
+        if not os.path.isdir(loc):
+            raise ValueError(("{} directory is not present. GRISM_NIRCAM and/or GRISM_NIRISS portion of Mirage reference "
+                              "file collection is out of date or not set up correctly. See "
+                              "https://mirage-data-simulator.readthedocs.io/en/latest/reference_files.html foe details.".format(loc)))
+        self.logger.info("Retrieving grism-related config files from: {}".format(loc))
 
         # Determine the name of the background file to use, as well as the
         # orders to disperse.

--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -858,9 +858,17 @@ class GrismTSO():
         # Only finalize and/or add the background if requested.
         if finalize:
             if add_background:
+                # Generate the name of a file to save the dispersed background into.
+                # We can put this here because this function is called with add_background=True
+                # only once in the grism_tso_simulator
+                bkgd_output_file = '{}_background_image.fits'.format(params['Output']['file'].split('.fits')[0])
+                background_image_filename = os.path.join(params['Output']['directory'], bkgd_output_file)
+
+                # Create a 2D background image and find the maximum value. Then apply this
+                # as the scaling when using the pre-computed 2D background image
                 background_image = disp_seed.disperse_background_1D([background_waves, background_fluxes])
                 scaling_factor = np.max(background_image)
-                disp_seed.finalize(BackLevel=scaling_factor, tofits=self.background_image_filename)
+                disp_seed.finalize(BackLevel=scaling_factor, tofits=background_image_filename)
             else:
                 disp_seed.finalize(Back=None, BackLevel=None)
         return disp_seed

--- a/mirage/reference_files/utils.py
+++ b/mirage/reference_files/utils.py
@@ -38,10 +38,11 @@ def get_transmission_file(parameter_dict):
     transmission_filename : str
         Full path to the transmission file
     """
+    logger = logging.getLogger('mirage.reference_files.utils.get_transmission_file')
     datadir = os.environ.get('MIRAGE_DATA')
 
     if parameter_dict['INSTRUME'].lower() == 'nircam':
-        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRCAM/V2')
+        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRCAM/current')
 
         module = parameter_dict['DETECTOR'][3]
 
@@ -64,7 +65,7 @@ def get_transmission_file(parameter_dict):
 
     # For NIRISS we search for a detector/filter/pupil-dependent file
     elif parameter_dict['INSTRUME'].lower() == 'niriss':
-        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRISS/V2')
+        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRISS/current')
         filt = parameter_dict['FILTER'].upper()
         if filt not in ['GR150R', 'GR150C']:
             transmission_filename = None
@@ -75,4 +76,5 @@ def get_transmission_file(parameter_dict):
     elif parameter_dict['INSTRUME'].lower() == 'fgs':
         transmission_filename = None
 
+    logger.info('POM Transmission filename: {}'.format(transmission_filename))
     return transmission_filename

--- a/mirage/reference_files/utils.py
+++ b/mirage/reference_files/utils.py
@@ -19,7 +19,40 @@ Use
         reffiles = utils.get_transmission_file(params)
 """
 from glob import glob
+import logging
 import os
+
+import grismconf
+
+
+def find_wfss_config_filename(pathname, instrument, filtername, mode):
+    """Construct the name of the WFSS configuration file given instrument parameters
+
+    Parameters
+    ----------
+    pathname : str
+        Path where the configuration files are located
+
+    instrument : str
+        Instrument name (e.g. 'nircam')
+
+    filtername : str
+        Name of the crossing filter (e.g. 'f444w')
+
+    mode : str
+        String containing dispersion direction ('R' or 'C') as well as
+        module name (for NIRCam). e.g. for NIRCam - modA_R and
+        for NIRISS GR150R
+
+    Returns
+    -------
+    config : str
+        Full path and filename of the appropriate configuation file
+    """
+    config = os.path.join(pathname,"{}_{}_{}.conf".format(instrument.upper(),
+                                                          filtername.upper(),
+                                                          mode))
+    return config
 
 
 def get_transmission_file(parameter_dict):
@@ -42,35 +75,45 @@ def get_transmission_file(parameter_dict):
     datadir = os.environ.get('MIRAGE_DATA')
 
     if parameter_dict['INSTRUME'].lower() == 'nircam':
-        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRCAM/current')
-
-        module = parameter_dict['DETECTOR'][3]
-
-        # Assume that detector names in the transmission file names will
-        # use 'NRCA5' rather than 'NRCALONG'
-        #if 'LONG' in parameter_dict['DETECTOR']:
-        #    parameter_dict['DETECTOR'] = parameter_dict['DETECTOR'].replace('LONG', '5')
-
         if parameter_dict['DETECTOR'] not in ['NRCA5', 'NRCB5', 'NRCALONG', 'NRCBLONG']:
-            # For NIRCam SW, we use the same file for all detectors/filters/pupils
+            # For NIRCam SW, we don't use a transmission file
             transmission_filename = None
         elif parameter_dict['PUPIL'] not in ['GRISMR', 'GRISMC']:
-            # For LW imaging, we use the same file for all detectors/filters/pupils
+            # For LW imaging, also don't use a transmission file
             transmission_filename = None
         else:
-            if module == 'A':
-                transmission_filename = os.path.join(dirname, 'NIRCAM_LW_POM_ModA.fits')
-            elif module == 'B':
-                transmission_filename = os.path.join(dirname, 'NIRCAM_LW_POM_ModB.fits')
+            module = parameter_dict['DETECTOR'][3]
+            instrument = parameter_dict['INSTRUME'].lower()
+
+            # POM transmission file is not grism orientation dependent. The file is the
+            # same for GRISMR as GRISMC, so we can just use R here
+            dmode = 'mod{}_R'.format(module)
+            filt = parameter_dict['FILTER'].upper()
+
+            loc = os.path.join(datadir, "{}/GRISM_{}/current".format(instrument.lower(),
+                                                                     instrument.upper()))
+            configuration_file = find_wfss_config_filename(loc, 'nircam', filt, dmode)
+            c = grismconf.Config(configuration_file)
+            transmission_filename = c.POM
 
     # For NIRISS we search for a detector/filter/pupil-dependent file
     elif parameter_dict['INSTRUME'].lower() == 'niriss':
-        dirname = os.path.join(datadir, parameter_dict['INSTRUME'].lower(), 'GRISM_NIRISS/current')
-        filt = parameter_dict['FILTER'].upper()
-        if filt not in ['GR150R', 'GR150C']:
+        if parameter_dict['FILTER'] not in ['GR150R', 'GR150C']:
+            # Imaging mode - no transmission file necessary
             transmission_filename = None
         else:
-            transmission_filename = os.path.join(dirname, 'jwst_niriss_cv3_pomtransmission_{}_{}.fits'.format(filt, parameter_dict['PUPIL']))
+            # POM transmission file is not grism orientation dependent. The file is the
+            # same for GR150R as GR150C, so we can just use R here
+            instrument = parameter_dict['INSTRUME'].lower()
+            dmode = 'GR150R'
+            filt = parameter_dict['PUPIL'].upper()
+
+            loc = os.path.join(datadir, "{}/GRISM_{}/current".format(instrument.lower(),
+                                                                     instrument.upper()))
+
+            configuration_file = find_wfss_config_filename(loc, 'niriss', filt, dmode)
+            c = grismconf.Config(configuration_file)
+            transmission_filename = c.POM
 
     # For FGS we don't need to worry about a transmission file
     elif parameter_dict['INSTRUME'].lower() == 'fgs':

--- a/mirage/utils/backgrounds.py
+++ b/mirage/utils/backgrounds.py
@@ -321,7 +321,7 @@ def low_medium_high_background_value(ra, dec, background_level, filter_waves, fi
     return value
 
 
-def nircam_background_spectrum(parameters, detector, module):
+def get_1d_background_spectrum(parameters, detector, module):
     """Generate a background spectrum by calling jwst_backgrounds and
     returning wavelengths and flux density values based on observation
     date or low/medium/high

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -197,22 +197,8 @@ class WFSSSim():
         elif self.instrument == 'niriss':
             dmode = 'GR150{}'.format(self.dispersion_direction)
 
-        if self.params['simSignals']['use_dateobs_for_background']:
-            self.logger.info("Generating background spectrum for observation date: {}".format(self.params['Output']['date_obs']))
-            back_wave, back_sig = backgrounds.day_of_year_background_spectrum(self.params['Telescope']['ra'],
-                                                                              self.params['Telescope']['dec'],
-                                                                              self.params['Output']['date_obs'])
-        else:
-            if isinstance(self.params['simSignals']['bkgdrate'], str):
-                if self.params['simSignals']['bkgdrate'].lower() in ['low', 'medium', 'high']:
-                    self.logger.info("Generating background spectrum based on requested level of: {}".format(self.params['simSignals']['bkgdrate']))
-                    back_wave, back_sig = backgrounds.low_med_high_background_spectrum(self.params, self.detector,
-                                                                                       self.module)
-                else:
-                    raise ValueError("ERROR: Unrecognized background rate. Must be one of 'low', 'medium', 'high'")
-            else:
-                raise ValueError(("ERROR: WFSS background rates must be one of 'low', 'medium', 'high', "
-                                  "or use_dateobs_for_background must be True "))
+        # Find the 1d spectrum of the background, based on date or 'low', 'medium', 'high'
+        back_wave, back_sig = backgrounds.get_1d_backgound_spectrum(self.params, self.detector, self.module)
 
         # Default to extracting all orders
         orders = None

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -291,7 +291,7 @@ class WFSSSim():
                                           "current version of the files and place them in the appropirate directory. "
                                           "See https://mirage-data-simulator.readthedocs.io/en/latest/reference_files.html"
                                           "#download-grism-related-reference-data for details.".format(configuration_file,
-                                                                                                       self.instrument.upper()))
+                                                                                                       self.instrument.upper())))
 
                     background_done = True
 

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -184,8 +184,13 @@ class WFSSSim():
                                                                   module=self.module, detector=det_name)
 
         # Location of the configuration files needed for dispersion
-        loc = os.path.join(self.datadir, "{}/GRISM_{}/".format(self.instrument,
-                                                               self.instrument.upper()))
+        loc = os.path.join(self.datadir, "{}/GRISM_{}/current".format(self.instrument,
+                                                                 self.instrument.upper()))
+        if not os.path.isdir(loc):
+            raise ValueError(("{} directory is not present. GRISM_NIRCAM and/or GRISM_NIRISS portion of Mirage reference "
+                              "file collection is out of date or not set up correctly. See "
+                              "https://mirage-data-simulator.readthedocs.io/en/latest/reference_files.html foe details.".format(loc)))
+        self.logger.info("Retrieving WFSS config files from: {}".format(loc))
 
         # Determine the name of the background file to use, as well as the
         # orders to disperse.

--- a/mirage/wfss_simulator.py
+++ b/mirage/wfss_simulator.py
@@ -185,7 +185,7 @@ class WFSSSim():
 
         # Location of the configuration files needed for dispersion
         loc = os.path.join(self.datadir, "{}/GRISM_{}/current".format(self.instrument,
-                                                                 self.instrument.upper()))
+                                                                      self.instrument.upper()))
         if not os.path.isdir(loc):
             raise ValueError(("{} directory is not present. GRISM_NIRCAM and/or GRISM_NIRISS portion of Mirage reference "
                               "file collection is out of date or not set up correctly. See "


### PR DESCRIPTION
This PR updates the location where the grism-related config files are located. With this change, Mirage will look in:
$MIRAGE_DATA/<inst_name>/GRISM_<inst_name>/current/ for the files. Previously it was looking one directory higher, which was causing confusion since that directory may also have V1, V2, etc subdirectories. 

With this change, when new grism conf files are released, users must copy them into the 'current' subdirectory.