### PR TITLE
WIP: Some dtype fixes to get poisson noise working properly for SOSS simulations

### DIFF
--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -1770,7 +1770,7 @@ class Observation():
         newimage = np.random.poisson(signalgain, signalgain.shape).astype(np.float64)
 
         if np.nanmin(signalgain) < 0.:
-            newimage[neg] = negatives[neg]
+            newimage[neg] = negatives[neg].astype(np.float64)
 
         newimage /= self.gain
 

--- a/mirage/soss_simulator.py
+++ b/mirage/soss_simulator.py
@@ -204,16 +204,16 @@ class SossSim():
         self.lines.add_row([name, profile, x_0, amplitude, fwhm, line])
 
     @run_required
-    def add_noise(self):
+    def add_noise(self, skip_dark=False):
         """
         Run the signal data through the ramp generator
         """
-        self.message("Starting noise generator...")
+        self.logger.info("Starting noise generator...")
         start = time.time()
 
         # Generate segmentation map with correct dimensions
-        self.segmap = segmentation_map.SegMap()
-        self.segmap.ydim = self.nrows
+        segmap = segmentation_map.SegMap()
+        segmap.ydim = self.nrows
 
         # Prepare dark current exposure if needed.
         if self.override_dark is None:
@@ -221,24 +221,44 @@ class SossSim():
             d = dark_prep.DarkPrep(offline=self.offline)
             d.paramfile = self.paramfile
             d.prepare()
-            use_darks = d.dark_files
+            self.use_darks = d.dark_files
         else:
-            self.logger.info('\noverride_dark is set. Skipping call to dark_prep and using these files instead.')
-            use_darks = self.override_dark
+            self.logger.info('Override_dark is set. Skipping call to dark_prep.')
+            self.use_darks = self.override_dark
 
         # Make a seed files split like the dark file
-        if isinstance(use_darks, str):
-            use_darks = [use_darks]
+        if isinstance(self.use_darks, str):
+            self.use_darks = [self.use_darks]
+
+        # Set darks to all zeros if skip_dark
+        if skip_dark:
+            self.logger.info('skip_dark is set. Setting dark frames to all zeroes.')
+            for dfile in self.use_darks:
+                hdu = fits.open(dfile)
+                hdu[1].data *= 0.
+                hdu[2].data *= 0.
+                hdu[3].data *= 0.
+                hdu[4].data *= 0.
+                hdu.flush()
+                hdu.close()
 
         nint = 0
-        nfiles = len(use_darks)
+        nfiles = len(self.use_darks)
         self.tso = np.empty_like(self.tso_ideal)
-        for n, dfile in enumerate(use_darks):
+        self.obs = []
+        for n, dfile in enumerate(self.use_darks):
+            self.logger.info('Using dark file {}/{}: {}'.format(n + 1, len(self.use_darks), dfile))
             dhead = fits.getheader(dfile)
             dnint = dhead['NINTS']
 
-            # Save the raw signal as a seed image
-            seed_seg = self.tso_ideal[nint:nint + dnint, :, :, :]
+            # Get the appropriate seed image segment
+            seed_seg = self.tso_ideal[nint:nint + dnint, :, :, :].astype(np.float64)
+
+            # NaNs and infs break np.random.poisson
+            seed_seg[np.where(np.isnan(seed_seg))] = 0.
+            seed_seg[np.where(np.isinf(seed_seg))] = 0.
+
+            # Save the seed image segment to file
             seedfile, seedinfo = save_seed.save(seed_seg, self.paramfile, self.params, True, False, 1., 2048, (self.nrows, self.ncols), {'xoffset': 0, 'yoffset': 0}, 1, frametime=self.frame_time)
 
             # Combine into final observation
@@ -246,7 +266,7 @@ class SossSim():
             obs = obs_generator.Observation(offline=self.offline)
             obs.linDark = dfile
             obs.seed = seed_seg
-            obs.segmap = self.segmap
+            obs.segmap = segmap
             obs.seedheader = seedinfo
             obs.paramfile = self.paramfile
             obs.create()
@@ -257,12 +277,15 @@ class SossSim():
             # Save ramp to tso attribute
             self.tso[nint:nint + dnint, :, :, :] = obs.raw_outramp
 
+            # Save obs object
+            self.obs.append(obs)
+
             # Pickup where last segment left off
             nint += dnint
 
         # Log it
