### PR TITLE
WebbPSF oversampling can be int or array

### DIFF
--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -309,7 +309,8 @@ class Catalog_seed():
 
             # Versions of photutils prior to 1.10.0 use an integer for the oversampling factor, while
             # newer versions use a numpy array with one value for each of the x and y dimensions.
-            # Make sure we can handle both of these options.
+            # Make sure we can handle both of these options. For the moment, Mirage assumes that the
+            # oversampling factor is the same in both dimensions.
             if isinstance(self.psf_library.oversampling, int):
                 self.psf_library_oversamp = self.psf_library.oversampling
             elif isinstance(self.psf_library.oversampling, list) or isinstance(oversamp, np.ndarray):

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -307,7 +307,7 @@ class Catalog_seed():
                 self.params['simSignals']['psfpath'])
             self.psf_library_core_y_dim, self.psf_library_core_x_dim = self.psf_library.data.shape[-2:]
 
-            # Older versions of webbpsf use an integer for the oversampling factor, while
+            # Versions of photutils prior to 1.10.0 use an integer for the oversampling factor, while
             # newer versions use a numpy array with one value for each of the x and y dimensions.
             # Make sure we can handle both of these options.
             if isinstance(self.psf_library.oversampling, int):

--- a/mirage/seed_image/catalog_seed_image.py
+++ b/mirage/seed_image/catalog_seed_image.py
@@ -306,7 +306,14 @@ class Catalog_seed():
                 self.params['simSignals']['psfwfegroup'],
                 self.params['simSignals']['psfpath'])
             self.psf_library_core_y_dim, self.psf_library_core_x_dim = self.psf_library.data.shape[-2:]
-            self.psf_library_oversamp = self.psf_library.oversampling
+
+            # Older versions of webbpsf use an integer for the oversampling factor, while
+            # newer versions use a numpy array with one value for each of the x and y dimensions.
+            # Make sure we can handle both of these options.
+            if isinstance(self.psf_library.oversampling, int):
+                self.psf_library_oversamp = self.psf_library.oversampling
+            elif isinstance(self.psf_library.oversampling, list) or isinstance(oversamp, np.ndarray):
+                self.psf_library_oversamp = self.psf_library.oversampling[0]
 
         # If reading in segment PSFs, use get_gridded_segment_psf_library_list
         # to get a list of photutils.griddedPSFModel objects


### PR DESCRIPTION
Small change that allows the oversampling factor in the WebbPSF gridded library to be an integer or an array. Local tests have shown this to be an integer, as expected. But in help desk ticket INC0196396, the oversampling factor was a numpy array with one value for each of the x and y dimensions. 

This PR updates catalog_seed_image.py to be able to accept either an integer or an array. Note that for this simple fix, when the oversampling is an array, Mirage assumes that the oversampling is the same in both dimensions. With a few more modifications, it appears that Mirage could support different factors in the two dimensions, but it's not clear that this is needed at the moment.