### PR TITLE
Handle new Glossary in pointing file

### DIFF
--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -833,6 +833,10 @@ class AptInput:
                 elif (len(line) > 1):
                     elements = line.split()
 
+                    # If we hit the Glossary at the end, we can stop
+                    if elements[0] == 'Glossary':
+                        break
+
                     # Look for lines that give visit/observation numbers
                     if line[0:2] == '* ':
                         paren = line.rfind('(')

--- a/mirage/apt/apt_inputs.py
+++ b/mirage/apt/apt_inputs.py
@@ -865,8 +865,6 @@ class AptInput:
 
                         # The exception to this rule is TA images.
                         # These have Exp values of 0. Sigh.
-
-
                         if ((int(elements[1]) > 0) & ('NRC' in elements[4]
                                                          or 'NIS' in elements[4]
                                                          or 'FGS' in elements[4]
@@ -934,7 +932,7 @@ class AptInput:
                             observation_id.append("V{}P{}{}{}{}".format(vid, '00000000', vgrp, seq, act))
                             # act_counter += 1
 
-                    except ValueError as e:
+                    except (ValueError, IndexError) as e:
                         if verbose:
                             self.logger.info('Skipping line:\n{}\nproducing error:\n{}'.format(line, e))
                         pass


### PR DESCRIPTION
Looks like the latest version of APT now adds a Glossary section to the pointing file. The current function for reading in the pointing file was finding the glossary section but not successfully ignoring it.

This PR updates the code to explicitly stop reading the pointing file when it reaches the Glossary line. It also protects against lines that are too short to contain pointing information.