### PR TITLE
Reduce signal of subsampled pix by factor of number of subpixels

### DIFF
--- a/mirage/seed_image/moving_targets.py
+++ b/mirage/seed_image/moving_targets.py
@@ -386,7 +386,7 @@ class MovingTarget():
 
         for i in range(xdim):
             for j in range(ydim):
-                substamp[factory*j:factory*(j+1), factorx*i:factorx*(i+1)] = image[j, i]
+                substamp[factory*j:factory*(j+1), factorx*i:factorx*(i+1)] = image[j, i] / (factorx * factory)
         return substamp
 
     def equidistantXY(self,xstart, ystart, xend, yend, dist):


### PR DESCRIPTION
In the function that subsamples pixels for the addition of moving targets, the code was not reducing the signal in the subsampled pixels by a factor equal to the number of subpixels. e.g. A pixel with a signal of 9 DN that is subsampled by a factor of 3 in the x dimension and 3 in the y-dimension (for a total of 9 subpixels). In this case, each subpixel should have a signal of 1 DN, so that the total adds up to the original 9 DN. Prior to this change, the signal in the subpixels was not being reduced, so we would have 9 subpixels with 9 DN each.