### PR TITLE
Fix bug in NIRISS filter list for imaging mode when creating cats

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -1116,7 +1116,7 @@ def get_filters(pointing_info):
             short_filters = np.array(pointing_info['FilterWheel'])[good]
             short_pupils = np.array(pointing_info['PupilWheel'])[good]
 
-            short_filter_only = np.where(short_pupils == 'CLEAR')[0]
+            short_filter_only = np.where(((short_pupils == 'CLEAR') | (short_pupils == 'CLEARP')))[0]
             filter_list = list(set(short_pupils))
 
             # Remove CLEAR and non-imaging elements if present

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -871,6 +871,19 @@ class ReadAPTXML():
                             #     print('{} {}'.format(parameter_tag_stripped, exposure_parameter.text))
                             exposure_dict[parameter_tag_stripped] = exposure_parameter.text
 
+                            # NIRISS imaging mode does not contain a Pupil entry in the xml file.
+                            # Determine which wheel the listed filter is in, and populate the
+                            # dictionary acordingly
+                            if instrument.lower() == 'niriss':
+                                if parameter_tag_stripped == 'Filter':
+                                    filt_wave = int(exposure_parameter.text[1:4])
+                                    if filt_wave > 200:
+                                        exposure_dict['FilterWheel'] = exposure_parameter.text
+                                        exposure_dict['PupilWheel'] = 'CLEARP'
+                                    else:
+                                        exposure_dict['FilterWheel'] = 'CLEAR'
+                                        exposure_dict['PupilWheel'] = exposure_parameter.text
+
                         # fill dictionary to return
                         for key in self.APTObservationParams_keys:
                             if key in exposure_dict.keys():
@@ -3180,6 +3193,7 @@ class ReadAPTXML():
             ta_dict['Groups'] = ta_groups
             ta_dict['Integrations'] = 1
             ta_dict['FilterWheel'] = ta_filter
+            ta_dict['Filter'] = ta_filter
 
             if 'BRIGHT' in ta_mode.upper():
                 ta_dict['PupilWheel'] = 'NRM'

--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -873,7 +873,7 @@ class ReadAPTXML():
 
                             # NIRISS imaging mode does not contain a Pupil entry in the xml file.
                             # Determine which wheel the listed filter is in, and populate the
-                            # dictionary acordingly
+                            # dictionary accordingly
                             if instrument.lower() == 'niriss':
                                 if parameter_tag_stripped == 'Filter':
                                     filt_wave = int(exposure_parameter.text[1:4])


### PR DESCRIPTION
This PR fixes a problem in the for_proposals() within create_catalog.py. For an input observation that uses NIRISS in imaging mode, the filter/pupil values being read in from the APT xml file were being placed in the wrong entry of the exposure dictionary. This was then causing for_proposal() to find an empty list of NIRISS filters to interpolate source magnitudes to. 

These updates populate the correct keys in the exposure dictionary. I've also increased the area covered by the created catalogs in the case of a single target in the xml file. The code was originally designed with multiple targets in mind. With a single target, the size of the area on the sky to query for was too small to cover all of the detectors. Now, if there is a single target, the catalogs output by for_proposal() will cover 6' x 6', which is large enough to cover both NIRCam modules.