### PR TITLE
Remove pipeline config files

### DIFF
--- a/docs/dark_preparation.rst
+++ b/docs/dark_preparation.rst
@@ -8,7 +8,7 @@ After creating the seed image `mirage` moves on to preparing the input dark curr
 Adjust Number of Frames/Groups and Integrations
 -----------------------------------------------
 
-Frist the number of groups and integrations are adjusted to match the requested groups and integrations specified in the input yaml file. If the input dark has more groups or integrations than the requested output, the extras are removed. If additional groups or integrations are required above what is present in the dark file, then copies of existing groups/integrations are made and appended to the observation. In the case where extra groups are needed, copies of the existing groups are added to the signal in the final group of the existing dark, such that the dark current signals continue increasing in as they would in a longer integration.
+First the number of groups and integrations are adjusted to match the requested groups and integrations specified in the input yaml file. If the input dark has more groups or integrations than the requested output, the extras are removed. If additional groups or integrations are required above what is present in the dark file, then copies of existing groups/integrations are made and appended to the observation. In the case where extra groups are needed, copies of the existing groups are added to the signal in the final group of the existing dark, such that the dark current signals continue increasing in as they would in a longer integration.
 
 Put into Requested Readout Pattern
 ----------------------------------

--- a/docs/example_yaml.rst
+++ b/docs/example_yaml.rst
@@ -113,13 +113,6 @@ Below is an example yaml input file for *Mirage*. The yaml file used as the prim
 	  rotation_: 0.0                #y axis rotation (degrees E of N)
 	  tracking_: sidereal           #sidereal or non-sidereal
 
-	newRamp_:
-	  dq_configfile_: config          #config file used by JWST pipeline
-	  sat_configfile_: config         #config file used by JWST pipeline
-	  superbias_configfile_: config   #config file used by JWST pipeline
-	  refpix_configfile_: config      #config file used by JWST pipeline
-	  linear_configfile_: config      #config file used by JWST pipeline
-
 	Output_:
 	  file_: jw42424024002_01101_00001_nrcb5_uncal.fits   # Output filename
 	  directory_: ./                                # Directory in which to place output files
@@ -1047,67 +1040,6 @@ Telescope tracking
 
 Either 'sidereal' or 'non-sidereal' depending on the type of exposure. If it is set to non-sidereal then the exposure will be created as if JWST is
 tracking on the source in the :ref:`movingTargetToTrack <movingTargetToTrack>` catalog. Sources in the :ref:`pointsource <pointsource>`, :ref:`galaxyListFile <galaxyListFile>`, and :ref:`extended <extended>` catalogs will trail across the field of view over the course of the exposure.
-
-.. _newRamp:
-
-newRamp section
----------------
-
-This section of the input file lists JWST calibration pipeline-style configuration files that may be needed when preparing the simulated data. Copies of all of these configuration files are included in the ‘config’ subdirectory of the MIRAGE repository. Therefore, unless you wish to use your own set of configuration files, you can set these fields all to 'config'. This is the default behavior when creating yaml files via the :ref:`yaml generator <yaml_generator>`.
-
-.. hint::
-	In order to create your own set of pipeline configuration files, use the shell command:
-
-	> collect_pipeline_cfg /your/destination/directory
-
-.. _dq_configfile:
-
-DQ step configuration file
-++++++++++++++++++++++++++
-
-*newRamp:dq_configfile*
-
-Name of the JWST calibration pipeline configuration file to be used in the dq_init step when it is run on the raw dark current integration.
-
-
-.. _sat_configfile:
-
-Saturation step configuration file
-++++++++++++++++++++++++++++++++++
-
-*newRamp:sat_configfile*
-
-Name of the JWST calibration pipeline configuration file to be used in the saturation step when it is run on the raw dark current integration.
-
-.. _superbias_configfile:
-
-Superbias step configuration file
-+++++++++++++++++++++++++++++++++
-
-*newRamp:superbias_configfile*
-
-Name of the JWST calibration pipeline configuration file to be used in the superbias step when it is run on the raw dark current integration.
-
-.. _refpix_configfile:
-
-Reference pixel subtraction configuration file
-++++++++++++++++++++++++++++++++++++++++++++++
-
-*newRamp:refpix_configfile*
-
-Name of the JWST calibration pipeline configuration file to be used in the reference pixel subtraction step when it is run on the raw dark current integration.
-
-.. hint::
-    If you choose to use your own reference pixel correction configuration file, we recommend setting the **odd_even_rows** entry to False, as this correction is not typically performed on NIRCam, NISISS, or FGS data.
-
-.. _linear_configfile:
-
-Linearity step configuration file
-+++++++++++++++++++++++++++++++++
-
-*newRamp:linear_configfile*
-
-Name of the JWST calibration pipeline configuration file to be used in the linearity correction step when it is run on the raw dark current integration.
 
 .. _output:
 

