### PR TITLE
Adjust PSF normalization limits by obs mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+2.0.1
+=====
+
+NIRISS AMI
+----------
+
+Updated the PSF normalization check to lower the expected total PSF signal in the gridded PSF library for cases where
+the NRM is in the beam, as well as imaging cases where CLEARP is used. (#662)
+
+
 2.0.0
 =====
 


### PR DESCRIPTION
This PR makes a small adjustment to #552. Normally, the PSFs  in the gridded PSF libraries are normalized such that the total signal of the PSF divided by the square of the oversampling factor is just under 1.0. But in the case of NIRISS NRM exposures, the throughput factor of 0.15 associated with the NRM mask is included in the webbpsf PSFs. Therefore the normalization is lower by a factor of 0.15. Similarly, for NIRISS imaging observations that use the CLEARP filter, the throughput factor of 0.84 is included in the webbpsf outputs. 

So here, we adjust the normalization check to lower the expected value by factors of 0.15 and 0.84 for these two cases.