### PR TITLE
Update install instructions. Fix broken badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/spacetelescope/mirage/actions/workflows/build.yml/badge.svg)](https://github.com/spacetelescope/mirage/actions/workflows/build.yml)
 [![License](https://img.shields.io/pypi/l/Django.svg)](https://github.com/spacetelescope/mirage/blob/master/LICENSE.txt)
-[![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12-blue.svg)](https://www.python.org/)
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
 [![DOI](https://zenodo.org/badge/109982775.svg)](https://doi.org/10.5281/zenodo.3519261)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MIRaGe = Multi Instrument Ramp Generator
 
-[![Build Status](https://github.com/spacetelescope/mirage/workflows/CI/badge.svg)](https://github.com/spacetelescope/mirage/actions)
+[![Build Status](https://github.com/spacetelescope/mirage/actions/workflows/build.yml/badge.svg)](https://github.com/spacetelescope/mirage/actions/workflows/build.yml)
 [![License](https://img.shields.io/pypi/l/Django.svg)](https://github.com/spacetelescope/mirage/blob/master/LICENSE.txt)
 [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.python.org/)
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
-[![DOI](https://zenodo.org/badge/109982775.svg)](https://zenodo.org/badge/latestdoi/109982775)
+[![DOI](https://zenodo.org/badge/109982775.svg)](https://doi.org/10.5281/zenodo.3519261)
 
 
 This repository contains code that can be used to generate
@@ -57,9 +57,6 @@ For any questions about the `mirage` project or its software or documentation, p
 - Bryan Hilbert [@bhilbert4](https://github.com/bhilbert4)
 - Joe Filippazzo [@hover2pi](https://github.com/hover2pi)
 - Nor Pirzkal [@NorPirzkal](https://github.com/npirzkal)
-- Kevin Volk [@KevinVolkSTScI](https://github.com/KevinVolkSTScI)
-- Shannon Osborne [@shanosborne](https://github.com/shanosborne)
-- Marshall Perrin [@mperrin](https://github.com/mperrin)
 
 
 ## Acknowledgments:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,7 +4,7 @@ There are two aspects to Mirage installation. First, the software itself must be
 must be downloaded. The preferred installation method is via :ref:`Pypi <pypi>`, as this is the latest stable version of the software.
 
 .. tip::
-    Mirage currently supports python 3.11 and 3.12.
+    Mirage currently supports python 3.11, 3.12, and 3.13.
 
 .. _pypi:
 
@@ -61,21 +61,15 @@ Create and activate a new environment. In this example we call the environment "
 Install via Environment File
 ----------------------------
 
-The Mirage repository also contains environment files, which can be used to create an environment with proper versions of all of Mirage's dependencies. After cloning the Mirage repository, the environment file (located within the top-level directory) can be used via the following commands. The *name* keyword is used to specify that the name of the environment. You can name the environment anything you like.
+The Mirage repository also contains environment files, which can be used to create an environment with proper versions of all of Mirage's dependencies. For each new release of Mirage, updated environment files are created. These can be found by clicking on the current release on the right side of the `repository page on GitHub <https://github.com/spacetelescope/mirage>`_, and then looking in the "Assets" section. Download the appropriate environment file for your operating system and python version.
+
+The following commands can then be used to create an environment. The *name* keyword is used to specify the name of the environment. You can name the environment anything you like.
 
 Create a python 3.11 environment using the environment file, activate the environment, and install mirage::
 
     cd mirage
-    conda env create -f environment_python_3.11.yml
+    conda env create --name mirage_py3.11 -f jwql_2.4.2_conda_macOS_ARM64_py3.11.yml
     conda activate mirage_py3.11
-    pip install .
-
-
-There is also an environment file that can be used to create python 3.12 environment::
-
-    cd mirage
-    conda env create -f environment_python_3.12.yml
-    conda activate mirage_py3.12
     pip install .
 
 
@@ -112,7 +106,7 @@ The installation errors are related to supporting Batman's ability to run calcul
     ::
 
         cd mirage
-        conda env create -f environment_python_3.11.yml
+        conda env create --name mirage-py3.11 -f jwql_2.4.2_conda_macOS_ARM64_py3.11.yml
         conda activate mirage-py3.11
         pip install .
         cd ../batman


### PR DESCRIPTION
Tweak the installation instructions to reflect the new packaging workflow.

Also fix the zenodo and build badges, which had missing images.