### PR TITLE
Renormalize gridded PSFs with a total signal over 1

### DIFF
--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -88,7 +88,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
             if total_signal > upper_limit:
                 if renorm_psfs_above_1 and total_signal <= absolute_upper_limit:
                     lib.data[i, :, :] = lib.data[i, :, :] / total_signal
-                elif:
+                else:
                     # We will end up here if the total signal is above 1,
                     # and renorm_psfs_above_1 is not set or if the signal is
                     # above 1.5.

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -78,6 +78,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
         The second element is a short string describing the
         result.
     """
+    absolute_upper_limit = 1.5
     result = True, 'correct'
     ndims = len(lib.data.shape)
     if ndims == 3:
@@ -85,7 +86,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
             total_signal = np.sum(lib.data[i, :, :])
             total_signal /= lib.meta['oversamp'][0]**2
             if total_signal > upper_limit:
-                if renorm_psfs_above_1:
+                if renorm_psfs_above_1 and total_signal < absolute_upper_limit:
                     lib.data[i, :, :] = lib.data[i, :, :] / total_signal
                 else:
                     result = False, 'too high'

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -91,7 +91,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
                 else:
                     # We will end up here if the total signal is above 1,
                     # and renorm_psfs_above_1 is not set or if the signal is
-                    # above 1.5.
+                    # above the absolute_upper_limit.
                     result = False, 'too high'
             elif total_signal < lower_limit:
                 result = False, 'too low'
@@ -105,7 +105,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
             else:
                 # We will end up here if the total signal is above 1,
                 # and renorm_psfs_above_1 is not set or if the signal is
-                # above 1.5.
+                # above the absolute_upper_limit.
                 result = False, 'too high'
         elif total_signal < lower_limit:
             result = False, 'too low'

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -78,7 +78,7 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
         The second element is a short string describing the
         result.
     """
-    absolute_upper_limit = 1.5
+    absolute_upper_limit = 1.1
     result = True, 'correct'
     ndims = len(lib.data.shape)
     if ndims == 3:

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -86,9 +86,12 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
             total_signal = np.sum(lib.data[i, :, :])
             total_signal /= lib.meta['oversamp'][0]**2
             if total_signal > upper_limit:
-                if renorm_psfs_above_1 and total_signal < absolute_upper_limit:
+                if renorm_psfs_above_1 and total_signal <= absolute_upper_limit:
                     lib.data[i, :, :] = lib.data[i, :, :] / total_signal
-                else:
+                elif:
+                    # We will end up here if the total signal is above 1,
+                    # and renorm_psfs_above_1 is not set or if the signal is
+                    # above 1.5.
                     result = False, 'too high'
             elif total_signal < lower_limit:
                 result = False, 'too low'
@@ -97,9 +100,12 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_abov
         total_signal = np.sum(lib.data)
         total_signal /= lib.meta['oversamp'][0]**2
         if total_signal > upper_limit:
-            if renorm_psfs_above_1:
+            if renorm_psfs_above_1 and total_signal <= absolute_upper_limit:
                     lib.data = lib.data / total_signal
             else:
+                # We will end up here if the total signal is above 1,
+                # and renorm_psfs_above_1 is not set or if the signal is
+                # above 1.5.
                 result = False, 'too high'
         elif total_signal < lower_limit:
             result = False, 'too low'

--- a/mirage/psf/psf_selection.py
+++ b/mirage/psf/psf_selection.py
@@ -49,7 +49,7 @@ classdir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../'))
 log_config_file = os.path.join(classdir, 'logging', LOG_CONFIG_FILENAME)
 logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
-def check_normalization(lib, lower_limit=0.80, upper_limit=1.0):
+def check_normalization(lib, lower_limit=0.80, upper_limit=1.0, renorm_psfs_above_1=True):
     """Check that the gridded PSF library is properly normalized. We expect
     the total signal of the PSF to be roughly 1.0 (minus up to several percent
     since it should be normalized to 1.0 at the pupil).
@@ -65,6 +65,11 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0):
     upper_limit : float
         Upper limit for the total signal in the PSF
 
+    renorm_psfs_above_1 : bool
+        If True, any PSFs that have a normalized signal > 1.0
+        will be renormalized down to 1.0. In this case, the result
+        will be set to 'correct'
+
     Returns
     -------
     result : tup
@@ -73,19 +78,30 @@ def check_normalization(lib, lower_limit=0.80, upper_limit=1.0):
         The second element is a short string describing the
         result.
     """
+    result = True, 'correct'
     ndims = len(lib.data.shape)
     if ndims == 3:
-        total_signal = np.sum(lib.data[0, :, :])
+        for i in range(lib.data.shape[0]):
+            total_signal = np.sum(lib.data[i, :, :])
+            total_signal /= lib.meta['oversamp'][0]**2
+            if total_signal > upper_limit:
+                if renorm_psfs_above_1:
+                    lib.data[i, :, :] = lib.data[i, :, :] / total_signal
+                else:
+                    result = False, 'too high'
+            elif total_signal < lower_limit:
+                result = False, 'too low'
+
     elif ndims == 2:
         total_signal = np.sum(lib.data)
-    total_signal /= lib.meta['oversamp'][0]**2
-
-    if total_signal > upper_limit:
-        result = False, 'too high'
-    elif total_signal < lower_limit:
-        result = False, 'too low'
-    else:
-        result = True, 'correct'
+        total_signal /= lib.meta['oversamp'][0]**2
+        if total_signal > upper_limit:
+            if renorm_psfs_above_1:
+                    lib.data = lib.data / total_signal
+            else:
+                result = False, 'too high'
+        elif total_signal < lower_limit:
+            result = False, 'too low'
     return result
 
 
@@ -330,7 +346,7 @@ def get_gridded_psf_library(instrument, detector, filtername, pupilname, wavefro
     # Check that the gridded PSF library is normalized as expected
     check_max = PSF_NORM_MAX * grid_min_factor
     check_min = PSF_NORM_MIN * grid_min_factor
-    correct_norm, reason = check_normalization(library, lower_limit=check_min, upper_limit=check_max)
+    correct_norm, reason = check_normalization(library, lower_limit=check_min, upper_limit=check_max, renorm_psfs_above_1=True)
     if correct_norm:
         return library
     else:


### PR DESCRIPTION
This PR contains a small update during the normalization checks that are performed on gridded PSF libraries. In some cases, the total normalized signal in a distorted PSF can be just > 1. This is due to the model WebbPSF uses when creating and distorting the PSF. See https://github.com/spacetelescope/webbpsf/issues/487

With this PR, rather than raising an exception, when a PSF with a signal > 1 is found, it is renormalized to be 1.0. Previously, the normalization check examined only the first PSF in the PSF grid in order to determine the normalized signal level. With this PR, Mirage now checks all PSFs in the grid, as there are cases where some PSFs have total signals under 1.0 while others are over 1.0.

 

