### PR TITLE
Enable use of IRAC mosaic as seed image

### DIFF
--- a/examples/Simulated_data_from_mosaic_image.ipynb
+++ b/examples/Simulated_data_from_mosaic_image.ipynb
@@ -63,6 +63,16 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "os.environ[\"CRDS_DATA\"] = \"/location/of/your/crds_cache\"\n",
+    "os.environ[\"CRDS_SERVER_URL\"] = \"https://jwst-crds.stsci.edu\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import yaml"
    ]
   },
@@ -863,7 +873,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/mirage/seed_image/crop_mosaic.py
+++ b/mirage/seed_image/crop_mosaic.py
@@ -155,9 +155,9 @@ class Extraction():
         if maxx > mosaic_shape[1]:
             maxx = mosaic_shape[1]
 
-        self.logger.info("Coords of center of cropped area", mosaic_center_x, mosaic_center_y)
-        self.logger.info("X-min, X-max coords: ", minx, maxx)
-        self.logger.info("Y-min, Y-max coords: ", miny, maxy)
+        self.logger.info("Coords of center of cropped area: {}, {}".format(mosaic_center_x, mosaic_center_y))
+        self.logger.info("X-min, X-max coords: {}, {}".format(minx, maxx))
+        self.logger.info("Y-min, Y-max coords: {}, {}".format(miny, maxy))
 
         crop = mosaic[self.data_extension_number].data[miny: maxy, minx: maxx]
 

--- a/mirage/seed_image/fits_seed_image.py
+++ b/mirage/seed_image/fits_seed_image.py
@@ -365,7 +365,7 @@ class ImgSeed:
             raise ValueError(("ERROR: FWHM of the mosaic image is larger than that of "
                               "the JWST PSF. Unable to create a matching PSF kernel "
                               "using photutils. \nMosaic FWHM: {}\nJWST FWHM: {}"
-                              .format(self.mosaic_fwhm, jwst_y_fwhm_arcsec)))
+                              .format(mosaic_fwhm_arcsec, jwst_y_fwhm_arcsec)))
 
         # The JWST PSF as read in is large (399 x 399 pixels). Crop to
         # something reasonable so that the convolution doesn't take
@@ -399,7 +399,11 @@ class ImgSeed:
         blot = blot_image.Blot(instrument=self.instrument, aperture=self.aperture,
                                ra=[self.blot_center_ra], dec=[self.blot_center_dec],
                                pav3=[self.blot_pav3], blotfile=crop.cropped,
-                               distortion_file=self.distortion_file)
+                               distortion_file=self.distortion_file,
+                               filtername=self.params['Readout']['filter'],
+                               pupilname=self.params['Readout']['pupil'],
+                               obs_date=self.params['Output']['date_obs'],
+                               obs_time=self.params['Output']['time_obs'])
         blot.blot()
 
         # Blot the PSF associated with the mosaic
@@ -686,10 +690,10 @@ class ImgSeed:
                     self.logger.info('Creating HST PSF, using 2D Gaussian')
                     self.logger.info('HST FWHM in arcsec: {}'.format(self.mosaic_fwhm * self.mosaic_metadata['pix_scale2']))
                     self.mosaic_psf = tools.get_HST_PSF(self.mosaic_metadata, self.mosaic_fwhm)
-                elif self.mosaic_psf_metadata['telescope'] == 'JWST':
+                elif self.mosaic_metadata['telescope'] == 'JWST':
                     self.logger.info("Retrieving JWST PSF")
                     self.mosaic_psf = tools.get_JWST_PSF(self.mosaic_metadata)
-                elif self.mosaic_psf_metadata['instrument'] == 'IRAC':
+                elif self.mosaic_metadata['instrument'] == 'IRAC':
                     self.logger.info("Retrieving IRAC PSF")
                     self.mosaic_psf = tools.get_IRAC_PSF(self.mosaic_metadata)
             else:

--- a/mirage/seed_image/save_seed.py
+++ b/mirage/seed_image/save_seed.py
@@ -72,10 +72,10 @@ def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength
     kw['PHOTPLAM'] = pivot_wavelength * 1.e4  # put into angstroms
     kw['NOMXDIM'] = nominal_dimensions[1]
     kw['NOMYDIM'] = nominal_dimensions[0]
-    kw['NOMXSTRT'] = np.int(coord_adjust['xoffset'] + 1)
-    kw['NOMXEND'] = np.int(nominal_dimensions[1] + coord_adjust['xoffset'])
-    kw['NOMYSTRT'] = np.int(coord_adjust['yoffset'] + 1)
-    kw['NOMYEND'] = np.int(nominal_dimensions[0] + coord_adjust['yoffset'])
+    kw['NOMXSTRT'] = int(coord_adjust['xoffset'] + 1)
+    kw['NOMXEND'] = int(nominal_dimensions[1] + coord_adjust['xoffset'])
+    kw['NOMYSTRT'] = int(coord_adjust['yoffset'] + 1)
+    kw['NOMYEND'] = int(nominal_dimensions[0] + coord_adjust['yoffset'])
 
     # Files/inputs used during seed image production
     kw['YAMLFILE'] = param_file
@@ -105,9 +105,9 @@ def save(seed_image, param_file, parameters, photflam, photfnu, pivot_wavelength
     if parameters['Inst']['mode'] in ['wfss', 'ts_wfss']:
         kw['NOMXDIM'] = fullframe_size
         kw['NOMYDIM'] = fullframe_size
-        kw['NOMXSTRT'] = np.int(fullframe_size * (grism_direct_factor - 1) / 2.)
+        kw['NOMXSTRT'] = int(fullframe_size * (grism_direct_factor - 1) / 2.)
         kw['NOMXEND'] = kw['NOMXSTRT'] + fullframe_size - 1
-        kw['NOMYSTRT'] = np.int(fullframe_size * (grism_direct_factor - 1) / 2.)
+        kw['NOMYSTRT'] = int(fullframe_size * (grism_direct_factor - 1) / 2.)
         kw['NOMYEND'] = kw['NOMYSTRT'] + fullframe_size - 1
 
     kw['GRISMPAD'] = grism_direct_factor


### PR DESCRIPTION
This PR makes some changes to the code that creates simulated data from an input mosaic image. Previously this mode had only been tested using an HST mosaic. Testing with an IRAC mosaic revealed some issues that needed to be fixed. 

This is still not a very well tested part of Mirage compared to catalog_seed_image.py.