### PR TITLE
Fixes broadcasting error in soss_simulator

### DIFF
--- a/mirage/soss_simulator.py
+++ b/mirage/soss_simulator.py
@@ -240,7 +240,7 @@ class SossSim():
         obs.segmap = self.segmap
         obs.seedheader = self.seedinfo
         obs.paramfile = self.paramfile
-        obs.create()
+        obs.create(params=self.params)
 
         # Save ramp to tso attribute
         self.tso = obs.raw_outramp


### PR DESCRIPTION
This line is essential to fix a broadcasting issue in `SossSim`.