### PR TITLE
Fix pypi url in build GA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
     # Settings > Environments > pypi > Add required reviewers
     environment:
       name: pypi
-      url: https://pypi.org/p/{{ cookiecutter.package_name }}
+      url: https://pypi.org/p/mirage
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:


### PR DESCRIPTION
Replace cookiecutter reference with 'mirage'