--- a/mirage/dark/dark_prep.py
+++ b/mirage/dark/dark_prep.py
@@ -145,37 +145,11 @@ class DarkPrep():
         # indicating the step should be skipped. Create a dictionary of steps
         # and populate with True or False
         self.runStep = {}
-        # self.runStep['linearity'] = self.check_run_step(self.params['Reffiles']['linearity'])
         self.runStep['badpixmask'] = self.check_run_step(self.params['Reffiles']['badpixmask'])
         self.runStep['linearized_darkfile'] = self.check_run_step(self.params['Reffiles']['linearized_darkfile'])
         self.runStep['saturation_lin_limit'] = self.check_run_step(self.params['Reffiles']['saturation'])
         self.runStep['superbias'] = self.check_run_step(self.params['Reffiles']['superbias'])
         self.runStep['linearity'] = self.check_run_step(self.params['Reffiles']['linearity'])
-
-        # If the pipeline is going to be used to create
-        # the linearized dark current ramp, make sure the
-        # specified configuration files are present.
-        if not self.runStep['linearized_darkfile']:
-            dqcheck = self.check_run_step(self.params['newRamp']['dq_configfile'])
-            if not dqcheck:
-                raise FileNotFoundError(("WARNING: DQ pipeline step configuration file not provided. "
-                                         "This file is needed to run the pipeline."))
-            satcheck = self.check_run_step(self.params['newRamp']['sat_configfile'])
-            if not satcheck:
-                raise FileNotFoundError(("WARNING: Saturation pipeline step configuration file not provided. "
-                                         "This file is needed to run the pipeline."))
-            sbcheck = self.check_run_step(self.params['newRamp']['superbias_configfile'])
-            if not sbcheck:
-                raise FileNotFoundError(("WARNING: Superbias pipeline step configuration file not provided. "
-                                        "This file is needed to run the pipeline."))
-            refpixcheck = self.check_run_step(self.params['newRamp']['refpix_configfile'])
-            if not refpixcheck:
-                raise FileNotFoundError(("WARNING: Refpix pipeline step configuration file not provided. "
-                                         "This file is needed to run the pipeline."))
-            lincheck = self.check_run_step(self.params['newRamp']['linear_configfile'])
-            if not lincheck:
-                raise FileNotFoundError(("WARNING: Linearity pipeline step configuration file not provided. "
-                                         "This file is needed to run the pipeline."))
 
     def check_run_step(self, filename):
         """Check to see if a filename exists in the parameter file
@@ -585,33 +559,24 @@ class DarkPrep():
 
         # Run the DQ_Init step
         if self.runStep['badpixmask']:
-            linDark = DQInitStep.call(dark,
-                                      config_file=self.params['newRamp']['dq_configfile'],
-                                      override_mask=self.params['Reffiles']['badpixmask'])
+            linDark = DQInitStep.call(dark, override_mask=self.params['Reffiles']['badpixmask'])
         else:
-            linDark = DQInitStep.call(dark, config_file=self.params['newRamp']['dq_configfile'])
+            linDark = DQInitStep.call(dark)
 
         # If the saturation map is provided, use it. If not, default to whatever is in CRDS
         if self.runStep['saturation_lin_limit']:
-            linDark = SaturationStep.call(linDark,
-                                          config_file=self.params['newRamp']['sat_configfile'],
-                                          override_saturation=self.params['Reffiles']['saturation'])
+            linDark = SaturationStep.call(linDark, override_saturation=self.params['Reffiles']['saturation'])
         else:
-            linDark = SaturationStep.call(linDark,
-                                          config_file=self.params['newRamp']['sat_configfile'])
+            linDark = SaturationStep.call(linDark)
 
         # If the superbias file is provided, use it. If not, default to whatever is in CRDS
         if self.runStep['superbias']:
-            linDark = SuperBiasStep.call(linDark,
-                                         config_file=self.params['newRamp']['superbias_configfile'],
-                                         override_superbias=self.params['Reffiles']['superbias'])
+            linDark = SuperBiasStep.call(linDark, override_superbias=self.params['Reffiles']['superbias'])
         else:
-            linDark = SuperBiasStep.call(linDark,
-                                         config_file=self.params['newRamp']['superbias_configfile'])
+            linDark = SuperBiasStep.call(linDark)
 
         # Reference pixel correction
-        linDark = RefPixStep.call(linDark,
-                                  config_file=self.params['newRamp']['refpix_configfile'])
+        linDark = RefPixStep.call(linDark)
 
         # Save a copy of the superbias- and reference pixel-subtracted
         # dark. This will be used later to add these effects back in
@@ -625,12 +590,9 @@ class DarkPrep():
         base_name = self.params['Output']['file'].split('/')[-1]
         linearoutfile = base_name[0:-5] + '_linearized_dark_current_ramp.fits'
         if self.runStep['linearity']:
-            linDark = LinearityStep.call(linDark,
-                                         config_file=self.params['newRamp']['linear_configfile'],
-                                         override_linearity=self.params['Reffiles']['linearity'])
+            linDark = LinearityStep.call(linDark, override_linearity=self.params['Reffiles']['linearity'])
         else:
-            linDark = LinearityStep.call(linDark,
-                                         config_file=self.params['newRamp']['linear_configfile'])
+            linDark = LinearityStep.call(linDark)
 
         # Now we need to put the data back into a read_fits object
         linDarkobj = read_fits.Read_fits()

--- a/mirage/yaml/yaml_generator.py
+++ b/mirage/yaml/yaml_generator.py
@@ -1539,23 +1539,8 @@ class SimInput:
         ensure_dir_exists(self.output_dir)
         ensure_dir_exists(self.simdata_output_dir)
 
-        # self.subarray_def_file = self.set_config(self.subarray_def_file, 'subarray_def_file')
-        # self.readpatt_def_file = self.set_config(self.readpatt_def_file, 'readpatt_def_file')
-        # self.filtpupil_pairs = self.set_config(self.filtpupil_pairs, 'filtpupil_pairs')
-        # self.fluxcal = self.set_config(self.fluxcal, 'fluxcal')
-        # self.filter_throughput = self.set_config(self.filter_throughput, 'filter_throughput')
-        # self.dq_init_config = self.set_config(self.dq_init_config, 'dq_init_config')
-        # self.refpix_config = self.set_config(self.refpix_config, 'refpix_config')
-        # self.saturation_config = self.set_config(self.saturation_config, 'saturation_config')
-        # self.superbias_config = self.set_config(self.superbias_config, 'superbias_config')
-        # self.linearity_config = self.set_config(self.linearity_config, 'linearity_config')
-
         if self.observation_list_file is not None:
             self.observation_list_file = os.path.abspath(os.path.expandvars(self.observation_list_file))
-        # if self.crosstalk not in [None, 'config']:
-        #     self.crosstalk = os.path.abspath(os.path.expandvars(self.crosstalk))
-        # elif self.crosstalk == 'config':
-        #     self.crosstalk = os.path.join(self.modpath, 'config', self.configfiles['crosstalk'])
 
     def reffile_setup(self):
         """Create lists of reference files associate with each detector.
