### PR TITLE
Remove skipped_obs keyword value

### DIFF
--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -832,7 +832,7 @@ class SimInput:
                         (self.info['ShortPupil'][i]=='n/a' and self.info['detector'][i] in ['A1','A2','A3','A4'])):
                         print(f"Skipping {self.info['yamlfile'][i]} because this coronagraphy obs does not use that detector")
                         continue
-                              
+
                     # SW coronagraphy exposures that use MASKRND collect data from A2 only
                     if (self.info['ShortPupil'][i] == 'MASKRND' and self.info['detector'][i] != 'A2'):
                         print(f"Skipping yaml for {self.info['detector'][i]} with {self.info['ShortPupil'][i]}")
@@ -841,7 +841,7 @@ class SimInput:
                     # SW coronagraphy exposures that use MASKSWB collect data from A4 only
                     if (self.info['ShortPupil'][i] == 'MASKSWB' and self.info['detector'][i] != 'A4'):
                         print(f"Skipping yaml for {self.info['detector'][i]} with {self.info['ShortPupil'][i]}")
-                        continue          
+                        continue
 
             file_dict = {}
             for key in self.info:
@@ -2354,7 +2354,7 @@ def default_obs_v3pa_on_date(pointing_filename, obs_num, date=None, verbose=Fals
     """
 
     if pointing_table is None:
-        pointing_table = apt_inputs.AptInput().get_pointing_info(pointing_filename, 0, skipped_obs_from_xml=self.xml_skipped_observations)
+        pointing_table = apt_inputs.AptInput().get_pointing_info(pointing_filename, 0)
     for i in range(len(pointing_table['obs_num'])):
         if pointing_table['obs_num'][i] == f"{obs_num:03d}":
             ra_deg, dec_deg = pointing_table['ra'][i], pointing_table['dec'][i]
@@ -2389,7 +2389,7 @@ def all_obs_v3pa_on_date(pointing_filename, date=None, verbose=False):
 
     """
     results = {}
-    pointing_table = apt_inputs.AptInput().get_pointing_info(pointing_filename, 0, skipped_obs_from_xml=self.xml_skipped_observations)
+    pointing_table = apt_inputs.AptInput().get_pointing_info(pointing_filename, 0)
     obsnums = sorted(list(set(pointing_table['obs_num'])))
     for obs_num in obsnums:
         results[obs_num] = default_obs_v3pa_on_date(pointing_filename, int(obs_num), date=date, verbose=verbose,


### PR DESCRIPTION
Resolves #673 

This PR removes the skipped_obs_from_xml keyword value in the call to `get_pointing_info` within default_obs_v3pa_on_date() and all_obs_v3pa_on_date(). 

This will allow a user to request V3PA values for observations that Mirage is unable to simulate (e.g. observations with MIRI), but since these functions are not used within e.g. the imaging simulator, this should be fine.