### PR TITLE
Switch build status badge to github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MIRaGe = Multi Instrument Ramp Generator
 
-[![Build Status](https://travis-ci.org/spacetelescope/mirage.svg?branch=master)](https://travis-ci.org/spacetelescope/mirage)
+[![Build Status](https://github.com/spacetelescope/mirage/workflows/CI/badge.svg)](https://github.com/spacetelescope/mirage/actions)
 [![License](https://img.shields.io/pypi/l/Django.svg)](https://github.com/spacetelescope/mirage/blob/master/LICENSE.txt)
 [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.python.org/)
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)


### PR DESCRIPTION
Quick fix to display the proper badge now that CI testing has moved to GitHub Actions