### PR TITLE
Fix file splitting sizes for non-RAPID observations

### DIFF
--- a/mirage/grism_tso_simulator.py
+++ b/mirage/grism_tso_simulator.py
@@ -609,10 +609,12 @@ class GrismTSO():
         # help align the split files between the seed image and the dark
         # object later (which is split by groups).
         if self.split_seed:
+            forced_ints_per_file = int(self.frames_per_int / self.numgroups) * (self.int_segment_indexes[1] - self.int_segment_indexes[0])
             split_seed_g, self.group_segment_indexes_g, self.file_segment_indexes = find_file_splits(self.seed_dimensions[1],
                                                                                                 self.seed_dimensions[0],
                                                                                                 self.numgroups,
-                                                                                                self.numints)
+                                                                                                self.numints,
+                                                                                                force_delta_int=forced_ints_per_file)
 
             # In order to avoid the case of having a single integration
             # in the final file, which leads to rate rather than rateints
@@ -1135,8 +1137,8 @@ class GrismTSO():
                                                     '_tso_grism_sources.{}'.format(suffix))
         utils.write_yaml(tso_params, self.tso_paramfile)
 
-    @staticmethod
-    def tso_catalog_check(catalog, exp_time):
+    #@staticmethod
+    def tso_catalog_check(self, catalog, exp_time):
         """Check that the start and end times specified in the TSO catalog file (which are
         used to calculate the lightcurves) are long enough to encompass the entire exposure.
         If not, extend the end time to the required time.

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -231,10 +231,13 @@ class Catalog_seed():
             # help align the split files between the seed image and the dark
             # object later (which is split by groups).
             if split_seed:
+                delta_index = integration_segment_indexes[1] - integration_segment_indexes[0]
+                forced_ints_per_file = int(self.frames_per_integration / self.params['Readout']['ngroup']) * delta_index
                 split_seed_g, self.group_segment_indexes_g, self.file_segment_indexes = find_file_splits(self.output_dims[1],
                                                                                                     self.output_dims[0],
                                                                                                     self.params['Readout']['ngroup'],
-                                                                                                    self.params['Readout']['nint'])
+                                                                                                    self.params['Readout']['nint'],
+                                                                                                    force_delta_int=forced_ints_per_file)
 
 
                 #print('\nOutputs:')

--- a/mirage/utils/file_splitting.py
+++ b/mirage/utils/file_splitting.py
@@ -21,7 +21,7 @@ logging_functions.create_logger(log_config_file, STANDARD_LOGFILE_NAME)
 
 
 def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
-                     pixel_limit=FILE_SPLITTING_LIMIT):
+                     pixel_limit=FILE_SPLITTING_LIMIT, force_delta_int=None):
     """Determine the frame and/or integration numbers where a file
     should be split in order to keep the file size reasonable.
 
@@ -46,6 +46,10 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
     pixel_limit : int
         Proxy for file size limit. Number of pixel read outs to treat
         as the upper limit to be contained in a single file.
+
+    force_delta_int : int
+        If provided, this forces the number of integrations in each
+        file
 
     Returns
     -------
@@ -94,7 +98,10 @@ def find_file_splits(xdim, ydim, groups, integrations, frames_per_group=None,
         split = True
         logger.info('Splitting by integration:')
         group_list = np.array([0, groups])
-        delta_int = int(pixel_limit / pix_per_int)
+        if not force_delta_int:
+            delta_int = int(pixel_limit / pix_per_int)
+        else:
+            delta_int = force_delta_int
         integration_list = np.arange(0, integrations, delta_int).astype(int)
         integration_list = np.append(integration_list, integrations)
         logger.info('integration_list: {}'.format(integration_list))


### PR DESCRIPTION
Resolves #729 

This PR resolves an issue with file splitting when the exposure being simulated does not use the RAPID readout pattern.

The number of integrations in a given segment file was determined by dividing the maximum number of allowed pixel read outs per file by the number of pixel read outs per integration. The problem with this is that that ratio is a float. The code used to take the floor of that result to get the number of integrations to include. However, in cases of non-RAPID exposures, the file splitting function is called for both the requested readout pattern as well as (effectively) RAPID mode, because the seed image, when it is split, contains all frames of the integration (i.e. 5 frames for each specified SHALLOW group). But for certain numbers of frames/pixels, seed images with N times more frames than groups were being split with (N-1) or (N+1) times the number of integrations per file.

For example, a TSO observation with 6 groups/integration and 1287 integrations using BRIGHT2 (2 frames per group):
When split using all frames in the observation, the integration numbers at the start of each segment file were:
 0, 106, 212, 318, 424, 530, 636, 742, 848, 954, 1060, 1166, 1272, 1287
But when split on groups, the integration numbers at the start of each segment file were: 
0, 213, 426, 639, 852, 1065, 1278, 1287

When splitting on groups, there is an extra integration in each segment file (e.g. 213 vs 212). This difference was causing problems when attempting to combine the split seed image with the split dark current ramp.

To fix the issue, I've added a keyword to the file splitting function that allows the user to force the number of integrations per file, and a couple of lines to use this new keyword when splitting based on groups after having split on frames.
