### PR TITLE
Bump jinja2 to 2.11.3

### DIFF
--- a/environment_python_3.7.yml
+++ b/environment_python_3.7.yml
@@ -19,7 +19,7 @@ dependencies:
     - hotsoss==0.1.7
     - h5py==3.1.0
     - ipython==7.20.0
-    - jinja2==2.11.2
+    - jinja2==2.11.3
     - jupyter==1.0.0
     - jwst==1.1.0
     - jwst-backgrounds==1.1.2

--- a/environment_python_3.8.yml
+++ b/environment_python_3.8.yml
@@ -18,7 +18,7 @@ dependencies:
     - hotsoss==0.1.7
     - h5py==3.1.0
     - ipython==7.20.0
-    - jinja2==2.11.2
+    - jinja2==2.11.3
     - jupyter==1.0.0
     - jwst==1.1.0
     - jwst-backgrounds==1.1.2

--- a/environment_python_3.9.yml
+++ b/environment_python_3.9.yml
@@ -18,7 +18,7 @@ dependencies:
     - hotsoss==0.1.7
     - h5py==3.1.0
     - ipython==7.20.0
-    - jinja2==2.11.2
+    - jinja2==2.11.3
     - jupyter==1.0.0
     - jwst==1.1.0
     - jwst-backgrounds==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ healpy>=1.12.5
 h5py>=2.8.0
 hotsoss>=0.1.7
 ipython>=7.18.1
-jinja2==2.11.2
+jinja2==2.11.3
 jupyter>=1.0.0
 jwst==1.1.0
 jwst-backgrounds>=1.1.1

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         'h5py>=2.8.0',
         'hotsoss==0.1.7',
         'ipython',
-        'jinja2==2.11.2',
+        'jinja2==2.11.3',
         'jupyter',
         'jwst==1.1.0',
         'jwst-backgrounds>=1.1.1',


### PR DESCRIPTION
Based on #682, this PR updates the version of jinja2 to 2.11.3. We want to avoid updating to version 3.0 at the moment because of the error seen in #680.

It seems like the addition of the pinned versions of jinja2 to the yaml environment files might not be necessary given that #682 passed all of the tests. I might keep it in there for the moment though, since some users will run the example notebooks, and the error seen in #680 only came about in the quickstart.ipynb notebook. Notebooks aren't included in any of the CI tests.