### PR TITLE
Look for correct WLP8 catalog colname in TSO notebook

### DIFF
--- a/examples/NIRCam_TSO_examples.ipynb
+++ b/examples/NIRCam_TSO_examples.ipynb
@@ -786,7 +786,7 @@
    "source": [
     "# Add source magnitudes\n",
     "tsimg_cat.add_magnitude_column([object_f182m_mag], magnitude_system='vegamag',\n",
-    "                               instrument='nircam', filter_name='f182m')\n",
+    "                               instrument='nircam', filter_name='f182m/wlp8')\n",
     "tsimg_cat.add_magnitude_column([object_f210m_mag], magnitude_system='vegamag',\n",
     "                               instrument='nircam', filter_name='f210m')\n",
     "tsimg_cat.add_magnitude_column([object_f470n_mag], magnitude_system='vegamag',\n",
@@ -877,7 +877,7 @@
    "source": [
     "# Add source magnitudes\n",
     "bkgd_cat.add_magnitude_column(bkgd_sources_f182m_mag, magnitude_system='vegamag',\n",
-    "                               instrument='nircam', filter_name='f182m')\n",
+    "                               instrument='nircam', filter_name='f182m/wlp8')\n",
     "bkgd_cat.add_magnitude_column(bkgd_sources_f444w_mag, magnitude_system='vegamag',\n",
     "                               instrument='nircam', filter_name='f444w')\n",
     "bkgd_cat.add_magnitude_column(bkgd_sources_f322w2_mag, magnitude_system='vegamag',\n",

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -3600,14 +3600,14 @@ class Catalog_seed():
                 elif actual_pupil_name in ['wlp8', 'wlm8']:
                     # Weak lenses were not supported with the old column
                     # name format, so if the new format column name is not
-                    # present, then we can only fall back to looking for
-                    # a generic 'magnitude' column.
-
-                    # The weak lenses do not have much effect on throughput, so
-                    # to first order, we can fall back to use a column for the
-                    # same filter but without the weak lenses
-                    specific_mag_col = "nircam_{}_magnitude".format(actual_filter_name)
-
+                    # present, then we raise an exception here. While WLP4
+                    # has a very small effect on throughput, WLP8 and WLM8
+                    # do, so falling back to looking for a <filter>+CLEAR
+                    # column seems like the wrong thing to do.
+                    raise ValueError(("WARNING: Catalog {} has no magnitude column for {} specifically called {}. "
+                                      "Unable to continue.".format(os.path.split(catalog_file_name)[1],
+                                                                   self.params['Inst']['instrument'],
+                                                                   specific_mag_col)))
         elif self.params['Inst']['instrument'].lower() == 'niriss':
             if self.params['Readout']['pupil'][0].upper() == 'F':
                 specific_mag_col = "{}_{}_magnitude".format('niriss', self.params['Readout']['pupil'].lower())


### PR DESCRIPTION
Resolves #635 

This PR makes some small changes to the case where a weak lens is used in a source catalog.

- In cases where a weak lens is used, if the corresponding catalog column name nircam\_\<filter>\_wlp8\_magnitude or nircam\_\<filter>\_wlm8\_magnitude is not present, then an exception is raised. Previously Mirage would fall back to look for nircam\_\<filter>\_magnitude, however the +/-8 weak lenses have a significant effect on throughput and should not be ignored. This was also leading to confusing errors in the case where nircam\_\<filter>\_clear\_magnitude was present, but was never searched for.
- A bug in the NIRCam TSO notebook was fixed, to create nircam\_f182m\_wlp8\_magnitude columns in the source catalogs, where previously the column names were nircam\_f182m\_clear\_magnitude