### PR TITLE
Add FOCUSPOS keyword for FGS and NIS

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2835,7 +2835,7 @@ class Observation():
             outModel.meta.instrument.channel = channel
 
         if self.instrument.upper() in ['NIRISS', 'FGS']:
-            outModel.meta.instrument.focus_position = 'DEFAULT' #Placeholder, required by WSS; will be float in flight.
+            outModel.meta.instrument.focus_position = 0.0 #Placeholder, required by WSS; will be float in flight.
 
         outModel.meta.instrument.detector = self.detector
         outModel.meta.coordinates.reference_frame = 'ICRS'

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -3218,6 +3218,9 @@ class Observation():
             outModel[0].header['FWCPOS'] = self.filter_wheel_position
             outModel[0].header['PWCPOS'] = self.pupil_wheel_position
 
+        if self.instrument.upper() in ['NIRISS', 'FGS']:
+            outModel[0].header['FOCUSPOS'] = 'DEFAULT' #Placeholder, required by WSS; will be float in flight.
+
         # Specify whether the exposure is part of a TSO observation
         if self.params['Inst']['mode'].lower() not in ['ts_imaging', 'ts_grism']:
             outModel[0].header['TSOVISIT'] = False

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2834,6 +2834,9 @@ class Observation():
                 channel = 'LONG'
             outModel.meta.instrument.channel = channel
 
+        if self.instrument.upper() in ['NIRISS', 'FGS']:
+            outModel.meta.instrument.focus_position = 'DEFAULT' #Placeholder, required by WSS; will be float in flight.
+
         outModel.meta.instrument.detector = self.detector
         outModel.meta.coordinates.reference_frame = 'ICRS'
 


### PR DESCRIPTION
This header keyword is required for FGS and NIRISS by the WFSC team analysis software.  The "DEFAULT" value is just a placeholder, but in flight will be populated with a float indicating the position of the focus mechanism.