### PR TITLE
Pass the segmentation threshold value through

### DIFF
--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -318,8 +318,12 @@ class SimInput:
 
         if segmap_flux_limit is None:
             self.segmentation_threshold = SEGMENTATION_MIN_SIGNAL_RATE
+        else:
+            self.segmentation_threshold = segmap_flux_limit
         if segmap_flux_limit_units is None:
             self.segmentation_threshold_units = 'ADU/sec'
+        else:
+            self.segmentation_threshold_units = segmap_flux_limit_units
 
         # Expand the MIRAGE_DATA environment variable
         self.datadir = expand_environment_variable(ENV_VAR, offline=self.offline)


### PR DESCRIPTION
Made sure the yaml_generator passes the segmentation_threshold through if a custom value for `segmap_flux_limit` or `segmap_flux_limit_units` are passed.
