### PR TITLE
Update for_proposal for recent updates

### DIFF
--- a/mirage/catalogs/catalog_generator.py
+++ b/mirage/catalogs/catalog_generator.py
@@ -104,6 +104,11 @@ class PointSourceCatalog():
         if len(x) > 0:
             self._location_units = 'position_pixels'
 
+    def __len__(self):
+        """Return the number of rows in the catalog
+        """
+        return len(self._ra)
+
     def add_catalog(self, catalog_to_add, magnitude_fill_value=99.):
         """Add a catalog to the current catalog instance"""
         # If the the source positions in the two catalogs have different units, then the catalogs


### PR DESCRIPTION
Resolves #694 

This PR makes a few small changes to `for_proposal()` in create_catalogs.py to account for other recent changes in Mirage. Prior to these changes, `for_proposal()` would crash with missing `ra_ref, dec_ref` entries in the pointing catalog. With this change, `for_proposal()` now calls `ra_dec_update()` in `apt_inputs.py`, which populates ra_ref and dec_ref. With these updates, I was able to successfully create stellar and galactic catalogs using the stripped-down CEERS APT file from #694.