### PR TITLE
Tweak PSF normalization limits for AMI and CLEARP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+2.0.2
+=====
+
+NIRISS AMI
+----------
+
+Updated the PSF normalization check threshold value to match the new value from an updated NRM mask calculation. Prior to this, Mirage was stopping AMI simulations because the normalization threshold was too low. (#664)
+
+
 2.0.1
 =====
 

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -126,7 +126,7 @@ NIRISS_GRISM_THROUGHPUT_FACTOR = 0.8
 # Factors by which total throughput is reduced and gridded PSF library
 # signal (output from WebbPSF) is reduced. Used in normalization_check()
 # in psf_selection.py when performing a sanity check on the input PSF signal
-NIRISS_NRM_PSF_THROUGHPUT_REDUCTION = 0.16
+NIRISS_NRM_PSF_THROUGHPUT_REDUCTION = 0.17
 NIRISS_CLEARP_PSF_THROUGHPUT_REDUCTION = 0.84
 
 # PSF normalization check - default min and max allowed values for the

--- a/mirage/utils/constants.py
+++ b/mirage/utils/constants.py
@@ -123,6 +123,19 @@ MEAN_GAIN_VALUES = {'nircam': {'swa': 2.443376, 'swb': 2.4908085, 'lwa': 2.19235
 # to when it is not in the beam
 NIRISS_GRISM_THROUGHPUT_FACTOR = 0.8
 
+# Factors by which total throughput is reduced and gridded PSF library
+# signal (output from WebbPSF) is reduced. Used in normalization_check()
+# in psf_selection.py when performing a sanity check on the input PSF signal
+NIRISS_NRM_PSF_THROUGHPUT_REDUCTION = 0.16
+NIRISS_CLEARP_PSF_THROUGHPUT_REDUCTION = 0.84
+
+# PSF normalization check - default min and max allowed values for the
+# total signal in the PSF divided by the square of the oversampling factor.
+# In most cases this value will be close to 1.0. In cases where NIRISS
+# NRM or CLEARP are used, these values will be reduced by the factors above.
+PSF_NORM_MAX = 1.0
+PSF_NORM_MIN = 0.8
+
 # Minimum signal rate for a pixel to be included in the segmentation map.
 SEGMENTATION_MIN_SIGNAL_RATE = 0.031  # ADU/sec
 SUPPORTED_SEGMENTATION_THRESHOLD_UNITS = ['adu/s', 'adu/sec', 'e/s', 'e/sec', 'mjy/str', 'mjy/sr', 'erg/cm2/a', 'erg/cm2/hz']


### PR DESCRIPTION
This PR updates the maximum value of the total signal in the gridded PSF library for NIRISS AMI observations. Recent updates to the NRM mask increased the total signal in the WebbPSF-created PSFs just above the previous threshold, resulting in Mirage stopping with an error that the libraries weren't normalized properly. This PR increases the maximum allowed value to account for the new NRM mask calculation.

It also pulls the custom thresholds for AMI and CLEARP observations out of catalog_seed_image.py and places them into the constants.py module, where they are a bit more obvious.