@@ -1590,11 +1575,6 @@ class SimInput:
                 self.psfpixfrac[instrument] = 0.1
 
             # Set global file paths
-            self.configfiles[instrument]['dq_init_config'] = os.path.join(self.modpath, 'config', 'dq_init.cfg')
-            self.configfiles[instrument]['saturation_config'] = os.path.join(self.modpath, 'config', 'saturation.cfg')
-            self.configfiles[instrument]['superbias_config'] = os.path.join(self.modpath, 'config', 'superbias.cfg')
-            self.configfiles[instrument]['refpix_config'] = os.path.join(self.modpath, 'config', 'refpix.cfg')
-            self.configfiles[instrument]['linearity_config'] = os.path.join(self.modpath, 'config', 'linearity.cfg')
             self.configfiles[instrument]['filter_throughput'] = os.path.join(self.modpath, 'config', 'placeholder.txt')
 
         for instrument in 'miri nirspec'.split():
@@ -2163,13 +2143,6 @@ class SimInput:
                 pav3_value = input['PAV3']
             f.write('  rotation: {}                    # PA_V3 in degrees, i.e. the position angle of the V3 axis at V1 (V2=0, V3=0) measured from N to E.\n'.format(pav3_value))
             f.write('  tracking: {}   #Telescope tracking. Can be sidereal or non-sidereal\n'.format(input['Tracking']))
-            f.write('\n')
-            f.write('newRamp:\n')
-            f.write('  dq_configfile: {}\n'.format(self.configfiles[instrument.lower()]['dq_init_config']))
-            f.write('  sat_configfile: {}\n'.format(self.configfiles[instrument.lower()]['saturation_config']))
-            f.write('  superbias_configfile: {}\n'.format(self.configfiles[instrument.lower()]['superbias_config']))
-            f.write('  refpix_configfile: {}\n'.format(self.configfiles[instrument.lower()]['refpix_config']))
-            f.write('  linear_configfile: {}\n'.format(self.configfiles[instrument.lower()]['linearity_config']))
             f.write('\n')
             f.write('Output:\n')
             # f.write('  use_stsci_output_name: {} # Output filename should follow STScI naming conventions (True/False)\n'.format(outtf))


### PR DESCRIPTION
Resolves #742 

This PR removes the pipeline configuration files (*.cfg) from Mirage. The JWST pipeline has switched to using parameter reference files, and these cfg files are no longer supported.

After some debate, I decided to remove the files completely and not add support for the parameter reference files. This is because the only place Mirage uses them is to linearize a raw dark current file. In this case, the superbias and reference pixel signal is subtracted, and the data are linearized. The simulated sources are added, the ramp is unlinearized, and the superbias and reference pixel signal is added back in. So really, the exact details of how the reference pixel signal is subtracted (that seems like the only step where someone would want to deviate from the defaults) don't matter, as the signal will be added back in at the end.