### PR TITLE
Add SOSS PSF files to downloader

### DIFF
--- a/mirage/reference_files/downloader.py
+++ b/mirage/reference_files/downloader.py
@@ -190,10 +190,12 @@ FGS_LINEARIZED_DARK_URLS = ['https://data.science.stsci.edu/redirect/JWST/jwst-s
 
 NIRISS_PSF_GHOST_STAMP = ['https://data.science.stsci.edu/redirect/JWST/jwst-simulations/mirage_reference_files/niriss/ghosts/niriss_ghost_stamps.tar.gz']
 
+NIRISS_SOSS_URLS = ['https://data.science.stsci.edu/redirect/JWST/jwst-simulations/mirage_reference_files/niriss/soss/niriss_soss_psfs.tar.gz']
+
 TEMP_DISTORTION_REFERENCE_FILES = ['https://data.science.stsci.edu/redirect/JWST/jwst-simulations/mirage_reference_files/nircam/reference_files/nircam_distortion_files.tar.gz']
 
 DISK_USAGE = {'nircam': {'crs': 1.1, 'psfs': 23, 'raw_darks': 79, 'lin_darks': 319},
-              'niriss': {'crs': 0.26, 'psfs': 0.87, 'raw_darks': 31, 'lin_darks': 121},
+              'niriss': {'crs': 0.26, 'psfs': 0.87, 'raw_darks': 31, 'lin_darks': 121, 'soss': 0.26},
               'fgs': {'crs': 0.31, 'psfs': .04, 'raw_darks': 11, 'lin_darks': 39}}
 
 def download_file(url, file_name, output_directory='./'):
@@ -229,7 +231,8 @@ def download_file(url, file_name, output_directory='./'):
 
 
 def download_reffiles(directory, instrument='all', dark_type='linearized',
-                      skip_darks=False, single_dark=False, skip_cosmic_rays=False, skip_psfs=False):
+                      skip_darks=False, single_dark=False, skip_cosmic_rays=False, skip_psfs=False,
+                      skip_soss=False):
     """Download tarred and gzipped reference files. Expand, unzip and
     organize into the necessary directory structure such that Mirage
     can use them.
@@ -275,6 +278,10 @@ def download_reffiles(directory, instrument='all', dark_type='linearized',
     skip_psfs : bool
         If False (default), download the requested PSF libraries.
         If True, do not download the libraries.
+
+    skip_soss : bool
+        If False (default), and NIRISS files are to be downloaded, then
+        include the NIRISS SOSS PSF files. If True, do not download the files.
     """
     # Expand env variables and tildes in direcotry, and make sure it is
     # an absolute path
@@ -285,7 +292,8 @@ def download_reffiles(directory, instrument='all', dark_type='linearized',
                               skip_darks=skip_darks,
                               single_dark=single_dark,
                               skip_cosmic_rays=skip_cosmic_rays,
-                              skip_psfs=skip_psfs)
+                              skip_psfs=skip_psfs,
+                              skip_soss=skip_soss)
 
     # Download everything first
     for file_url in file_list:
@@ -354,7 +362,7 @@ def download_reffiles(directory, instrument='all', dark_type='linearized',
 
 
 def get_file_list(instruments, dark_current, skip_darks=False, single_dark=False, skip_cosmic_rays=False,
-                  skip_psfs=False):
+                  skip_psfs=False, skip_soss=False):
     """Collect the list of URLs corresponding to the Mirage reference
     files to be downloaded
 
@@ -386,6 +394,10 @@ def get_file_list(instruments, dark_current, skip_darks=False, single_dark=False
     skip_psfs : bool
         If False (default), include the requested PSF libraries.
         If True, do not include the libraries.
+
+    skip_soss : bool
+        If False (default), include the NIRISS SOSS PSF files.
+        If True, do not download the files.
 
     Returns
     -------
@@ -486,6 +498,13 @@ def get_file_list(instruments, dark_current, skip_darks=False, single_dark=False
 
             # Ghost stamp image for PSF sources
             urls.extend(NIRISS_PSF_GHOST_STAMP)
+
+            # SOSS mode PSFs
+            if not skip_soss:
+                urls.extend(NIRISS_SOSS_URLS)
+                added_size = DISK_USAGE['niriss']['soss']
+                total_download_size += added_size
+                print('Size of NIRISS SOSS PSF file: {} Gb'.format(added_size))
 
         # FGS
         elif instrument_name.lower() == 'fgs':


### PR DESCRIPTION
This PR updates the reference file downloader module to include the SOSS mode PSF files. I've also added a `skip_soss` keyword so that those not creating SOSS simulations don't have to download the file.