### PR TITLE
Updates for NIRISS ami moving targets

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -2159,7 +2159,8 @@ class Catalog_seed():
             extended.write(temp_ext_filename, format='ascii', overwrite=True)
 
             extlist, extstamps, ext_ghosts_file = self.getExtendedSourceList(temp_ext_filename, ghost_search=True)
-            extCRImage, extSegmap = self.make_extended_source_image(extlist, extstamps)
+            conv = [self.params['simSignals']['PSFConvolveExtended']] * len(extlist)
+            extCRImage, extSegmap = self.make_extended_source_image(extlist, extstamps, conv)
 
             totalCRList.append(extCRImage)
             totalSegList.append(extSegmap)


### PR DESCRIPTION
This PR tweaks a call to make_extended_source_image() in the case where a non-sidereal observation is being created. The call was missing a PSF convolution keyword that was inserted recently for imaging modes.