### PR TITLE
Catalog crossmatch inconsistencies

### DIFF
--- a/mirage/catalogs/create_catalog.py
+++ b/mirage/catalogs/create_catalog.py
@@ -643,6 +643,12 @@ def get_all_catalogs(ra, dec, box_width, besancon_catalog_file=None, instrument=
     gaia_cat, gaia_mag_cols, gaia_2mass, gaia_2mass_crossref, gaia_wise, \
         gaia_wise_crossref = query_GAIA_ptsrc_catalog(outra, outdec, box_width)
     twomass_cat, twomass_cols = query_2MASS_ptsrc_catalog(outra, outdec, box_width)
+
+    print('2MASS: ', outra, outdec, box_width)
+    print(twomass_cat)
+    print('')
+    print(twomass_cols)
+
     wise_cat, wise_cols = query_WISE_ptsrc_catalog(outra, outdec, box_width, wise_catalog=wise_catalog)
 
     if besancon_catalog_file is not None:
@@ -1113,6 +1119,19 @@ def combine_and_interpolate(gaia_cat, gaia_2mass, gaia_2mass_crossref, gaia_wise
     raout[0:ngaia] = gaia_cat['ra']
     decout[0:ngaia] = gaia_cat['dec']
     ngaia2masscr = twomass_crossmatch(gaia_cat, gaia_2mass, gaia_2mass_crossref, twomass_cat)
+
+    print('gaia_2mass:')
+    print(gaia_2mass)
+    print('gaia_cat:')
+    print(gaia_cat)
+    print('twomass_cat:')
+    print(twomass_cat)
+
+
+    print(ngaia2masscr)
+    print('\n\n\n')
+
+
     twomassflag = [True] * n2mass2
     for n1 in range(n2mass2):
         for loop in range(len(gaia_2mass['ra'])):
@@ -1120,6 +1139,17 @@ def combine_and_interpolate(gaia_cat, gaia_2mass, gaia_2mass_crossref, gaia_wise
                 if ngaia2masscr[n1] >= 0:
                     twomassflag[n1] = False
     matchwise, gaiawiseinds, twomasswiseinds = wise_crossmatch(gaia_cat, gaia_wise, gaia_wise_crossref, wise_cat, twomass_cat)
+
+
+    print(matchwise)
+    print('\n\n')
+    print(gaiawiseinds)
+    print('\n\n')
+    print(twomasswiseinds)
+    print('\n\n')
+
+
+
     wisekeys = ['w1sigmpro', 'w2sigmpro', 'w3sigmpro', 'w4sigmpro']
 
     # Set invalid values to NaN
@@ -1451,6 +1481,7 @@ def interpolate_magnitudes(wl1, mag1, wl2, filternames):
     # Case 1:  All dummy values, return all magnitudes = 10000.0 (this should
     #          not happen)
     if np.min(mag1) > 100.:
+        print('uh oh')
         return outmags
     # Case 2,  Only GAIA magnitudes.  Either transform from the GAIA BP and RP
     #          colour to the JWST magnitudes or assume a default colour value
@@ -1462,8 +1493,17 @@ def interpolate_magnitudes(wl1, mag1, wl2, filternames):
             inmags = np.zeros((2), dtype=np.float32)
             inmags[0] = mag1[1] + 0.5923
             inmags[1] = mag1[1] - 0.7217
+
+
+            print('Use K4V star')
+
+
         else:
             inmags = np.copy(mag1[[0, 2]])
+
+            print('copying')
+
+
         standard_magnitudes, standard_values, standard_filters, standard_labels = read_standard_magnitudes()
         in_filters = ['GAIA gbp', 'GAIA grp']
         newmags = match_model_magnitudes(inmags, in_filters, standard_magnitudes, standard_values,
@@ -1473,6 +1513,9 @@ def interpolate_magnitudes(wl1, mag1, wl2, filternames):
         return outmags
     # Case 3, some infrared magnitudes are available, interpolate good values
     # (magnitude = 10000 for bad values)
+
+    print('interpolating')
+
     inds = np.where(mag1 < 100.)
     inmags = mag1[inds]
     inwl = wl1[inds]
@@ -1912,6 +1955,13 @@ def query_GAIA_ptsrc_catalog(ra, dec, box_width):
         table = job.get_results()
         outvalues[key] = table
         logger.info('Retrieved {} sources for catalog {}'.format(len(table), key))
+
+
+        if key == 'tmass':
+            print('2mass Table from gaia query box width {}:'.format(boxwidth))
+            print(table)
+
+
     gaia_mag_cols = ['phot_g_mean_mag', 'phot_bp_mean_mag', 'phot_rp_mean_mag']
     return outvalues['gaia'], gaia_mag_cols, outvalues['tmass'], outvalues['tmass_crossmatch'], outvalues['wise'], outvalues['wise_crossmatch']
 


### PR DESCRIPTION
This PR fixes a bug in the Gaia/2MASS/WISE catalog query and generation code. An indexing error was causing the incorrect magnitude values to go into the interpolation function in some cases. This was resulting in different magnitudes for a given object depending on the width of the box on the sky used for the catalog search.

Resolves #708 

Initial test results:

Search center:
ra = 96.354515
dec = -63.9448861111

At these coords, we should find a source with kmag = 8.918


10" box_width (results are unchanged, and look reasonable):

Master branch:
          x_or_RA                         y_or_Dec          f200w  f444w f356w f070w f090w 
96.3545150756836 -63.94488525390625  8.97    8.94    8.87    10.88 10.29

Fix:
96.3545150756836 -63.94488525390625 8.97     8.94    8.87    10.88 10.29

60" box width:

Master branch: 
Note the F200W mag for the first source, which is the source from the 10" search above,
as well as the F200W mag for the 4th source, which is much brighter than in the other filters
96.3545150756836 -63.94488525390625  9.75     8.94    8.89    10.88   10.47
96.35475158691406 -63.9473495483398 19.70    19.65  19.66    19.95  19.81
96.3580093383789 -63.94111633300781   16.30   16.22   16.23    17.79  17.34
96.36162567138672 -63.9528427124023   8.97     13.48   13.47    14.75  13.14
96.335693359375 -63.941307067871094 15.82    15.76   15.75     16.80  16.80
96.37287139892578 -63.9367027282714  17.58     17.49   17.56     17.58  17.58

Fix: 
Note how the first source magnitudes now matches that from the 10" search. The fourth source
now has magnitudes across all filters that are more consistent and reasonable.
96.3545150756836 -63.94488525390625   8.97     8.94    8.87     10.88  10.29
96.35475158691406 -63.9473495483398  19.70   19.65   19.66    19.95  19.81
96.3580093383789 -63.94111633300781   16.30    16.22  16.23     17.79   17.34
96.36162567138672 -63.9528427124023   13.50    13.48  13.47    14.75   14.34
96.335693359375 -63.941307067871094   15.82   15.76   15.75    16.80   16.80
96.37287139892578 -63.9367027282714   17.58     17.49   17.56    17.58   17.58

In general, I think a lot of the catalog creation functions could probably be streamlined in order to avoid indexing errors like this. But given that the results with this fix in place look correct, a more involved code revision can be saved for later.