### PR TITLE
Increase file splitting limit

### DIFF
--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -97,7 +97,7 @@ TSO_MODES = ['ts_imaging', 'ts_grism']
 
 # Upper limit to the size of a seed image or dark current array. Arrays
 # containing more pixels than this limit will be split into segment files.
-FILE_SPLITTING_LIMIT = 38. * 2048. * 2048
+FILE_SPLITTING_LIMIT = 160. * 2048. * 2048
 
 CRDS_FILE_TYPES = {'badpixmask': 'mask',
                    'astrometric': 'distortion',


### PR DESCRIPTION
Resolves #630 

This PR increases the file splitting limit from 38 full frames to 160 full frames. This is after some discussion of how file splitting will be implemented by DMS. See the issue for details. With this new limit, file splitting will basically only happen in TSO observations.