### PR TITLE
Remove CLEAR and CLEARP from NIRISS filter list

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -1117,7 +1117,13 @@ def get_filters(pointing_info):
 
             short_filter_only = np.where(short_pupils == 'CLEAR')[0]
             filter_list = list(set(short_pupils))
-            filter_list.remove('CLEAR')
+
+            # Remove CLEAR elements if present
+            niriss_clears = ['CLEAR', 'CLEARP']
+            for clear in niriss_clears:
+                if clear in filter_list:
+                filter_list.remove(clear)
+
             filter_list.append(list(set(short_filters[short_filter_only])))
 
         filters[inst.upper()] = filter_list


### PR DESCRIPTION
This PR removes CLEAR and CLEARP from the list of filters that are read in from the pointing file when creating source catalogs for NIRISS. In the case where a clear element is present, all we care about is the element in the other filter/pupil wheel.

Resolves #690 