### PR TITLE
Allow transmission file to be None or 'None' 

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -771,6 +771,10 @@ class Catalog_seed():
         """
         filename = self.params['Reffiles']['transmission']
 
+        if isinstance(filename, str):
+            if filename.lower() == 'none':
+                filename = None
+
         if filename is not None:
             # Read in file
             try:


### PR DESCRIPTION
Resolves #693 

This PR allows the transmission filename to be None or 'None' in the input yaml file when working in imaging mode. Previously the code was looking for only None, and was raising a FileNotFound error in cases where the file was listed as 'None'.