### PR TITLE
Set correct mode for NIRISS wfss obs in Ext Cal template

### DIFF
--- a/mirage/apt/read_apt_xml.py
+++ b/mirage/apt/read_apt_xml.py
@@ -3299,8 +3299,6 @@ class ReadAPTXML():
                             value = template_name
                         elif key == 'Tracking':
                             value = tracking
-                        #elif (key == 'Mode'):
-                            #value = mode
                         elif key == 'Module':
                             value = mod
                         elif key == 'Subarray':


### PR DESCRIPTION
This is a small bugfix in the APT file reader. For observations taken using the NIRISS external calibration template, this fix will set the mode to 'wfss' for exposures that have a grism in the filter wheel. Previously Mirage assumed that all exposures in the External Calibration template were imaging mode.