### PR TITLE
Read NIRISS Ext Cal template from APT xml file

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -2735,7 +2735,7 @@ class ReadAPTXML():
         # Determine what template is used for the parallel observation
         template = obs.find(self.apt + 'FirstCoordinatedTemplate')[0]
         template_name = etree.QName(template).localname
-        if template_name in ['NircamImaging', 'NircamEngineeringImaging', 'NirissExternalCalibration', 'NirissImaging',
+        if template_name in ['NircamImaging', 'NircamEngineeringImaging', 'NirissImaging',
                              'NirspecImaging', 'MiriMRS', 'FgsExternalCalibration']:
             parallel_exposures_dictionary = self.read_generic_imaging_template(template,
                                                                                template_name, obs,

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -3212,11 +3212,6 @@ class ReadAPTXML():
             if dither_pattern_type == 'WFSS':
                 dither_size = template.find(ns + 'DitherSize').text
 
-            # TEST - pointing file shows 1 dither for PARALLEL dither type
-            # even when I choose other numbers in APT??!!
-            if dither_pattern_type == 'PARALLEL':
-                primary_dithers = 1
-
         number_of_dithers = int(primary_dithers) * int(subpixel_positions)
 
         # Now that we have the correct number of dithers, we can


### PR DESCRIPTION
This PR updates read_apt_xml.py to improve support for the NIRISS External Calibration template. With this update, the reading of external calibration observations is pulled out of read_generic_imaging_template() and instead done with a new function read_niriss_external_calibration_template(). Moving to a custom function made sense because of the wide range of options in the external calibration template, including TA exposures, and several dither pattern types which use inconsistent keywords to capture dither information.

Resolves #644 