### PR TITLE
Add missing function definition in Imaging mode notebook

### DIFF
--- a/examples/Imaging_simulator_use_examples.ipynb
+++ b/examples/Imaging_simulator_use_examples.ipynb
@@ -545,15 +545,38 @@
     "        m = imaging_simulator.ImgSim()\n",
     "        m.paramfile = file\n",
     "        m.create()\n",
-    "```\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### In Parallel\n",
     "\n",
     "Since each `yaml` simulations does not depend on the others, we can parallelize the process to speed things up:\n",
     "```python\n",
     "from multiprocessing import Pool\n",
+    "from glob import glob\n",
+    "\n",
+    "\n",
+    "def make_sim(paramfile):\n",
+    "    \"\"\"Wrapper around imaging simulator call so that it can\n",
+    "    be called via multiprocessing\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    paramfile: str\n",
+    "        Name of yaml input file\n",
+    "    \"\"\"\n",
+    "    m = imaging_simulator.ImgSim()\n",
+    "    m.paramfile = paramfile\n",
+    "    m.create()\n",
+    "\n",
+    "\n",
     "\n",
     "n_procs = 5 # number of cores available\n",
+    "paramlist = glob('/path/to/your/yaml/input/files/jw*yaml')\n",
     "\n",
     "with Pool(n_procs) as pool:\n",
     "    pool.map(make_sim, paramlist)\n",
@@ -792,7 +815,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -806,7 +829,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a missing function to the Imaging mode example notebook. The function is used in the section on parallel processing to run the imaging simulator on a series of yaml files. The function is added to the existing markdown cell containing the multiprocessing set up. This was to avoid having someone blindly run that cell, which would take quite a while depending on the number of yaml files.