### PR TITLE
Create detector-sized transmission array for AMI and TSO imaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+Unreleased
+==========
+
+Create a pom transmission image composed of all 1's for NIRISS AMI and NIRCam imaging TSO simulations, as is done now for regular imaging simulations.
+
+
 2.1.0
 =====
 

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -784,7 +784,7 @@ class Catalog_seed():
         else:
             self.logger.info(('No transmission file given. Assuming full transmission for all pixels, '
                               'not including flat field effects. (no e.g. occulters blocking any pixels).'))
-            if self.params['Inst']['mode'].lower() == 'imaging':
+            if self.params['Inst']['mode'].lower() in ['imaging', 'ami', 'ts_imaging']:
                 transmission = np.ones((2048, 2048))
                 header = {'NOMXSTRT': 0, 'NOMYSTRT': 0}
             elif self.params['Inst']['mode'].lower() == 'pom':


### PR DESCRIPTION
Small oversight related to #695. This PR adds NIRISS AMI and NIRCam imaging TSO to the list of modes where a detector-sized array of 1's is created on the fly to represent the POM transmission mapping.