### PR TITLE
Fixes bug where simulating F277W with yaml file tries to simulate order 2

### DIFF
--- a/mirage/soss_simulator.py
+++ b/mirage/soss_simulator.py
@@ -708,6 +708,10 @@ class SossSim():
         # Save paramfile
         self._paramfile = pfile
 
+        # Only first order if F277W
+        if self.filter == 'F277W':
+            self.orders = [1]
+
         # Set the dependent quantities
         self.wave = hu.wave_solutions(self.subarray)
         self.avg_wave = np.mean(self.wave, axis=1)


### PR DESCRIPTION
This is a very small change but fixes SOSS simulations of F277W so it is not looking for a nonexistent order 2.