### PR TITLE
Fix timer error when sources are not on detector

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+Unreleased - in development version only
+========================================
+
+Timer
+-----
+
+Stop the timer before moving on to the next source in the source catalog when the current source is completely off the detector. Prior to this, sources that were outside the detector would sometimes raise a timer error when Mirage attempted to start the timer for the next source while that for the current source was still running. (#669)
+
+
+Logging
+-------
+
+Fix logging error so that in NIRISS simulations where ghosts are requested, if the filter used does not support the addition of ghosts, this fact is logged only once, rather than for each source. (#667)
+
+
 2.0.2
 =====
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2979,6 +2979,7 @@ class Catalog_seed():
 
             # Skip sources that fall completely off the detector
             if scaled_psf is None:
+                self.timer.stop()
                 continue
 
             scaled_psf *= entry['countrate_e/s']
@@ -3010,6 +3011,7 @@ class Catalog_seed():
 
             # Skip sources that fall completely off the detector
             if None in [i1, i2, j1, j2, k1, k2, l1, l2]:
+                self.timer.stop()
                 continue
 
             try:
@@ -4245,6 +4247,7 @@ class Catalog_seed():
 
             # Skip sources that fall completely off the detector
             if psf_image is None:
+                self.timer.stop()
                 continue
 
             # Normalize the signal in the PSF stamp so that the final galaxy

--- a/mirage/utils/timer.py
+++ b/mirage/utils/timer.py
@@ -6,6 +6,10 @@ Inspired by a tutorial on RealPython: https://realpython.com/python-timer/
 import time
 
 
+class TimerError(Exception):
+    """A custom exception used to report errors in use of Timer class"""
+
+
 class Timer:
     timers = dict()
 


### PR DESCRIPTION
Resolves #668 

This PR defines the TimerError class for when there are errors in running the timer to estimate how long a simulation will take. It also stops the timer when the catalog_seed_generator encounters a source that is completely off the detector. Previously in this case, Mirage would move to the next iteration of the loop over sources, but not stop the timer. This may have been causing problems when trying to start an already-running timer for the next source.

Strange though, I'm sure that in all the time since the timer was added that we have run simulations with sources that are not on the detector.

@KevinVolkSTScI do you want to test this branch? Or send me your yaml file and catalog so I can test it?