### PR TITLE
Update output file metadata to use NRIMDTPT

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2943,12 +2943,12 @@ class Observation():
 
         num_primary_dithers = self.params['Output']['total_primary_dither_positions']
         if isinstance(self.params['Output']['total_primary_dither_positions'], str):
-            num_primary_dithers = np.int(self.params['Output']['total_primary_dither_positions'][0])
+            num_primary_dithers = int(self.params['Output']['total_primary_dither_positions'][0])
 
         outModel.meta.dither.primary_type = self.params['Output']['primary_dither_type'].upper()
         outModel.meta.dither.position_number = self.params['Output']['primary_dither_position']
         outModel.meta.dither.total_points = num_primary_dithers
-        outModel.meta.dither.dither_points = str(self.params['Output']['total_primary_dither_positions'])
+        outModel.meta.dither.dither_points = int(self.params['Output']['total_primary_dither_positions'])
         outModel.meta.dither.pattern_size = 'DEFAULT'
         outModel.meta.dither.subpixel_type = self.params['Output']['subpix_dither_type']
         outModel.meta.dither.subpixel_number = self.params['Output']['subpix_dither_position']
@@ -3247,6 +3247,7 @@ class Observation():
         outModel[0].header['PATT_NUM'] = self.params['Output']['primary_dither_position']
         outModel[0].header['NUMDTHPT'] = num_primary_dithers
         outModel[0].header['NDITHPTS'] = str(self.params['Output']['total_primary_dither_positions'])
+        outModel[0].header['NRIMDTPT'] = int(self.params['Output']['total_primary_dither_positions'])
         outModel[0].header['PATTSIZE'] = 'DEFAULT'
         outModel[0].header['SUBPXTYP'] = self.params['Output']['subpix_dither_type']
         outModel[0].header['SUBPXNUM'] = self.params['Output']['subpix_dither_position']


### PR DESCRIPTION
This PR updates Mirage to be in agreement with recent (v1.2.3) changes to the jwst package. The NDITHPTS keyword has been replaced with the NRIMDTPT keyword. Both keywords use the dither.dither_points schema entry in jwst. When this entry pointed to NDITHPTS the entry was a string. Now, with NRIMDTPT, the entry is an integer. 

Resolves #704
Resolves #688