-        self.logger.info('\nSOSS simulator complete')
-        self.message('Noise model finished: {} {}'.format(round(time.time() - start, 3), 's'))
+        self.logger.info('SOSS simulator complete')
+        self.logger.info('Noise model finished: {} {}'.format(round(time.time() - start, 3), 's'))
 
     def create(self, n_jobs=-1, noise=True, override_dark=None, **kwargs):
         """
@@ -322,15 +345,14 @@ class SossSim():
         self._reset_psfs()
 
         # Logging
-        self.logger.info('\n\nRunning soss_simulator....\n')
-        self.logger.info('Using parameter file: ')
-        self.logger.info('{}'.format(self.paramfile))
+        self.logger.info('Running soss_simulator....')
+        self.logger.info('Using parameter file: {}'.format(self.paramfile or 'None'))
         begin = time.time()
 
         # Make a simulation of all ones to save time
         if self.test:
 
-            self.message("Generating test simulation of shape {}...".format(self.dims))
+            self.logger.info("Generating test simulation of shape {}...".format(self.dims))
             self.tso_order1_ideal = self.tso_order2_ideal = np.ones((self.nints * self.ngrps, 256, 2048))
 
         # Make a true simulation
@@ -351,11 +373,13 @@ class SossSim():
             n_chunks = len(time_chunks)
 
             # Iterate over chunks
-            self.message('Simulating {target} in {title}\nConfiguration: {subarray} + {filter}\nGroups: {ngrps}, Integrations: {nints}\n'.format(**self.info))
+            self.logger.info('Simulating {} in {}'.format(self.target, self.title))
+            self.logger.info('Configuration: {} + {}'.format(self.subarray, self.filter))
+            self.logger.info('Groups: {}, Integrations: {}'.format(self.ngrps, self.nints))
             for chunk, (time_chunk, inttime_chunk) in enumerate(zip(time_chunks, inttime_chunks)):
 
                 # Run multiprocessing to generate lightcurves
-                self.message('Constructing frames for chunk {}/{}...'.format(chunk + 1, n_chunks))
+                self.logger.info('Constructing frames for chunk {}/{}...'.format(chunk + 1, n_chunks))
                 start = time.time()
 
                 # Get transit model for the current time chunk
@@ -382,7 +406,7 @@ class SossSim():
                     pool = ThreadPool(n_jobs)
                     func = partial(soss_trace.psf_lightcurve, time=time_chunk)
                     data = list(zip(psfs, tmodels))
-                    lightcurves = np.asarray(pool.starmap(func, data), dtype=np.float16)
+                    lightcurves = np.asarray(pool.starmap(func, data))
                     pool.close()
                     pool.join()
                     del pool
@@ -410,7 +434,7 @@ class SossSim():
                     # Clear memory
                     del frames, lightcurves, psfs
 
-                self.message('Chunk {}/{} finished: {} {}'.format(chunk + 1, n_chunks, round(time.time() - start, 3), 's'))
+                self.logger.info('Chunk {}/{} finished: {} {}'.format(chunk + 1, n_chunks, round(time.time() - start, 3), 's'))
 
         # Trim SUBSTRIP256 array if SUBSTRIP96
         if self.subarray == 'SUBSTRIP96':
@@ -438,7 +462,7 @@ class SossSim():
         else:
             self.tso = self.tso_ideal
 
-        self.message('\nTotal time: {} {}'.format(round(time.time() - begin, 3), 's'))
+        self.logger.info('Total time: {} {}'.format(round(time.time() - begin, 3), 's'))
 
     @property
     def filter(self):
@@ -973,7 +997,7 @@ class SossSim():
         """
         # Check if the star has been set
         if spectrum is None:
-            self.message("No star to simulate! Please set the self.star attribute!")
+            self.logger.info("No star to simulate! Please set the self.star attribute!")
             self._star = None
 
         else:
@@ -1009,8 +1033,10 @@ class SossSim():
             if spec_min > sim_min or spec_max < sim_max:
                 print("Wavelength range of input spectrum ({} - {}) does not cover the {} - {} range needed for a complete simulation. Interpolation will be used at the edges.".format(spec_min, spec_max, sim_min, sim_max))
 
-            # Good to go
-            self._star = spectrum
+            # Good to go (Poisson statistics in obs_generator require float16)
+            non_nan = np.invert(np.isnan(spectrum[1]))
+            non_inf = np.invert(np.isinf(spectrum[1]))
+            self._star = [i[non_nan * non_inf] for i in spectrum]
 
     @property
     def subarray(self):


### PR DESCRIPTION
This PR fixes a bug that was not allowing pixels to saturate and were breaking the poisson noise modeling for large simulations in SOSS mode. The issue was primarily array dtypes butting heads so forcing them all to float64 seems to fix it.

Also adds a keyword arg to replace the dark current step with all zeroes for debugging purposes.

Also moves all `message` method calls to `logging` calls instead so they are written to the log rather than just printed in the terminal.