### PR TITLE
Add NOUTPUTS keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,13 @@
+Unreleased
+==========
+
+Headers
+-------
+
+Populate the NOUTPUTS header keyword in saved uncal and linear files. This is needed in order to find the correct CRDS reference files in some cases. (#756)
+
+
+
 2.2.0
 =====
 

--- a/mirage/ramp_generator/obs_generator.py
+++ b/mirage/ramp_generator/obs_generator.py
@@ -2990,6 +2990,7 @@ class Observation():
         outModel.meta.exposure.nframes = self.params['Readout']['nframe']
         outModel.meta.exposure.ngroups = self.params['Readout']['ngroup']
         outModel.meta.exposure.nints = self.params['Readout']['nint']
+        outModel.meta.exposure.noutputs = self.params['Readout']['namp']
 
         # TODO: Putting this try/except here because SOSS mode mysteriously breaks it (Joe)
         try:


### PR DESCRIPTION
Resolves #755 

This PR adds code to populate the NOUTPUTS header keyword in the uncal and linear files output by mirage. The information was already in the input yaml file, so populating the appropriate metadata entry was trivial.